### PR TITLE
Fix Escape key handling for modals

### DIFF
--- a/src/hooks/useEscapeKey.ts
+++ b/src/hooks/useEscapeKey.ts
@@ -13,16 +13,17 @@ export const useEscapeKey = (isOpen: boolean, onClose: () => void) => {
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape" && modalStack[modalStack.length - 1] === modalId) {
+        e.preventDefault();
         onClose();
       }
     };
 
-    document.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keydown", handleKeyDown, true);
 
     return () => {
       const idx = modalStack.lastIndexOf(modalId);
       if (idx !== -1) modalStack.splice(idx, 1);
-      document.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keydown", handleKeyDown, true);
     };
   }, [isOpen, onClose]);
 };


### PR DESCRIPTION
## Summary
- listen for Escape key events during capture to close the active modal reliably
- prevent default Escape behavior when dismissing the modal

## Testing
- Not run (not requested)

## Related
Fixes #62