### PR TITLE
feat(ui): add drag and drop functionality for connection groups

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6057,7 +6057,7 @@ dependencies = [
 
 [[package]]
 name = "tabularis"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/src/components/connections/ConnectionCard.tsx
+++ b/src/components/connections/ConnectionCard.tsx
@@ -22,6 +22,7 @@ export interface ConnectionCardProps {
   onDuplicate: () => void;
   onDelete: () => void;
   onContextMenu: (e: MouseEvent<HTMLDivElement>) => void;
+  onMouseDown?: (e: MouseEvent<HTMLDivElement>) => void;
 }
 
 export const ConnectionCard = ({
@@ -35,6 +36,7 @@ export const ConnectionCard = ({
   onDuplicate,
   onDelete,
   onContextMenu,
+  onMouseDown,
 }: ConnectionCardProps) => {
   const { t } = useTranslation();
   const { activeConnectionId, isConnectionOpen } = useDatabase();
@@ -49,10 +51,9 @@ export const ConnectionCard = ({
 
   return (
     <div
-      draggable
-      onDragStart={(e) => e.dataTransfer.setData('connectionId', conn.id)}
       onDoubleClick={() => isDriverEnabled && !isConnecting && onConnect()}
       onContextMenu={onContextMenu}
+      onMouseDown={onMouseDown}
       className={clsx(
         'group relative flex flex-col rounded-2xl border transition-all duration-150 cursor-pointer select-none overflow-hidden',
         !isDriverEnabled && 'opacity-60 cursor-not-allowed',

--- a/src/components/connections/ConnectionListItem.tsx
+++ b/src/components/connections/ConnectionListItem.tsx
@@ -22,6 +22,7 @@ export interface ConnectionListItemProps {
   onDuplicate: () => void;
   onDelete: () => void;
   onContextMenu: (e: MouseEvent<HTMLDivElement>) => void;
+  onMouseDown?: (e: MouseEvent<HTMLDivElement>) => void;
 }
 
 export const ConnectionListItem = ({
@@ -35,6 +36,7 @@ export const ConnectionListItem = ({
   onDuplicate,
   onDelete,
   onContextMenu,
+  onMouseDown,
 }: ConnectionListItemProps) => {
   const { t } = useTranslation();
   const { activeConnectionId, isConnectionOpen } = useDatabase();
@@ -51,6 +53,7 @@ export const ConnectionListItem = ({
     <div
       onDoubleClick={() => isDriverEnabled && !isConnecting && onConnect()}
       onContextMenu={onContextMenu}
+      onMouseDown={onMouseDown}
       className={clsx(
         'group flex items-center gap-3 px-3.5 py-2 rounded-xl border transition-all duration-150 cursor-pointer select-none',
         !isDriverEnabled && 'opacity-60 cursor-not-allowed',

--- a/src/components/connections/GroupHeader.tsx
+++ b/src/components/connections/GroupHeader.tsx
@@ -1,5 +1,5 @@
 import type { RefObject } from 'react';
-import { ChevronRight, Folder, FolderOpen, MoreVertical } from 'lucide-react';
+import { GripVertical, ChevronRight, Folder, FolderOpen, MoreVertical } from 'lucide-react';
 import clsx from 'clsx';
 import type { ConnectionGroup } from '../../contexts/DatabaseContext';
 
@@ -15,6 +15,8 @@ export interface GroupHeaderProps {
   setEditGroupName: (name: string) => void;
   setEditingGroupId: (id: string | null) => void;
   onRenameConfirm: (groupId: string) => void;
+  onGripMouseDown?: (e: React.MouseEvent) => void;
+  isDragOver?: boolean;
 }
 
 export const GroupHeader = ({
@@ -29,15 +31,29 @@ export const GroupHeader = ({
   setEditGroupName,
   setEditingGroupId,
   onRenameConfirm,
+  onGripMouseDown,
+  isDragOver,
 }: GroupHeaderProps) => (
   <div
-    className="flex items-center gap-2 group cursor-pointer"
+    className={clsx(
+      "flex items-center gap-2 group cursor-pointer rounded-lg",
+      isDragOver && "ring-1 ring-blue-400 bg-blue-500/5"
+    )}
     onClick={onToggleCollapse}
     onContextMenu={(e) => {
       e.preventDefault();
       onOpenContextMenu(e.clientX, e.clientY, group.id);
     }}
   >
+    {onGripMouseDown && (
+      <div
+        onMouseDown={onGripMouseDown}
+        onClick={(e) => e.stopPropagation()}
+        className="opacity-0 group-hover:opacity-100 cursor-grab p-0.5 rounded text-muted hover:text-secondary shrink-0 select-none"
+      >
+        <GripVertical size={12} />
+      </div>
+    )}
     <ChevronRight
       size={14}
       className={clsx('text-muted transition-transform', !isCollapsed && 'rotate-90')}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -37,6 +37,7 @@ export const Sidebar = () => {
     connections,
     updateGroup,
     deleteGroup,
+    moveConnectionToGroup,
     toggleGroupCollapsed,
   } = useDatabase();
   const navigate = useNavigate();

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -37,7 +37,6 @@ export const Sidebar = () => {
     connections,
     updateGroup,
     deleteGroup,
-    moveConnectionToGroup,
     toggleGroupCollapsed,
   } = useDatabase();
   const navigate = useNavigate();

--- a/src/components/layout/sidebar/ConnectionGroupFolder.tsx
+++ b/src/components/layout/sidebar/ConnectionGroupFolder.tsx
@@ -117,7 +117,7 @@ export const ConnectionGroupFolder = ({
   const connectedCount = connections.filter(c => c.isConnected).length;
 
   return (
-    <div className="w-full">
+    <div className="w-full" data-group-id={group.id}>
       {/* Group header */}
       <div
         className={clsx(

--- a/src/pages/Connections.tsx
+++ b/src/pages/Connections.tsx
@@ -42,6 +42,7 @@ export const Connections = () => {
     updateGroup,
     deleteGroup,
     moveConnectionToGroup,
+    reorderGroups,
     toggleGroupCollapsed,
     loadConnections,
     connections: contextConnections,
@@ -77,6 +78,8 @@ export const Connections = () => {
     message: string;
     onConfirm: () => void;
   } | null>(null);
+  const [draggingGroupId, setDraggingGroupId] = useState<string | null>(null);
+  const [dragOverGroupId, setDragOverGroupId] = useState<string | null>(null);
   const isRenameCancelledRef = useRef(false);
 
   useEffect(() => {
@@ -324,7 +327,79 @@ export const Connections = () => {
     onDelete: () => handleDelete(conn.id),
     onContextMenu: (e: React.MouseEvent<HTMLDivElement>) =>
       handleConnContextMenu(e, conn),
+    onMouseDown: (e: React.MouseEvent<HTMLDivElement>) =>
+      handleConnectionMouseDown(e, conn.id, conn.group_id),
   });
+
+  const handleConnectionMouseDown = (e: React.MouseEvent, connId: string, currentGroupId: string | undefined) => {
+    if (e.button !== 0) return;
+    const startX = e.clientX;
+    const startY = e.clientY;
+    let isDragging = false;
+
+    const onMouseMove = (ev: MouseEvent) => {
+      if (!isDragging) {
+        const dx = ev.clientX - startX;
+        const dy = ev.clientY - startY;
+        if (dx * dx + dy * dy < 25) return;
+        isDragging = true;
+      }
+      const el = document.elementFromPoint(ev.clientX, ev.clientY);
+      const groupEl = (el as HTMLElement)?.closest("[data-group-id]") as HTMLElement | null;
+      setDragOverGroupId(groupEl?.dataset.groupId ?? null);
+    };
+
+    const onMouseUp = (ev: MouseEvent) => {
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+      if (!isDragging) {
+        setDragOverGroupId(null);
+        return;
+      }
+      const el = document.elementFromPoint(ev.clientX, ev.clientY);
+      const groupEl = (el as HTMLElement)?.closest("[data-group-id]") as HTMLElement | null;
+      const targetGroupId = groupEl?.dataset.groupId ?? null;
+      setDragOverGroupId(null);
+      if (!targetGroupId || targetGroupId === currentGroupId) return;
+      void handleMoveToGroup(connId, targetGroupId);
+    };
+
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+  };
+
+  const handleGripMouseDown = (e: React.MouseEvent, sourceGroupId: string) => {
+    e.preventDefault();
+    setDraggingGroupId(sourceGroupId);
+
+    const onMouseMove = (ev: MouseEvent) => {
+      const el = document.elementFromPoint(ev.clientX, ev.clientY);
+      const groupEl = (el as HTMLElement)?.closest("[data-group-id]") as HTMLElement | null;
+      const targetId = groupEl?.dataset.groupId ?? null;
+      setDragOverGroupId(targetId !== sourceGroupId ? targetId : null);
+    };
+
+    const onMouseUp = (ev: MouseEvent) => {
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+      const el = document.elementFromPoint(ev.clientX, ev.clientY);
+      const groupEl = (el as HTMLElement)?.closest("[data-group-id]") as HTMLElement | null;
+      const targetGroupId = groupEl?.dataset.groupId ?? null;
+      setDraggingGroupId(null);
+      setDragOverGroupId(null);
+      if (!targetGroupId || targetGroupId === sourceGroupId) return;
+      const newOrder = [...sortedGroups];
+      const fromIdx = newOrder.findIndex((g) => g.id === sourceGroupId);
+      const toIdx = newOrder.findIndex((g) => g.id === targetGroupId);
+      if (fromIdx === -1 || toIdx === -1) return;
+      const [moved] = newOrder.splice(fromIdx, 1);
+      newOrder.splice(toIdx, 0, moved);
+      void reorderGroups(newOrder.map((g, i) => [g.id, i]));
+    };
+
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+  };
 
   const groupHeaderProps = (group: (typeof sortedGroups)[number]) => ({
     group,
@@ -338,6 +413,8 @@ export const Connections = () => {
     setEditGroupName,
     setEditingGroupId,
     onRenameConfirm: handleRenameGroup,
+    onGripMouseDown: (e: React.MouseEvent) => handleGripMouseDown(e, group.id),
+    isDragOver: dragOverGroupId === group.id && draggingGroupId !== group.id,
   });
 
   return (
@@ -546,7 +623,11 @@ export const Connections = () => {
                   const groupConns = filteredGroupedConnections[group.id] || [];
                   if (groupConns.length === 0 && search.trim()) return null;
                   return (
-                    <div key={group.id} className="space-y-3">
+                    <div
+                      key={group.id}
+                      data-group-id={group.id}
+                      className="space-y-3"
+                    >
                       <GroupHeader
                         {...groupHeaderProps(group)}
                         connCount={groupConns.length}
@@ -608,7 +689,11 @@ export const Connections = () => {
                   const groupConns = filteredGroupedConnections[group.id] || [];
                   if (groupConns.length === 0 && search.trim()) return null;
                   return (
-                    <div key={group.id} className="space-y-2">
+                    <div
+                      key={group.id}
+                      data-group-id={group.id}
+                      className="space-y-2"
+                    >
                       <GroupHeader
                         {...groupHeaderProps(group)}
                         connCount={groupConns.length}


### PR DESCRIPTION
This PR adds drag and drop functionality to the Database Manager Connections.

Connections now can be dragged into a group and from one group to another. It is also possible to change the order of the groups by drag and drop.