### PR TITLE
bug: fix the editbility of data in some cases

### DIFF
--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -493,13 +493,14 @@ export const Editor = () => {
   }, [tabs, updateScrollArrows]);
 
   const fetchPkColumn = useCallback(
-    async (table: string, tabId?: string) => {
+    async (table: string, tabId?: string, tabSchema?: string) => {
       if (!activeConnectionId) return;
+      const effectiveSchema = tabSchema ?? activeSchema;
       try {
         const cols = await invoke<TableColumn[]>("get_columns", {
           connectionId: activeConnectionId,
           tableName: table,
-          ...(activeSchema ? { schema: activeSchema } : {}),
+          ...(effectiveSchema ? { schema: effectiveSchema } : {}),
         });
         const pk = cols.find((c) => c.is_pk);
         const autoInc = cols
@@ -683,7 +684,7 @@ export const Editor = () => {
 
         if (tableName) {
           // Wait for PK column to be fetched before showing results
-          await fetchPkColumn(tableName, targetTabId);
+          await fetchPkColumn(tableName, targetTabId, targetTab?.schema ?? undefined);
         } else {
           // No table, explicitly set pkColumn to null (read-only mode)
           updateTab(targetTabId, { pkColumn: null });


### PR DESCRIPTION
In multi-database MySQL connections, fetchPkColumn always fell back to activeSchema when
  resolving which database to query for column metadata. Since MySQL has schemas: false,
  activeSchema is null, so the backend fell back to params.database.primary() — the first database
  in the selection.

  Tables opened from a non-primary selected database would have their columns queried from the
  wrong database. get_columns would return no results, pkColumn would be set to null, and the
  DataGrid would be read-only even for tables with a proper primary key.

  Query execution was unaffected because it correctly used targetTab?.schema rather than
  activeSchema.

  Fix: Add an optional tabSchema parameter to fetchPkColumn and pass targetTab?.schema at the call
  site, so column metadata is always fetched from the same database the query runs against.