### PR TITLE
feat(ui) remove table limits for monaco autosuggestion

### DIFF
--- a/src/utils/autocomplete.ts
+++ b/src/utils/autocomplete.ts
@@ -253,14 +253,9 @@ export const registerSqlAutocomplete = (
       }
 
       // ============================================
-      // 4. TABLE SUGGESTIONS (limit to 50 for large schemas)
+      // 4. TABLE SUGGESTIONS
       // ============================================
-      const MAX_TABLE_SUGGESTIONS = 50;
-      const tablesToShow = tables.length > MAX_TABLE_SUGGESTIONS 
-        ? tables.slice(0, MAX_TABLE_SUGGESTIONS) 
-        : tables;
-      
-      const tableSuggestions = tablesToShow.map((t) => ({
+      const tableSuggestions = tables.map((t) => ({
         label: t.name,
         kind: monaco.languages.CompletionItemKind.Class,
         detail: "Table",
@@ -269,18 +264,12 @@ export const registerSqlAutocomplete = (
         sortText: `1_${t.name}`
       }));
 
-      // Combine suggestions with smart limits
-      const allSuggestions = [
-        ...contextColumnSuggestions,
-        ...tableSuggestions,
-        ...keywordSuggestions
-      ];
-      
-      // Monaco handles filtering/limiting internally, but we cap total results
-      const MAX_TOTAL_SUGGESTIONS = 200;
-      
       return {
-        suggestions: allSuggestions.slice(0, MAX_TOTAL_SUGGESTIONS),
+        suggestions: [
+          ...contextColumnSuggestions,
+          ...tableSuggestions,
+          ...keywordSuggestions,
+        ],
       };
     },
   });

--- a/tests/utils/autocomplete.test.ts
+++ b/tests/utils/autocomplete.test.ts
@@ -151,7 +151,7 @@ describe('autocomplete', () => {
       expect(tableSuggestions[1].label).toBe('orders');
     });
 
-    it('should limit table suggestions to MAX_TABLE_SUGGESTIONS', async () => {
+    it('should include all table suggestions regardless of count', async () => {
       const monaco = createMockMonaco();
       const tables: TableInfo[] = Array.from({ length: 60 }, (_, i) => ({
         name: `table_${i}`,
@@ -168,12 +168,12 @@ describe('autocomplete', () => {
       const position = { lineNumber: 1, column: 15 };
 
       const result = await provider.provideCompletionItems(model, position);
-      
-      // Tables are limited to 50, but keywords are also included
-      const tableSuggestions = result.suggestions.filter((s: { sortText?: string }) => 
+
+      // All 60 tables should be present — no arbitrary cap
+      const tableSuggestions = result.suggestions.filter((s: { sortText?: string }) =>
         s.sortText?.startsWith('1_')
       );
-      expect(tableSuggestions.length).toBeLessThanOrEqual(50);
+      expect(tableSuggestions.length).toBe(60);
     });
 
     it('should return keyword suggestions when no context', async () => {
@@ -324,7 +324,7 @@ describe('autocomplete', () => {
   });
 
   describe('suggestion limits', () => {
-    it('should cap total suggestions to MAX_TOTAL_SUGGESTIONS', async () => {
+    it('should return all suggestions without an arbitrary total cap', async () => {
       const monaco = createMockMonaco();
       const tables: TableInfo[] = Array.from({ length: 100 }, (_, i) => ({
         name: `table_${i}`,
@@ -341,9 +341,12 @@ describe('autocomplete', () => {
       const position = { lineNumber: 1, column: 15 };
 
       const result = await provider.provideCompletionItems(model, position);
-      
-      // Should be limited to 200 total
-      expect(result.suggestions.length).toBeLessThanOrEqual(200);
+
+      // All 100 tables should be present — Monaco handles filtering internally
+      const tableSuggestions = result.suggestions.filter((s: { sortText?: string }) =>
+        s.sortText?.startsWith('1_')
+      );
+      expect(tableSuggestions.length).toBe(100);
     });
   });
 });


### PR DESCRIPTION
This PR removes the number of tables limitations which where implemented in the use of monaco.

I tested with database which have 6000+ tables and there seem to be no significant performance deteriorations.