### PR TITLE
fix(website): scope badge image rule to shields.io only

### DIFF
--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -1311,7 +1311,8 @@ pre {
 }
 
 /* Inline badge images (e.g. shields.io wrapped in a link) */
-.post-content a > img {
+.post-content a > img[src*="img.shields.io"],
+.post-content a > img[src*="badge"] {
     width: auto;
     height: 20px;
     display: inline;


### PR DESCRIPTION
The `.post-content a > img` selector was shrinking ALL linked images in blog posts to 20px height, not just shield/badge images. Narrowed the selector to only match `img[src*="img.shields.io"]` and `img[src*="badge"]` so regular post images wrapped in links render at full size.