### PR TITLE
feat(blob): add image thumbnail preview in BlobInput

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -631,6 +631,7 @@
     "downloadDisabledTruncated": "Download unavailable - only preview loaded",
     "downloading": "Downloading...",
     "uploading": "Uploading...",
-    "openSidebar": "Open in editor"
+    "openSidebar": "Open in editor",
+    "imagePreview": "Image preview"
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -611,6 +611,7 @@
     "downloadDisabledTruncated": "Descarga no disponible - solo vista previa cargada",
     "downloading": "Descargando...",
     "uploading": "Subiendo...",
-    "openSidebar": "Abrir en el editor"
+    "openSidebar": "Abrir en el editor",
+    "imagePreview": "Vista previa de imagen"
   }
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -631,6 +631,7 @@
     "downloadDisabledTruncated": "Download non disponibile - caricata solo anteprima",
     "downloading": "Download in corso...",
     "uploading": "Caricamento in corso...",
-    "openSidebar": "Apri nell'editor"
+    "openSidebar": "Apri nell'editor",
+    "imagePreview": "Anteprima immagine"
   }
 }

--- a/src/utils/blob.ts
+++ b/src/utils/blob.ts
@@ -186,6 +186,26 @@ export function mimeToExtension(mimeType: string): string {
 }
 
 /**
+ * Extracts a data URL for image preview from a BLOB wire format value.
+ * Returns null if the value is not an image or not in base64 wire format.
+ */
+export function extractImageDataUrl(value: unknown): string | null {
+  const metadata = extractBlobMetadata(value);
+  if (!metadata || !metadata.isBase64 || !metadata.mimeType.startsWith("image/")) {
+    return null;
+  }
+  const stringValue = String(value);
+  if (!stringValue.startsWith("BLOB:")) return null;
+  const firstColon = 5;
+  const secondColon = stringValue.indexOf(":", firstColon);
+  const thirdColon = stringValue.indexOf(":", secondColon + 1);
+  if (thirdColon === -1) return null;
+  const base64Payload = stringValue.substring(thirdColon + 1);
+  if (!base64Payload) return null;
+  return `data:${metadata.mimeType};base64,${base64Payload}`;
+}
+
+/**
  * Formats a BLOB value for display in the DataGrid.
  * Shows MIME type and size instead of raw data.
  */


### PR DESCRIPTION
## Summary
- Add inline image thumbnail preview when BLOB contains image data (`image/*` MIME types)
- Users get immediate visual feedback without downloading the file
- Non-image BLOBs remain unchanged (file icon + metadata)

## Changes
- **`src/utils/blob.ts`**: New `extractImageDataUrl()` utility — extracts data URL from BLOB wire format for image types
- **`src/components/ui/BlobInput.tsx`**: Show `<img>` thumbnail above metadata row for image BLOBs, use `ImageIcon` instead of `FileIcon` for image types
- **`src/i18n/locales/{en,it,es}.json`**: Add `blobInput.imagePreview` translation key
- **`tests/utils/blob.test.ts`**: 6 new tests for `extractImageDataUrl` (null, non-image, file ref, multiple MIME types)

## Preview behavior
- Image preview shows max 176px height, object-fit contain
- Truncated BLOBs with image MIME still show the truncated preview (first 4KB)
- Non-base64 values (plain text, file refs) show no preview

## Test plan
- [x] All 27 blob utility tests pass (`npx vitest run tests/utils/blob.test.ts`)
- [ ] Manual test: upload PNG/JPEG to BLOB column, verify thumbnail appears
- [ ] Manual test: upload PDF to BLOB column, verify no thumbnail (just file icon)
- [ ] Manual test: large image (>4KB) shows truncated preview with warning banner