### PR TITLE
feat: add table search filter for PostgreSQL schema mode

### DIFF
--- a/src/components/layout/sidebar/SidebarSchemaItem.tsx
+++ b/src/components/layout/sidebar/SidebarSchemaItem.tsx
@@ -7,6 +7,8 @@ import {
   Layers,
   Plus,
   RefreshCw,
+  Search,
+  X,
 } from "lucide-react";
 import { Accordion } from "./Accordion";
 import { SidebarTableItem } from "./SidebarTableItem";
@@ -86,6 +88,7 @@ export const SidebarSchemaItem = ({
   const [routinesOpen, setRoutinesOpen] = useState(false);
   const [functionsOpen, setFunctionsOpen] = useState(true);
   const [proceduresOpen, setProceduresOpen] = useState(true);
+  const [tableFilter, setTableFilter] = useState("");
 
   // Adjust isExpanded during render when activeSchema changes (avoids useEffect)
   if (activeSchema !== prevActiveSchema) {
@@ -96,6 +99,9 @@ export const SidebarSchemaItem = ({
   }
 
   const tables = schemaData?.tables ?? [];
+  const filteredTables = tableFilter
+    ? tables.filter((t) => t.name.toLowerCase().includes(tableFilter.toLowerCase()))
+    : tables;
   const views = schemaData?.views ?? [];
   const routines = schemaData?.routines ?? [];
   const isLoading = schemaData?.isLoading ?? false;
@@ -189,13 +195,36 @@ export const SidebarSchemaItem = ({
                   </div>
                 }
               >
-                {tables.length === 0 ? (
+                {tables.length > 0 && (
+                  <div className="px-2 py-1">
+                    <div className="relative flex items-center">
+                      <Search size={11} className="absolute left-2 text-muted pointer-events-none" />
+                      <input
+                        type="text"
+                        value={tableFilter}
+                        onChange={(e) => setTableFilter(e.target.value)}
+                        placeholder={t("sidebar.filterTables")}
+                        className="w-full bg-surface-secondary text-xs text-secondary placeholder:text-muted rounded pl-6 pr-6 py-1 border border-default focus:outline-none focus:border-blue-500/50"
+                        onClick={(e) => e.stopPropagation()}
+                      />
+                      {tableFilter && (
+                        <button
+                          onClick={(e) => { e.stopPropagation(); setTableFilter(""); }}
+                          className="absolute right-1.5 text-muted hover:text-primary"
+                        >
+                          <X size={11} />
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                )}
+                {filteredTables.length === 0 ? (
                   <div className="text-center p-2 text-xs text-muted italic">
-                    {t("sidebar.noTables")}
+                    {tableFilter ? t("sidebar.noTablesMatch") : t("sidebar.noTables")}
                   </div>
                 ) : (
                   <div>
-                    {tables.map((table) => (
+                    {filteredTables.map((table) => (
                       <SidebarTableItem
                         key={table.name}
                         table={table}


### PR DESCRIPTION
## Summary

PostgreSQL schema mode lacks table search/filter functionality, while MySQL multi-database mode and flat layouts already have it. This creates an inconsistent user experience when working with large PostgreSQL schemas.

## Changes

### Frontend (React/TypeScript)

**`src/components/layout/sidebar/SidebarSchemaItem.tsx`**:
- Add `Search` and `X` icon imports from `lucide-react`
- Add `tableFilter` state for search input
- Implement `filteredTables` with case-insensitive filtering logic
- Add search input UI (search icon + input + clear button)
- Update table rendering to use filtered results
- Show contextual empty states: "No tables" vs "No tables match your search"

The search box matches the UX pattern already present in:
- `SidebarDatabaseItem.tsx` (MySQL multi-database mode)
- `ExplorerSidebar.tsx` flat layout (MySQL/SQLite single database)

## Screenshots

### Before (no search box)

<img width="820" height="612" alt="tabularis_03" src="https://github.com/user-attachments/assets/6e2292b7-3089-48b4-abb5-d3694e1196da" />

### After (with search functionality)

<img width="1862" height="1028" alt="tabularis_01" src="https://github.com/user-attachments/assets/1ce8cb7c-300c-498f-9905-bd01448e9558" />

<img width="936" height="558" alt="tabularis_02" src="https://github.com/user-attachments/assets/b8c4f6fa-b6bf-4105-9c46-ff1bf1cc84d8" />

## Test plan

- [x] Connect to PostgreSQL database
- [x] Expand any schema in the sidebar
- [x] Verify search input appears above table list (with search icon)
- [x] Type keywords to filter tables (case-insensitive)
- [x] Verify filtered results update in real-time
- [x] Click X button to clear search
- [x] Verify empty state shows "No tables match your search" when no results
- [x] Verify search doesn't affect Views or Routines sections
- [x] Verify UX consistency with MySQL database search