### PR TITLE
bug: improved the readabiltiy of the dracula theme

### DIFF
--- a/src/themes/presets/dracula.ts
+++ b/src/themes/presets/dracula.ts
@@ -24,8 +24,8 @@ export const dracula: Theme = {
     },
     text: {
       primary: '#f8f8f2',
-      secondary: '#6272a4',
-      muted: '#6272a4',
+      secondary: '#b8c2e0',
+      muted: '#7d88ae',
       disabled: '#6c7290',
       accent: '#bd93f9',
       inverse: '#282a36',


### PR DESCRIPTION
In dracula.ts, three color tokens were all set to #6272a4 (Dracula's comment/selection color):
  - text.secondary = #6272a4
  - text.muted = #6272a4
  - surface.secondary = #6272a4

This made text invisible anywhere both a text and background token from this set were combined.

I updated text.secondary → #b8c2e0 (light blue-gray, fits Dracula palette) and text.muted → #7d88ae (medium blue-gray, visibly lighter than the surface). All other themes are unaffected.