### PR TITLE
feat: Add Redis plugin to registry (Rust, tabularis-redis-plugin)

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -84,7 +84,7 @@
       "description": "Redis key-value store with Hash and RedisJSON row storage",
       "author": "nicholas-papachriston <https://github.com/nicholas-papachriston>",
       "homepage": "https://github.com/nicholas-papachriston/tabularis-redis-plugin",
-      "latest_version": "0.1.0",
+      "latest_version": "0.2.0",
       "releases": [
         {
           "version": "0.2.0",


### PR DESCRIPTION
## Description

This PR adds **tabularis-redis-plugin** to the plugin registry -- a Redis driver written in Rust that exposes Redis as a browsable, queryable data source inside Tabularis.

**Repository:** https://github.com/nicholas-papachriston/tabularis-redis-plugin
**Release:** [v0.1.0](https://github.com/nicholas-papachriston/tabularis-redis-plugin/releases/tag/v0.1.0)

## Key Features

- **Metadata tables** -- store structured row data in Redis using Hash or RedisJSON, with full SQL support: `WHERE` (AND/OR/IN/BETWEEN/LIKE), `ORDER BY`, `LIMIT`, aggregates, and `GROUP BY`.
- **Virtual key browser** -- `__redis_keys__` lists all keys with type, value preview, and TTL; prefix-grouped tables (`__keys:prefix__`) are generated automatically.
- **Type-specific tables** -- dedicated views for hashes, lists, sets, sorted sets, and streams.
- **Full CRUD** -- insert, update, and delete directly from the Tabularis data grid on both metadata and virtual key tables.
- **TLS support** -- via rustls with no OpenSSL dependency.
- **Pub/Sub visibility** -- list active channels and subscriber counts.
- **Server stats** -- parsed `INFO` output as structured JSON.
- **Pipelined reads** -- type, value preview, and TTL fetched in batches to minimize round-trips.
- **Binary key support** -- non-UTF-8 keys exposed via Base64 (`key_raw`) for lossless round-trip.
- **Cross-platform** -- pre-built binaries for Linux (x64, arm64), macOS (x64, arm64), and Windows (x64).
- **Valkey Support** -- tested against 9.0.3

## Implementation Details

| | |
|---|---|
| **Language** | Rust (edition 2021) |
| **Redis client** | [redis](https://crates.io/crates/redis) 1.x (TLS via rustls, cluster, sentinel) |
| **SQL parsing** | [sqlparser](https://crates.io/crates/sqlparser) for metadata-table queries |
| **Protocol** | JSON-RPC 2.0 over stdio |
| **Release binary** | LTO, stripped, single codegen unit, `panic=abort` |

## Registry Entry

Adds a single entry to `plugins/registry.json`:

- **id:** `redis`
- **latest_version:** `0.1.0`
- **min_tabularis_version:** `0.9.2`
- **assets:** 5 platform zips (linux-arm64, linux-x64, darwin-arm64, darwin-x64, win-x64)

## Testing

- Tested locally on macOS against Tabularis via `sync.sh` (copies binary + manifest into the plugins directory).
- Automated CI builds and packages release zips for all 5 platforms on every push to `main`.
- Integration test binary (`cargo run --bin test_plugin`) exercises the full JSON-RPC interface against a live Redis/Valkey instance.

## Note on Existing PR

I noticed #58 also adds a Redis driver (Go-based). This plugin was developed independently for personal use in Rust with a different feature set. Happy to coordinate with the maintainers on how best to list both, or adjust the plugin ID if needed.