### PR TITLE
bug: Modify MySQL connection URL to use system timezone

### DIFF
--- a/src-tauri/src/pool_manager.rs
+++ b/src-tauri/src/pool_manager.rs
@@ -52,7 +52,8 @@ fn build_mysql_options(
         .port(port)
         .username(username)
         .password(password)
-        .database(database);
+        .database(database)
+        .timezone("SYSTEM".to_string());
 
     // Configure SSL mode based on params.ssl_mode
     let ssl_mode = match params.ssl_mode.as_deref().unwrap_or("required") {


### PR DESCRIPTION
In pool_manager.rs:43, the MySQL connection URL has no timezone parameter. The sqlx  MySQL driver defaults to setting time_zone='UTC' on every connection, so NOW() always returns UTC regardless of the server or user's local timezone.

The fix is to add timezone=SYSTEM to the connection URL, which tells MySQL to use the server's configured system timezone instead of being forced to UTC.