### PR TITLE
Feat/ai audit log

### DIFF
--- a/.agents/skills/gitnexus/debugging/SKILL.md
+++ b/.agents/skills/gitnexus/debugging/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: gitnexus-debugging
+description: Trace bugs through call chains using knowledge graph
+---
+
+# Debugging with GitNexus
+
+## When to Use
+- "Why is this function failing?"
+- "Trace where this error comes from"
+- "Who calls this method?"
+- "This endpoint returns 500"
+- Investigating bugs, errors, or unexpected behavior
+
+## Workflow
+
+```
+1. gitnexus_query({query: "<error or symptom>"})            → Find related execution flows
+2. gitnexus_context({name: "<suspect>"})                    → See callers/callees/processes
+3. READ gitnexus://repo/{name}/process/{name}                → Trace execution flow
+4. gitnexus_cypher({query: "MATCH path..."})                 → Custom traces if needed
+```
+
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] Understand the symptom (error message, unexpected behavior)
+- [ ] gitnexus_query for error text or related code
+- [ ] Identify the suspect function from returned processes
+- [ ] gitnexus_context to see callers and callees
+- [ ] Trace execution flow via process resource if applicable
+- [ ] gitnexus_cypher for custom call chain traces if needed
+- [ ] Read source files to confirm root cause
+```
+
+## Debugging Patterns
+
+| Symptom | GitNexus Approach |
+|---------|-------------------|
+| Error message | `gitnexus_query` for error text → `context` on throw sites |
+| Wrong return value | `context` on the function → trace callees for data flow |
+| Intermittent failure | `context` → look for external calls, async deps |
+| Performance issue | `context` → find symbols with many callers (hot paths) |
+| Recent regression | `detect_changes` to see what your changes affect |
+
+## Tools
+
+**gitnexus_query** — find code related to error:
+```
+gitnexus_query({query: "payment validation error"})
+→ Processes: CheckoutFlow, ErrorHandling
+→ Symbols: validatePayment, handlePaymentError, PaymentException
+```
+
+**gitnexus_context** — full context for a suspect:
+```
+gitnexus_context({name: "validatePayment"})
+→ Incoming calls: processCheckout, webhookHandler
+→ Outgoing calls: verifyCard, fetchRates (external API!)
+→ Processes: CheckoutFlow (step 3/7)
+```
+
+**gitnexus_cypher** — custom call chain traces:
+```cypher
+MATCH path = (a)-[:CodeRelation {type: 'CALLS'}*1..2]->(b:Function {name: "validatePayment"})
+RETURN [n IN nodes(path) | n.name] AS chain
+```
+
+## Example: "Payment endpoint returns 500 intermittently"
+
+```
+1. gitnexus_query({query: "payment error handling"})
+   → Processes: CheckoutFlow, ErrorHandling
+   → Symbols: validatePayment, handlePaymentError
+
+2. gitnexus_context({name: "validatePayment"})
+   → Outgoing calls: verifyCard, fetchRates (external API!)
+
+3. READ gitnexus://repo/my-app/process/CheckoutFlow
+   → Step 3: validatePayment → calls fetchRates (external)
+
+4. Root cause: fetchRates calls external API without proper timeout
+```

--- a/.agents/skills/gitnexus/exploring/SKILL.md
+++ b/.agents/skills/gitnexus/exploring/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: gitnexus-exploring
+description: Navigate unfamiliar code using GitNexus knowledge graph
+---
+
+# Exploring Codebases with GitNexus
+
+## When to Use
+- "How does authentication work?"
+- "What's the project structure?"
+- "Show me the main components"
+- "Where is the database logic?"
+- Understanding code you haven't seen before
+
+## Workflow
+
+```
+1. READ gitnexus://repos                          → Discover indexed repos
+2. READ gitnexus://repo/{name}/context             → Codebase overview, check staleness
+3. gitnexus_query({query: "<what you want to understand>"})  → Find related execution flows
+4. gitnexus_context({name: "<symbol>"})            → Deep dive on specific symbol
+5. READ gitnexus://repo/{name}/process/{name}      → Trace full execution flow
+```
+
+> If step 2 says "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] READ gitnexus://repo/{name}/context
+- [ ] gitnexus_query for the concept you want to understand
+- [ ] Review returned processes (execution flows)
+- [ ] gitnexus_context on key symbols for callers/callees
+- [ ] READ process resource for full execution traces
+- [ ] Read source files for implementation details
+```
+
+## Resources
+
+| Resource | What you get |
+|----------|-------------|
+| `gitnexus://repo/{name}/context` | Stats, staleness warning (~150 tokens) |
+| `gitnexus://repo/{name}/clusters` | All functional areas with cohesion scores (~300 tokens) |
+| `gitnexus://repo/{name}/cluster/{name}` | Area members with file paths (~500 tokens) |
+| `gitnexus://repo/{name}/process/{name}` | Step-by-step execution trace (~200 tokens) |
+
+## Tools
+
+**gitnexus_query** — find execution flows related to a concept:
+```
+gitnexus_query({query: "payment processing"})
+→ Processes: CheckoutFlow, RefundFlow, WebhookHandler
+→ Symbols grouped by flow with file locations
+```
+
+**gitnexus_context** — 360-degree view of a symbol:
+```
+gitnexus_context({name: "validateUser"})
+→ Incoming calls: loginHandler, apiMiddleware
+→ Outgoing calls: checkToken, getUserById
+→ Processes: LoginFlow (step 2/5), TokenRefresh (step 1/3)
+```
+
+## Example: "How does payment processing work?"
+
+```
+1. READ gitnexus://repo/my-app/context       → 918 symbols, 45 processes
+2. gitnexus_query({query: "payment processing"})
+   → CheckoutFlow: processPayment → validateCard → chargeStripe
+   → RefundFlow: initiateRefund → calculateRefund → processRefund
+3. gitnexus_context({name: "processPayment"})
+   → Incoming: checkoutHandler, webhookHandler
+   → Outgoing: validateCard, chargeStripe, saveTransaction
+4. Read src/payments/processor.ts for implementation details
+```

--- a/.agents/skills/gitnexus/gitnexus-cli/SKILL.md
+++ b/.agents/skills/gitnexus/gitnexus-cli/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: gitnexus-cli
+description: "Use when the user needs to run GitNexus CLI commands like analyze/index a repo, check status, clean the index, generate a wiki, or list indexed repos. Examples: \"Index this repo\", \"Reanalyze the codebase\", \"Generate a wiki\""
+---
+
+# GitNexus CLI Commands
+
+All commands work via `npx` — no global install required.
+
+## Commands
+
+### analyze — Build or refresh the index
+
+```bash
+npx gitnexus analyze
+```
+
+Run from the project root. This parses all source files, builds the knowledge graph, writes it to `.gitnexus/`, and generates AGENTS.md / AGENTS.md context files.
+
+| Flag           | Effect                                                           |
+| -------------- | ---------------------------------------------------------------- |
+| `--force`      | Force full re-index even if up to date                           |
+| `--embeddings` | Enable embedding generation for semantic search (off by default) |
+
+**When to run:** First time in a project, after major code changes, or when `gitnexus://repo/{name}/context` reports the index is stale. In Codex, a PostToolUse hook runs `analyze` automatically after `git commit` and `git merge`, preserving embeddings if previously generated.
+
+### status — Check index freshness
+
+```bash
+npx gitnexus status
+```
+
+Shows whether the current repo has a GitNexus index, when it was last updated, and symbol/relationship counts. Use this to check if re-indexing is needed.
+
+### clean — Delete the index
+
+```bash
+npx gitnexus clean
+```
+
+Deletes the `.gitnexus/` directory and unregisters the repo from the global registry. Use before re-indexing if the index is corrupt or after removing GitNexus from a project.
+
+| Flag      | Effect                                            |
+| --------- | ------------------------------------------------- |
+| `--force` | Skip confirmation prompt                          |
+| `--all`   | Clean all indexed repos, not just the current one |
+
+### wiki — Generate documentation from the graph
+
+```bash
+npx gitnexus wiki
+```
+
+Generates repository documentation from the knowledge graph using an LLM. Requires an API key (saved to `~/.gitnexus/config.json` on first use).
+
+| Flag                | Effect                                    |
+| ------------------- | ----------------------------------------- |
+| `--force`           | Force full regeneration                   |
+| `--model <model>`   | LLM model (default: minimax/minimax-m2.5) |
+| `--base-url <url>`  | LLM API base URL                          |
+| `--api-key <key>`   | LLM API key                               |
+| `--concurrency <n>` | Parallel LLM calls (default: 3)           |
+| `--gist`            | Publish wiki as a public GitHub Gist      |
+
+### list — Show all indexed repos
+
+```bash
+npx gitnexus list
+```
+
+Lists all repositories registered in `~/.gitnexus/registry.json`. The MCP `list_repos` tool provides the same information.
+
+## After Indexing
+
+1. **Read `gitnexus://repo/{name}/context`** to verify the index loaded
+2. Use the other GitNexus skills (`exploring`, `debugging`, `impact-analysis`, `refactoring`) for your task
+
+## Troubleshooting
+
+- **"Not inside a git repository"**: Run from a directory inside a git repo
+- **Index is stale after re-analyzing**: Restart Codex to reload the MCP server
+- **Embeddings slow**: Omit `--embeddings` (it's off by default) or set `OPENAI_API_KEY` for faster API-based embedding

--- a/.agents/skills/gitnexus/gitnexus-debugging/SKILL.md
+++ b/.agents/skills/gitnexus/gitnexus-debugging/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: gitnexus-debugging
+description: "Use when the user is debugging a bug, tracing an error, or asking why something fails. Examples: \"Why is X failing?\", \"Where does this error come from?\", \"Trace this bug\""
+---
+
+# Debugging with GitNexus
+
+## When to Use
+
+- "Why is this function failing?"
+- "Trace where this error comes from"
+- "Who calls this method?"
+- "This endpoint returns 500"
+- Investigating bugs, errors, or unexpected behavior
+
+## Workflow
+
+```
+1. gitnexus_query({query: "<error or symptom>"})            → Find related execution flows
+2. gitnexus_context({name: "<suspect>"})                    → See callers/callees/processes
+3. READ gitnexus://repo/{name}/process/{name}                → Trace execution flow
+4. gitnexus_cypher({query: "MATCH path..."})                 → Custom traces if needed
+```
+
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] Understand the symptom (error message, unexpected behavior)
+- [ ] gitnexus_query for error text or related code
+- [ ] Identify the suspect function from returned processes
+- [ ] gitnexus_context to see callers and callees
+- [ ] Trace execution flow via process resource if applicable
+- [ ] gitnexus_cypher for custom call chain traces if needed
+- [ ] Read source files to confirm root cause
+```
+
+## Debugging Patterns
+
+| Symptom              | GitNexus Approach                                          |
+| -------------------- | ---------------------------------------------------------- |
+| Error message        | `gitnexus_query` for error text → `context` on throw sites |
+| Wrong return value   | `context` on the function → trace callees for data flow    |
+| Intermittent failure | `context` → look for external calls, async deps            |
+| Performance issue    | `context` → find symbols with many callers (hot paths)     |
+| Recent regression    | `detect_changes` to see what your changes affect           |
+
+## Tools
+
+**gitnexus_query** — find code related to error:
+
+```
+gitnexus_query({query: "payment validation error"})
+→ Processes: CheckoutFlow, ErrorHandling
+→ Symbols: validatePayment, handlePaymentError, PaymentException
+```
+
+**gitnexus_context** — full context for a suspect:
+
+```
+gitnexus_context({name: "validatePayment"})
+→ Incoming calls: processCheckout, webhookHandler
+→ Outgoing calls: verifyCard, fetchRates (external API!)
+→ Processes: CheckoutFlow (step 3/7)
+```
+
+**gitnexus_cypher** — custom call chain traces:
+
+```cypher
+MATCH path = (a)-[:CodeRelation {type: 'CALLS'}*1..2]->(b:Function {name: "validatePayment"})
+RETURN [n IN nodes(path) | n.name] AS chain
+```
+
+## Example: "Payment endpoint returns 500 intermittently"
+
+```
+1. gitnexus_query({query: "payment error handling"})
+   → Processes: CheckoutFlow, ErrorHandling
+   → Symbols: validatePayment, handlePaymentError
+
+2. gitnexus_context({name: "validatePayment"})
+   → Outgoing calls: verifyCard, fetchRates (external API!)
+
+3. READ gitnexus://repo/my-app/process/CheckoutFlow
+   → Step 3: validatePayment → calls fetchRates (external)
+
+4. Root cause: fetchRates calls external API without proper timeout
+```

--- a/.agents/skills/gitnexus/gitnexus-exploring/SKILL.md
+++ b/.agents/skills/gitnexus/gitnexus-exploring/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: gitnexus-exploring
+description: "Use when the user asks how code works, wants to understand architecture, trace execution flows, or explore unfamiliar parts of the codebase. Examples: \"How does X work?\", \"What calls this function?\", \"Show me the auth flow\""
+---
+
+# Exploring Codebases with GitNexus
+
+## When to Use
+
+- "How does authentication work?"
+- "What's the project structure?"
+- "Show me the main components"
+- "Where is the database logic?"
+- Understanding code you haven't seen before
+
+## Workflow
+
+```
+1. READ gitnexus://repos                          → Discover indexed repos
+2. READ gitnexus://repo/{name}/context             → Codebase overview, check staleness
+3. gitnexus_query({query: "<what you want to understand>"})  → Find related execution flows
+4. gitnexus_context({name: "<symbol>"})            → Deep dive on specific symbol
+5. READ gitnexus://repo/{name}/process/{name}      → Trace full execution flow
+```
+
+> If step 2 says "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] READ gitnexus://repo/{name}/context
+- [ ] gitnexus_query for the concept you want to understand
+- [ ] Review returned processes (execution flows)
+- [ ] gitnexus_context on key symbols for callers/callees
+- [ ] READ process resource for full execution traces
+- [ ] Read source files for implementation details
+```
+
+## Resources
+
+| Resource                                | What you get                                            |
+| --------------------------------------- | ------------------------------------------------------- |
+| `gitnexus://repo/{name}/context`        | Stats, staleness warning (~150 tokens)                  |
+| `gitnexus://repo/{name}/clusters`       | All functional areas with cohesion scores (~300 tokens) |
+| `gitnexus://repo/{name}/cluster/{name}` | Area members with file paths (~500 tokens)              |
+| `gitnexus://repo/{name}/process/{name}` | Step-by-step execution trace (~200 tokens)              |
+
+## Tools
+
+**gitnexus_query** — find execution flows related to a concept:
+
+```
+gitnexus_query({query: "payment processing"})
+→ Processes: CheckoutFlow, RefundFlow, WebhookHandler
+→ Symbols grouped by flow with file locations
+```
+
+**gitnexus_context** — 360-degree view of a symbol:
+
+```
+gitnexus_context({name: "validateUser"})
+→ Incoming calls: loginHandler, apiMiddleware
+→ Outgoing calls: checkToken, getUserById
+→ Processes: LoginFlow (step 2/5), TokenRefresh (step 1/3)
+```
+
+## Example: "How does payment processing work?"
+
+```
+1. READ gitnexus://repo/my-app/context       → 918 symbols, 45 processes
+2. gitnexus_query({query: "payment processing"})
+   → CheckoutFlow: processPayment → validateCard → chargeStripe
+   → RefundFlow: initiateRefund → calculateRefund → processRefund
+3. gitnexus_context({name: "processPayment"})
+   → Incoming: checkoutHandler, webhookHandler
+   → Outgoing: validateCard, chargeStripe, saveTransaction
+4. Read src/payments/processor.ts for implementation details
+```

--- a/.agents/skills/gitnexus/gitnexus-guide/SKILL.md
+++ b/.agents/skills/gitnexus/gitnexus-guide/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: gitnexus-guide
+description: "Use when the user asks about GitNexus itself — available tools, how to query the knowledge graph, MCP resources, graph schema, or workflow reference. Examples: \"What GitNexus tools are available?\", \"How do I use GitNexus?\""
+---
+
+# GitNexus Guide
+
+Quick reference for all GitNexus MCP tools, resources, and the knowledge graph schema.
+
+## Always Start Here
+
+For any task involving code understanding, debugging, impact analysis, or refactoring:
+
+1. **Read `gitnexus://repo/{name}/context`** — codebase overview + check index freshness
+2. **Match your task to a skill below** and **read that skill file**
+3. **Follow the skill's workflow and checklist**
+
+> If step 1 warns the index is stale, run `npx gitnexus analyze` in the terminal first.
+
+## Skills
+
+| Task                                         | Skill to read       |
+| -------------------------------------------- | ------------------- |
+| Understand architecture / "How does X work?" | `gitnexus-exploring`         |
+| Blast radius / "What breaks if I change X?"  | `gitnexus-impact-analysis`   |
+| Trace bugs / "Why is X failing?"             | `gitnexus-debugging`         |
+| Rename / extract / split / refactor          | `gitnexus-refactoring`       |
+| Tools, resources, schema reference           | `gitnexus-guide` (this file) |
+| Index, status, clean, wiki CLI commands      | `gitnexus-cli`               |
+
+## Tools Reference
+
+| Tool             | What it gives you                                                        |
+| ---------------- | ------------------------------------------------------------------------ |
+| `query`          | Process-grouped code intelligence — execution flows related to a concept |
+| `context`        | 360-degree symbol view — categorized refs, processes it participates in  |
+| `impact`         | Symbol blast radius — what breaks at depth 1/2/3 with confidence         |
+| `detect_changes` | Git-diff impact — what do your current changes affect                    |
+| `rename`         | Multi-file coordinated rename with confidence-tagged edits               |
+| `cypher`         | Raw graph queries (read `gitnexus://repo/{name}/schema` first)           |
+| `list_repos`     | Discover indexed repos                                                   |
+
+## Resources Reference
+
+Lightweight reads (~100-500 tokens) for navigation:
+
+| Resource                                       | Content                                   |
+| ---------------------------------------------- | ----------------------------------------- |
+| `gitnexus://repo/{name}/context`               | Stats, staleness check                    |
+| `gitnexus://repo/{name}/clusters`              | All functional areas with cohesion scores |
+| `gitnexus://repo/{name}/cluster/{clusterName}` | Area members                              |
+| `gitnexus://repo/{name}/processes`             | All execution flows                       |
+| `gitnexus://repo/{name}/process/{processName}` | Step-by-step trace                        |
+| `gitnexus://repo/{name}/schema`                | Graph schema for Cypher                   |
+
+## Graph Schema
+
+**Nodes:** File, Function, Class, Interface, Method, Community, Process
+**Edges (via CodeRelation.type):** CALLS, IMPORTS, EXTENDS, IMPLEMENTS, DEFINES, MEMBER_OF, STEP_IN_PROCESS
+
+```cypher
+MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "myFunc"})
+RETURN caller.name, caller.filePath
+```

--- a/.agents/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
+++ b/.agents/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: gitnexus-impact-analysis
+description: "Use when the user wants to know what will break if they change something, or needs safety analysis before editing code. Examples: \"Is it safe to change X?\", \"What depends on this?\", \"What will break?\""
+---
+
+# Impact Analysis with GitNexus
+
+## When to Use
+
+- "Is it safe to change this function?"
+- "What will break if I modify X?"
+- "Show me the blast radius"
+- "Who uses this code?"
+- Before making non-trivial code changes
+- Before committing — to understand what your changes affect
+
+## Workflow
+
+```
+1. gitnexus_impact({target: "X", direction: "upstream"})  → What depends on this
+2. READ gitnexus://repo/{name}/processes                   → Check affected execution flows
+3. gitnexus_detect_changes()                               → Map current git changes to affected flows
+4. Assess risk and report to user
+```
+
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] gitnexus_impact({target, direction: "upstream"}) to find dependents
+- [ ] Review d=1 items first (these WILL BREAK)
+- [ ] Check high-confidence (>0.8) dependencies
+- [ ] READ processes to check affected execution flows
+- [ ] gitnexus_detect_changes() for pre-commit check
+- [ ] Assess risk level and report to user
+```
+
+## Understanding Output
+
+| Depth | Risk Level       | Meaning                  |
+| ----- | ---------------- | ------------------------ |
+| d=1   | **WILL BREAK**   | Direct callers/importers |
+| d=2   | LIKELY AFFECTED  | Indirect dependencies    |
+| d=3   | MAY NEED TESTING | Transitive effects       |
+
+## Risk Assessment
+
+| Affected                       | Risk     |
+| ------------------------------ | -------- |
+| <5 symbols, few processes      | LOW      |
+| 5-15 symbols, 2-5 processes    | MEDIUM   |
+| >15 symbols or many processes  | HIGH     |
+| Critical path (auth, payments) | CRITICAL |
+
+## Tools
+
+**gitnexus_impact** — the primary tool for symbol blast radius:
+
+```
+gitnexus_impact({
+  target: "validateUser",
+  direction: "upstream",
+  minConfidence: 0.8,
+  maxDepth: 3
+})
+
+→ d=1 (WILL BREAK):
+  - loginHandler (src/auth/login.ts:42) [CALLS, 100%]
+  - apiMiddleware (src/api/middleware.ts:15) [CALLS, 100%]
+
+→ d=2 (LIKELY AFFECTED):
+  - authRouter (src/routes/auth.ts:22) [CALLS, 95%]
+```
+
+**gitnexus_detect_changes** — git-diff based impact analysis:
+
+```
+gitnexus_detect_changes({scope: "staged"})
+
+→ Changed: 5 symbols in 3 files
+→ Affected: LoginFlow, TokenRefresh, APIMiddlewarePipeline
+→ Risk: MEDIUM
+```
+
+## Example: "What breaks if I change validateUser?"
+
+```
+1. gitnexus_impact({target: "validateUser", direction: "upstream"})
+   → d=1: loginHandler, apiMiddleware (WILL BREAK)
+   → d=2: authRouter, sessionManager (LIKELY AFFECTED)
+
+2. READ gitnexus://repo/my-app/processes
+   → LoginFlow and TokenRefresh touch validateUser
+
+3. Risk: 2 direct callers, 2 processes = MEDIUM
+```

--- a/.agents/skills/gitnexus/gitnexus-refactoring/SKILL.md
+++ b/.agents/skills/gitnexus/gitnexus-refactoring/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: gitnexus-refactoring
+description: "Use when the user wants to rename, extract, split, move, or restructure code safely. Examples: \"Rename this function\", \"Extract this into a module\", \"Refactor this class\", \"Move this to a separate file\""
+---
+
+# Refactoring with GitNexus
+
+## When to Use
+
+- "Rename this function safely"
+- "Extract this into a module"
+- "Split this service"
+- "Move this to a new file"
+- Any task involving renaming, extracting, splitting, or restructuring code
+
+## Workflow
+
+```
+1. gitnexus_impact({target: "X", direction: "upstream"})  → Map all dependents
+2. gitnexus_query({query: "X"})                            → Find execution flows involving X
+3. gitnexus_context({name: "X"})                           → See all incoming/outgoing refs
+4. Plan update order: interfaces → implementations → callers → tests
+```
+
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklists
+
+### Rename Symbol
+
+```
+- [ ] gitnexus_rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
+- [ ] Review graph edits (high confidence) and ast_search edits (review carefully)
+- [ ] If satisfied: gitnexus_rename({..., dry_run: false}) — apply edits
+- [ ] gitnexus_detect_changes() — verify only expected files changed
+- [ ] Run tests for affected processes
+```
+
+### Extract Module
+
+```
+- [ ] gitnexus_context({name: target}) — see all incoming/outgoing refs
+- [ ] gitnexus_impact({target, direction: "upstream"}) — find all external callers
+- [ ] Define new module interface
+- [ ] Extract code, update imports
+- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] Run tests for affected processes
+```
+
+### Split Function/Service
+
+```
+- [ ] gitnexus_context({name: target}) — understand all callees
+- [ ] Group callees by responsibility
+- [ ] gitnexus_impact({target, direction: "upstream"}) — map callers to update
+- [ ] Create new functions/services
+- [ ] Update callers
+- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] Run tests for affected processes
+```
+
+## Tools
+
+**gitnexus_rename** — automated multi-file rename:
+
+```
+gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+→ 12 edits across 8 files
+→ 10 graph edits (high confidence), 2 ast_search edits (review)
+→ Changes: [{file_path, edits: [{line, old_text, new_text, confidence}]}]
+```
+
+**gitnexus_impact** — map all dependents first:
+
+```
+gitnexus_impact({target: "validateUser", direction: "upstream"})
+→ d=1: loginHandler, apiMiddleware, testUtils
+→ Affected Processes: LoginFlow, TokenRefresh
+```
+
+**gitnexus_detect_changes** — verify your changes after refactoring:
+
+```
+gitnexus_detect_changes({scope: "all"})
+→ Changed: 8 files, 12 symbols
+→ Affected processes: LoginFlow, TokenRefresh
+→ Risk: MEDIUM
+```
+
+**gitnexus_cypher** — custom reference queries:
+
+```cypher
+MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "validateUser"})
+RETURN caller.name, caller.filePath ORDER BY caller.filePath
+```
+
+## Risk Rules
+
+| Risk Factor         | Mitigation                                |
+| ------------------- | ----------------------------------------- |
+| Many callers (>5)   | Use gitnexus_rename for automated updates |
+| Cross-area refs     | Use detect_changes after to verify scope  |
+| String/dynamic refs | gitnexus_query to find them               |
+| External/public API | Version and deprecate properly            |
+
+## Example: Rename `validateUser` to `authenticateUser`
+
+```
+1. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+   → 12 edits: 10 graph (safe), 2 ast_search (review)
+   → Files: validator.ts, login.ts, middleware.ts, config.json...
+
+2. Review ast_search edits (config.json: dynamic reference!)
+
+3. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
+   → Applied 12 edits across 8 files
+
+4. gitnexus_detect_changes({scope: "all"})
+   → Affected: LoginFlow, TokenRefresh
+   → Risk: MEDIUM — run tests for these flows
+```

--- a/.agents/skills/gitnexus/impact-analysis/SKILL.md
+++ b/.agents/skills/gitnexus/impact-analysis/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: gitnexus-impact-analysis
+description: Analyze blast radius before making code changes
+---
+
+# Impact Analysis with GitNexus
+
+## When to Use
+- "Is it safe to change this function?"
+- "What will break if I modify X?"
+- "Show me the blast radius"
+- "Who uses this code?"
+- Before making non-trivial code changes
+- Before committing — to understand what your changes affect
+
+## Workflow
+
+```
+1. gitnexus_impact({target: "X", direction: "upstream"})  → What depends on this
+2. READ gitnexus://repo/{name}/processes                   → Check affected execution flows
+3. gitnexus_detect_changes()                               → Map current git changes to affected flows
+4. Assess risk and report to user
+```
+
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] gitnexus_impact({target, direction: "upstream"}) to find dependents
+- [ ] Review d=1 items first (these WILL BREAK)
+- [ ] Check high-confidence (>0.8) dependencies
+- [ ] READ processes to check affected execution flows
+- [ ] gitnexus_detect_changes() for pre-commit check
+- [ ] Assess risk level and report to user
+```
+
+## Understanding Output
+
+| Depth | Risk Level | Meaning |
+|-------|-----------|---------|
+| d=1 | **WILL BREAK** | Direct callers/importers |
+| d=2 | LIKELY AFFECTED | Indirect dependencies |
+| d=3 | MAY NEED TESTING | Transitive effects |
+
+## Risk Assessment
+
+| Affected | Risk |
+|----------|------|
+| <5 symbols, few processes | LOW |
+| 5-15 symbols, 2-5 processes | MEDIUM |
+| >15 symbols or many processes | HIGH |
+| Critical path (auth, payments) | CRITICAL |
+
+## Tools
+
+**gitnexus_impact** — the primary tool for symbol blast radius:
+```
+gitnexus_impact({
+  target: "validateUser",
+  direction: "upstream",
+  minConfidence: 0.8,
+  maxDepth: 3
+})
+
+→ d=1 (WILL BREAK):
+  - loginHandler (src/auth/login.ts:42) [CALLS, 100%]
+  - apiMiddleware (src/api/middleware.ts:15) [CALLS, 100%]
+
+→ d=2 (LIKELY AFFECTED):
+  - authRouter (src/routes/auth.ts:22) [CALLS, 95%]
+```
+
+**gitnexus_detect_changes** — git-diff based impact analysis:
+```
+gitnexus_detect_changes({scope: "staged"})
+
+→ Changed: 5 symbols in 3 files
+→ Affected: LoginFlow, TokenRefresh, APIMiddlewarePipeline
+→ Risk: MEDIUM
+```
+
+## Example: "What breaks if I change validateUser?"
+
+```
+1. gitnexus_impact({target: "validateUser", direction: "upstream"})
+   → d=1: loginHandler, apiMiddleware (WILL BREAK)
+   → d=2: authRouter, sessionManager (LIKELY AFFECTED)
+
+2. READ gitnexus://repo/my-app/processes
+   → LoginFlow and TokenRefresh touch validateUser
+
+3. Risk: 2 direct callers, 2 processes = MEDIUM
+```

--- a/.agents/skills/gitnexus/refactoring/SKILL.md
+++ b/.agents/skills/gitnexus/refactoring/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: gitnexus-refactoring
+description: Plan safe refactors using blast radius and dependency mapping
+---
+
+# Refactoring with GitNexus
+
+## When to Use
+- "Rename this function safely"
+- "Extract this into a module"
+- "Split this service"
+- "Move this to a new file"
+- Any task involving renaming, extracting, splitting, or restructuring code
+
+## Workflow
+
+```
+1. gitnexus_impact({target: "X", direction: "upstream"})  → Map all dependents
+2. gitnexus_query({query: "X"})                            → Find execution flows involving X
+3. gitnexus_context({name: "X"})                           → See all incoming/outgoing refs
+4. Plan update order: interfaces → implementations → callers → tests
+```
+
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklists
+
+### Rename Symbol
+```
+- [ ] gitnexus_rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
+- [ ] Review graph edits (high confidence) and ast_search edits (review carefully)
+- [ ] If satisfied: gitnexus_rename({..., dry_run: false}) — apply edits
+- [ ] gitnexus_detect_changes() — verify only expected files changed
+- [ ] Run tests for affected processes
+```
+
+### Extract Module
+```
+- [ ] gitnexus_context({name: target}) — see all incoming/outgoing refs
+- [ ] gitnexus_impact({target, direction: "upstream"}) — find all external callers
+- [ ] Define new module interface
+- [ ] Extract code, update imports
+- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] Run tests for affected processes
+```
+
+### Split Function/Service
+```
+- [ ] gitnexus_context({name: target}) — understand all callees
+- [ ] Group callees by responsibility
+- [ ] gitnexus_impact({target, direction: "upstream"}) — map callers to update
+- [ ] Create new functions/services
+- [ ] Update callers
+- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] Run tests for affected processes
+```
+
+## Tools
+
+**gitnexus_rename** — automated multi-file rename:
+```
+gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+→ 12 edits across 8 files
+→ 10 graph edits (high confidence), 2 ast_search edits (review)
+→ Changes: [{file_path, edits: [{line, old_text, new_text, confidence}]}]
+```
+
+**gitnexus_impact** — map all dependents first:
+```
+gitnexus_impact({target: "validateUser", direction: "upstream"})
+→ d=1: loginHandler, apiMiddleware, testUtils
+→ Affected Processes: LoginFlow, TokenRefresh
+```
+
+**gitnexus_detect_changes** — verify your changes after refactoring:
+```
+gitnexus_detect_changes({scope: "all"})
+→ Changed: 8 files, 12 symbols
+→ Affected processes: LoginFlow, TokenRefresh
+→ Risk: MEDIUM
+```
+
+**gitnexus_cypher** — custom reference queries:
+```cypher
+MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "validateUser"})
+RETURN caller.name, caller.filePath ORDER BY caller.filePath
+```
+
+## Risk Rules
+
+| Risk Factor | Mitigation |
+|-------------|------------|
+| Many callers (>5) | Use gitnexus_rename for automated updates |
+| Cross-area refs | Use detect_changes after to verify scope |
+| String/dynamic refs | gitnexus_query to find them |
+| External/public API | Version and deprecate properly |
+
+## Example: Rename `validateUser` to `authenticateUser`
+
+```
+1. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+   → 12 edits: 10 graph (safe), 2 ast_search (review)
+   → Files: validator.ts, login.ts, middleware.ts, config.json...
+
+2. Review ast_search edits (config.json: dynamic reference!)
+
+3. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
+   → Applied 12 edits across 8 files
+
+4. gitnexus_detect_changes({scope: "all"})
+   → Affected: LoginFlow, TokenRefresh
+   → Risk: MEDIUM — run tests for these flows
+```

--- a/.agents/skills/tabularis-plugin-driver/SKILL.md
+++ b/.agents/skills/tabularis-plugin-driver/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: tabularis-plugin-driver
+description: "Use when creating or updating a Tabularis database driver plugin in Rust. Covers modern manifest fields, JSON-RPC over stdio, modular plugin layout, MySQL-level feature coverage targets, optional UI extensions, and validation against Tabularis repo rules."
+---
+
+# Tabularis Plugin Driver
+
+Use this skill when building or updating a database plugin for Tabularis.
+
+The skill is optimized for this repository. Follow `AGENTS.md`, the files in `.rules/`, and the current plugin-system behavior in `src-tauri/src/plugins/` and `src/types/plugins.ts`.
+
+## Goals
+
+- Build a Rust plugin that speaks Tabularis JSON-RPC over stdin/stdout
+- Use the modern plugin manifest, not the old minimal format
+- Aim for broad feature coverage comparable to the built-in MySQL driver where the target database supports it
+- Keep the plugin modular instead of concentrating logic in a single `main.rs`
+- Add unit tests for pure utilities and SQL generation
+
+## Default Repo Layout
+
+Prefer this structure for a new plugin repository:
+
+```text
+plugin-root/
+├── Cargo.toml
+├── manifest.json
+├── README.md
+├── src/
+│   ├── main.rs
+│   ├── rpc.rs
+│   ├── client.rs
+│   ├── error.rs
+│   ├── models.rs
+│   ├── handlers/
+│   │   ├── mod.rs
+│   │   ├── metadata.rs
+│   │   ├── query.rs
+│   │   ├── crud.rs
+│   │   └── ddl.rs
+│   └── utils/
+│       ├── mod.rs
+│       ├── identifiers.rs
+│       ├── values.rs
+│       ├── types.rs
+│       └── pagination.rs
+├── src/bin/
+│   └── test_plugin.rs
+└── tests/                # only if integration tests are worth the overhead
+```
+
+Keep `src/main.rs` thin. It should mostly parse requests, dispatch methods, and serialize responses.
+
+## Required Research Before Coding
+
+1. Read the current plugin manifest shape in:
+   - `plugins/manifest.schema.json`
+   - `src/types/plugins.ts`
+   - `src-tauri/src/plugins/manager.rs`
+2. Read the JSON-RPC expectations in:
+   - `plugins/PLUGIN_GUIDE.md`
+   - `src-tauri/src/plugins/driver.rs`
+   - `src-tauri/src/plugins/rpc.rs`
+3. Read a built-in driver with broad coverage to understand expected behaviors:
+   - `src-tauri/src/drivers/mysql/mod.rs`
+4. Read plugin-loading behavior and modern feature flags in:
+   - `src/hooks/useDrivers.ts`
+   - `src/utils/connectionStringParser.ts`
+   - `src/utils/driverCapabilities.ts`
+
+## Implementation Workflow
+
+### 1. Define plugin scope
+
+Decide which capabilities are truly supported by the target database and driver library:
+
+- `schemas`
+- `views`
+- `routines`
+- `file_based`
+- `folder_based`
+- `connection_string`
+- `connection_string_example`
+- `identifier_quote`
+- `alter_primary_key`
+- `alter_column`
+- `create_foreign_keys`
+- `manage_tables`
+- `readonly`
+- `no_connection_required`
+
+Do not advertise support you cannot back with working handlers.
+
+### 2. Create a modern manifest
+
+At minimum define:
+
+- `id`
+- `name`
+- `version`
+- `description`
+- `default_port`
+- `executable`
+- `capabilities`
+- `data_types`
+- `default_username`
+- `color`
+- `icon`
+
+Use modern optional fields when useful:
+
+- `settings`
+- `ui_extensions`
+
+See [references/manifest-checklist.md](./references/manifest-checklist.md).
+
+### 3. Build a modular RPC surface
+
+Implement the request loop in `main.rs`, but move logic out immediately:
+
+- `rpc.rs`: request parsing, success/error helpers, method routing support
+- `client.rs`: connection config, client creation, pooling or reuse key logic
+- `handlers/metadata.rs`: databases, schemas, tables, columns, indexes, foreign keys, views, routines
+- `handlers/query.rs`: `test_connection`, `ping`, `execute_query`, `count_query`, `explain_query_plan` if possible
+- `handlers/crud.rs`: `insert_record`, `update_record`, `delete_record`
+- `handlers/ddl.rs`: SQL generation helpers and DDL RPC methods
+- `utils/*`: quoting, escaping, value formatting, type normalization, pagination math
+
+### 4. Target broad feature coverage
+
+Use the built-in MySQL driver as the feature benchmark, not as text to copy.
+
+For each feature area, classify it:
+
+- `supported`: implement fully
+- `partially_supported`: implement with explicit limitations
+- `unsupported`: return an accurate error or empty result as appropriate
+
+Prioritize these methods:
+
+- `test_connection`
+- `get_databases`
+- `get_schemas`
+- `get_tables`
+- `get_columns`
+- `get_foreign_keys`
+- `get_indexes`
+- `get_views`
+- `get_view_definition`
+- `get_view_columns`
+- `get_routines`
+- `get_routine_parameters`
+- `get_routine_definition`
+- `execute_query`
+- `insert_record`
+- `update_record`
+- `delete_record`
+- `get_schema_snapshot`
+- `get_all_columns_batch`
+- `get_all_foreign_keys_batch`
+- `get_create_table_sql`
+- `get_add_column_sql`
+- `get_alter_column_sql`
+- `get_create_index_sql`
+- `get_create_foreign_key_sql`
+- `drop_index`
+- `drop_foreign_key`
+
+If a method is not safe to emulate, fail explicitly instead of faking success.
+
+### 5. Add settings only when they solve a real problem
+
+Typical useful settings:
+
+- DSN name
+- driver/library path
+- default schema
+- TLS mode
+- extra connection properties
+
+Keep settings in the manifest and resolve them in a dedicated config path, not inline in handlers.
+
+### 6. Add UI extensions only when the database needs them
+
+Examples of good reasons:
+
+- a custom connection helper for DSN-based setup
+- an advanced settings panel for database-specific options
+- contextual UI for unsupported-but-important caveats
+
+Avoid UI extensions that only decorate the product without improving DB-specific workflows.
+
+## Testing Strategy
+
+Always add unit tests for pure logic:
+
+- identifier quoting
+- SQL builders
+- type normalization
+- pagination helpers
+- value serialization
+- capability-driven helper decisions
+
+Prefer pure utility modules so tests stay fast and deterministic.
+
+If the plugin includes a JSON-RPC smoke binary like `src/bin/test_plugin.rs`, use it to simulate Tabularis requests over stdio.
+
+## Validation Checklist
+
+Before finishing:
+
+- `cargo test`
+- `cargo build --release`
+- smoke test at least one JSON-RPC request through stdin/stdout
+- verify `manifest.json` matches current Tabularis schema and capabilities
+- verify any advertised capability has corresponding handler behavior
+- verify unsupported operations return clear errors
+
+## Tabularis-Specific Rules
+
+- Comments and docs must be in English
+- Keep code split by responsibility; avoid a monolithic `main.rs`
+- Add unit tests for extracted utility logic
+- When updating this repo itself, follow `AGENTS.md` requirements including GitNexus impact analysis before editing existing symbols
+- Use `pnpm` for frontend-side validation in this repo and `cargo` for plugin validation
+
+## Common Mistakes
+
+- copying old plugin manifests that omit modern fields
+- putting connection logic, SQL generation, RPC parsing, and metadata extraction in one file
+- advertising `manage_tables` or `alter_column` without implementing the related methods
+- returning fake empty success for operations that should surface unsupported behavior
+- skipping tests for identifier quoting and SQL generation
+
+## References
+
+- Manifest details: [references/manifest-checklist.md](./references/manifest-checklist.md)

--- a/.agents/skills/tabularis-plugin-driver/agents/openai.yaml
+++ b/.agents/skills/tabularis-plugin-driver/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Tabularis Plugin Driver"
+  short_description: "Create Rust database plugins for Tabularis."
+  default_prompt: "Use $tabularis-plugin-driver to create or update a Rust Tabularis database plugin with a modern manifest, modular handlers, tests, and validation."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/tabularis-plugin-driver/references/manifest-checklist.md
+++ b/.agents/skills/tabularis-plugin-driver/references/manifest-checklist.md
@@ -1,0 +1,67 @@
+# Manifest Checklist
+
+Use this checklist when authoring `manifest.json` for a Tabularis database plugin.
+
+## Required Core Fields
+
+- `id`
+- `name`
+- `version`
+- `description`
+- `capabilities`
+
+For driver plugins, also include:
+
+- `default_port`
+- `executable`
+- `data_types`
+
+## Recommended Modern Fields
+
+- `default_username`
+- `color`
+- `icon`
+- `settings`
+- `ui_extensions`
+
+## Capability Guidance
+
+Set these deliberately:
+
+- `schemas`: true only if the database exposes multiple named schemas/namespaces in Tabularis terms
+- `views`: true only if view listing and definition retrieval are implemented
+- `routines`: true only if routines can be listed and inspected
+- `file_based`: true only for file-backed databases
+- `folder_based`: true only for directory-backed databases
+- `connection_string`: false only when connection-string import should be hidden
+- `connection_string_example`: provide a real example when `connection_string` is enabled
+- `identifier_quote`: use the real quoting character for generated SQL
+- `alter_primary_key`: true only if ALTER support is actually reliable
+- `alter_column`: true only if alter/modify column flows are implemented
+- `create_foreign_keys`: true only if FK DDL is supported and enforced
+- `manage_tables`: false for read-only or inspection-only plugins
+- `readonly`: true if insert/update/delete and table management must be hidden
+- `no_connection_required`: true only for API-style plugins
+
+## Settings Guidance
+
+Add manifest `settings` when configuration cannot be expressed cleanly through the normal connection form.
+
+Good examples:
+
+- DSN selector
+- TLS mode
+- driver path
+- default schema
+- extra connection properties
+
+## UI Extensions Guidance
+
+Use `ui_extensions` only when a database-specific workflow benefits from custom UI.
+
+Good examples:
+
+- plugin settings content for advanced driver setup
+- connection-helper UI for DSN-based databases
+
+Avoid UI extensions for cosmetic customization only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Adhere to the rules defined in the [rules directory](./.rules/):
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **tabularis** (9670 symbols, 16768 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **tabularis** (5581 symbols, 13441 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -24,12 +24,44 @@ This project is indexed by GitNexus as **tabularis** (9670 symbols, 16768 relati
 - When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
 - When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
+## When Debugging
+
+1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
+2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
+3. `READ gitnexus://repo/tabularis/process/{processName}` — trace the full execution flow step by step
+4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
+
+## When Refactoring
+
+- **Renaming**: MUST use `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` first. Review the preview — graph edits are safe, text_search edits need manual review. Then run with `dry_run: false`.
+- **Extracting/Splitting**: MUST run `gitnexus_context({name: "target"})` to see all incoming/outgoing refs, then `gitnexus_impact({target: "target", direction: "upstream"})` to find all external callers before moving code.
+- After any refactor: run `gitnexus_detect_changes({scope: "all"})` to verify only expected files changed.
+
 ## Never Do
 
 - NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
 - NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
 - NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Tools Quick Reference
+
+| Tool | When to use | Command |
+|------|-------------|---------|
+| `query` | Find code by concept | `gitnexus_query({query: "auth validation"})` |
+| `context` | 360-degree view of one symbol | `gitnexus_context({name: "validateUser"})` |
+| `impact` | Blast radius before editing | `gitnexus_impact({target: "X", direction: "upstream"})` |
+| `detect_changes` | Pre-commit scope check | `gitnexus_detect_changes({scope: "staged"})` |
+| `rename` | Safe multi-file rename | `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` |
+| `cypher` | Custom graph queries | `gitnexus_cypher({query: "MATCH ..."})` |
+
+## Impact Risk Levels
+
+| Depth | Meaning | Action |
+|-------|---------|--------|
+| d=1 | WILL BREAK — direct callers/importers | MUST update these |
+| d=2 | LIKELY AFFECTED — indirect deps | Should test |
+| d=3 | MAY NEED TESTING — transitive | Test if critical path |
 
 ## Resources
 
@@ -39,6 +71,32 @@ This project is indexed by GitNexus as **tabularis** (9670 symbols, 16768 relati
 | `gitnexus://repo/tabularis/clusters` | All functional areas |
 | `gitnexus://repo/tabularis/processes` | All execution flows |
 | `gitnexus://repo/tabularis/process/{name}` | Step-by-step execution trace |
+
+## Self-Check Before Finishing
+
+Before completing any code modification task, verify:
+1. `gitnexus_impact` was run for all modified symbols
+2. No HIGH/CRITICAL risk warnings were ignored
+3. `gitnexus_detect_changes()` confirms changes match expected scope
+4. All d=1 (WILL BREAK) dependents were updated
+
+## Keeping the Index Fresh
+
+After committing code changes, the GitNexus index becomes stale. Re-run analyze to update it:
+
+```bash
+npx gitnexus analyze
+```
+
+If the index previously included embeddings, preserve them by adding `--embeddings`:
+
+```bash
+npx gitnexus analyze --embeddings
+```
+
+To check whether embeddings exist, inspect `.gitnexus/meta.json` — the `stats.embeddings` field shows the count (0 means no embeddings). **Running analyze without `--embeddings` will delete any previously generated embeddings.**
+
+> Claude Code users: A PostToolUse hook handles this automatically after `git commit` and `git merge`.
 
 ## CLI
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1874,6 +1874,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2790,6 +2799,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2959,6 +2988,26 @@ dependencies = [
  "security-framework 3.7.0",
  "windows-sys 0.60.2",
  "zeroize",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -3230,6 +3279,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
@@ -3349,6 +3410,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6066,12 +6146,14 @@ dependencies = [
  "csv",
  "deadpool-postgres",
  "directories",
+ "filetime",
  "futures",
  "gtk",
  "infer 0.16.0",
  "keyring",
  "log",
  "native-tls",
+ "notify",
  "once_cell",
  "openssl",
  "postgres-native-tls",
@@ -6682,7 +6764,7 @@ checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.1.1",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -58,6 +58,7 @@ tokio-postgres = { version = "0.7.13", features = ["with-chrono-0_4", "with-uuid
 deadpool-postgres = "0.14.1"
 postgres-native-tls = "0.5.1"
 native-tls = "0.2.13"
+notify = "6"
 
 # GTK dependencies for Wayland window title workaround (Linux only)
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -68,3 +69,4 @@ tauri-plugin-updater = "2"
 
 [dev-dependencies]
 tempfile = "3.24.0"
+filetime = "0.2"

--- a/src-tauri/src/ai_activity.rs
+++ b/src-tauri/src/ai_activity.rs
@@ -1,0 +1,591 @@
+//! AI Activity audit log.
+//!
+//! Records every MCP tool call to a JSON Lines file. The MCP subprocess is
+//! the only writer; the main Tauri app is the reader. No IPC required —
+//! both processes touch the same files.
+//!
+//! Storage layout under the application config directory:
+//!   - `ai_activity.jsonl` — active log (append-only, one event per line)
+//!   - `ai_activity.{1..5}.jsonl` — rotated archives (1 = most recent)
+//!   - `.mcp_session_state.json` — current session id + last activity timestamp
+
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashSet};
+use std::fs::{self, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+use crate::paths::get_app_config_dir;
+
+const ACTIVITY_FILENAME: &str = "ai_activity.jsonl";
+const SESSION_STATE_FILENAME: &str = ".mcp_session_state.json";
+const MAX_ROTATED_FILES: usize = 5;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AiActivityEvent {
+    pub id: String,
+    pub session_id: String,
+    pub timestamp: String,
+    pub tool: String,
+    pub connection_id: Option<String>,
+    pub connection_name: Option<String>,
+    pub query: Option<String>,
+    pub query_kind: Option<String>,
+    pub duration_ms: u64,
+    pub status: String,
+    pub rows: Option<usize>,
+    pub error: Option<String>,
+    pub client_hint: Option<String>,
+    pub approval_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionSummary {
+    pub session_id: String,
+    pub started_at: String,
+    pub ended_at: String,
+    pub event_count: usize,
+    pub run_query_count: usize,
+    pub connection_names: Vec<String>,
+    pub client_hint: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct EventFilter {
+    pub session_id: Option<String>,
+    pub connection_id: Option<String>,
+    pub tool: Option<String>,
+    pub status: Option<String>,
+    pub query_contains: Option<String>,
+    pub since: Option<String>,
+    pub until: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionState {
+    pub session_id: String,
+    pub last_activity_at: String,
+    pub client_hint: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+fn activity_path_in(dir: &Path) -> PathBuf {
+    dir.join(ACTIVITY_FILENAME)
+}
+
+fn rotated_path_in(dir: &Path, index: usize) -> PathBuf {
+    dir.join(format!("ai_activity.{}.jsonl", index))
+}
+
+fn session_state_path_in(dir: &Path) -> PathBuf {
+    dir.join(SESSION_STATE_FILENAME)
+}
+
+fn ensure_dir(dir: &Path) -> Result<(), String> {
+    if !dir.exists() {
+        fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Append + rotation (testable; take a directory)
+// ---------------------------------------------------------------------------
+
+pub fn append_event_in(dir: &Path, event: &AiActivityEvent) -> Result<(), String> {
+    ensure_dir(dir)?;
+    let path = activity_path_in(dir);
+    let line = serde_json::to_string(event).map_err(|e| e.to_string())?;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .map_err(|e| e.to_string())?;
+    writeln!(file, "{}", line).map_err(|e| e.to_string())
+}
+
+fn count_lines(path: &Path) -> Result<usize, String> {
+    if !path.exists() {
+        return Ok(0);
+    }
+    let file = fs::File::open(path).map_err(|e| e.to_string())?;
+    let reader = BufReader::new(file);
+    Ok(reader.lines().count())
+}
+
+pub fn rotate_if_needed_in(dir: &Path, max_entries: usize) -> Result<bool, String> {
+    if max_entries == 0 {
+        return Ok(false);
+    }
+    let active = activity_path_in(dir);
+    if count_lines(&active)? < max_entries {
+        return Ok(false);
+    }
+    // Drop the oldest, then shift each archived file by one.
+    for i in (1..=MAX_ROTATED_FILES).rev() {
+        let src = rotated_path_in(dir, i);
+        if i == MAX_ROTATED_FILES {
+            if src.exists() {
+                fs::remove_file(&src).map_err(|e| e.to_string())?;
+            }
+        } else if src.exists() {
+            let dst = rotated_path_in(dir, i + 1);
+            fs::rename(&src, &dst).map_err(|e| e.to_string())?;
+        }
+    }
+    if active.exists() {
+        let dst = rotated_path_in(dir, 1);
+        fs::rename(&active, &dst).map_err(|e| e.to_string())?;
+    }
+    Ok(true)
+}
+
+pub fn append_and_rotate_in(
+    dir: &Path,
+    event: &AiActivityEvent,
+    max_entries: usize,
+) -> Result<(), String> {
+    append_event_in(dir, event)?;
+    if max_entries > 0 {
+        rotate_if_needed_in(dir, max_entries)?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Read + filter
+// ---------------------------------------------------------------------------
+
+fn read_all_events_in(dir: &Path) -> Result<Vec<AiActivityEvent>, String> {
+    let mut paths: Vec<PathBuf> = Vec::new();
+    // Oldest archive first → newest archive → active. Within each file events
+    // are already in chronological order.
+    for i in (1..=MAX_ROTATED_FILES).rev() {
+        let p = rotated_path_in(dir, i);
+        if p.exists() {
+            paths.push(p);
+        }
+    }
+    let active = activity_path_in(dir);
+    if active.exists() {
+        paths.push(active);
+    }
+
+    let mut events: Vec<AiActivityEvent> = Vec::new();
+    for p in paths {
+        let file = fs::File::open(&p).map_err(|e| e.to_string())?;
+        let reader = BufReader::new(file);
+        for line in reader.lines() {
+            let line = match line {
+                Ok(l) => l,
+                Err(_) => continue,
+            };
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<AiActivityEvent>(trimmed) {
+                Ok(ev) => events.push(ev),
+                Err(_) => {
+                    log::warn!("Skipping unparsable ai_activity entry");
+                }
+            }
+        }
+    }
+    Ok(events)
+}
+
+pub fn read_events_in(dir: &Path, filter: &EventFilter) -> Result<Vec<AiActivityEvent>, String> {
+    let events = read_all_events_in(dir)?;
+    Ok(events
+        .into_iter()
+        .filter(|e| matches_filter(e, filter))
+        .collect())
+}
+
+pub fn read_session_events_in(
+    dir: &Path,
+    session_id: &str,
+) -> Result<Vec<AiActivityEvent>, String> {
+    let mut events = read_all_events_in(dir)?;
+    events.retain(|e| e.session_id == session_id);
+    events.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+    Ok(events)
+}
+
+pub fn read_sessions_in(dir: &Path) -> Result<Vec<SessionSummary>, String> {
+    let events = read_all_events_in(dir)?;
+    let mut by_session: BTreeMap<String, Vec<AiActivityEvent>> = BTreeMap::new();
+    for e in events {
+        by_session.entry(e.session_id.clone()).or_default().push(e);
+    }
+    let mut summaries: Vec<SessionSummary> = by_session
+        .into_iter()
+        .map(|(sid, evs)| build_summary(&sid, &evs))
+        .collect();
+    summaries.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+    Ok(summaries)
+}
+
+pub fn clear_in(dir: &Path) -> Result<(), String> {
+    let active = activity_path_in(dir);
+    if active.exists() {
+        fs::remove_file(&active).map_err(|e| e.to_string())?;
+    }
+    for i in 1..=MAX_ROTATED_FILES {
+        let p = rotated_path_in(dir, i);
+        if p.exists() {
+            fs::remove_file(&p).map_err(|e| e.to_string())?;
+        }
+    }
+    Ok(())
+}
+
+fn matches_filter(e: &AiActivityEvent, f: &EventFilter) -> bool {
+    if let Some(s) = &f.session_id {
+        if e.session_id != *s {
+            return false;
+        }
+    }
+    if let Some(c) = &f.connection_id {
+        if e.connection_id.as_deref() != Some(c.as_str()) {
+            return false;
+        }
+    }
+    if let Some(t) = &f.tool {
+        if e.tool != *t {
+            return false;
+        }
+    }
+    if let Some(s) = &f.status {
+        if e.status != *s {
+            return false;
+        }
+    }
+    if let Some(q) = &f.query_contains {
+        let needle = q.to_lowercase();
+        match &e.query {
+            Some(query) if query.to_lowercase().contains(&needle) => {}
+            _ => return false,
+        }
+    }
+    if let Some(since) = &f.since {
+        if e.timestamp < *since {
+            return false;
+        }
+    }
+    if let Some(until) = &f.until {
+        if e.timestamp > *until {
+            return false;
+        }
+    }
+    true
+}
+
+fn build_summary(session_id: &str, events: &[AiActivityEvent]) -> SessionSummary {
+    let started_at = events
+        .iter()
+        .map(|e| e.timestamp.clone())
+        .min()
+        .unwrap_or_default();
+    let ended_at = events
+        .iter()
+        .map(|e| e.timestamp.clone())
+        .max()
+        .unwrap_or_default();
+    let run_query_count = events.iter().filter(|e| e.tool == "run_query").count();
+    let mut names = HashSet::new();
+    for e in events {
+        if let Some(n) = &e.connection_name {
+            names.insert(n.clone());
+        }
+    }
+    let mut connection_names: Vec<String> = names.into_iter().collect();
+    connection_names.sort();
+    let client_hint = events.iter().find_map(|e| e.client_hint.clone());
+    SessionSummary {
+        session_id: session_id.to_string(),
+        started_at,
+        ended_at,
+        event_count: events.len(),
+        run_query_count,
+        connection_names,
+        client_hint,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public default-dir wrappers (used at runtime)
+// ---------------------------------------------------------------------------
+
+pub fn append_and_rotate(event: &AiActivityEvent, max_entries: usize) -> Result<(), String> {
+    append_and_rotate_in(&get_app_config_dir(), event, max_entries)
+}
+
+pub fn read_events(filter: &EventFilter) -> Result<Vec<AiActivityEvent>, String> {
+    read_events_in(&get_app_config_dir(), filter)
+}
+
+pub fn read_sessions() -> Result<Vec<SessionSummary>, String> {
+    read_sessions_in(&get_app_config_dir())
+}
+
+pub fn read_session_events(session_id: &str) -> Result<Vec<AiActivityEvent>, String> {
+    read_session_events_in(&get_app_config_dir(), session_id)
+}
+
+pub fn clear() -> Result<(), String> {
+    clear_in(&get_app_config_dir())
+}
+
+// ---------------------------------------------------------------------------
+// SQL classification
+// ---------------------------------------------------------------------------
+
+/// Classify the kind of SQL: `"select"`, `"write"`, `"ddl"`, or `"unknown"`.
+///
+/// Conservative on purpose: any input we cannot confidently identify as a
+/// read returns `"unknown"`, so callers can fail closed when enforcing
+/// safety policies (read-only mode, approval gates).
+pub fn classify_query_kind(sql: &str) -> &'static str {
+    let stripped = strip_strings_and_comments(sql);
+    let trimmed = stripped.trim_start();
+    if trimmed.is_empty() {
+        return "unknown";
+    }
+    let upper = trimmed.to_uppercase();
+    let first = first_keyword(&upper);
+
+    match first.as_str() {
+        "SELECT" | "SHOW" | "EXPLAIN" | "DESCRIBE" | "DESC" | "PRAGMA" | "VALUES" => "select",
+        "INSERT" | "UPDATE" | "DELETE" | "MERGE" | "REPLACE" => "write",
+        "CREATE" | "DROP" | "ALTER" | "TRUNCATE" | "RENAME" | "GRANT" | "REVOKE" | "COMMENT" => {
+            "ddl"
+        }
+        "WITH" => classify_cte(&upper),
+        _ => "unknown",
+    }
+}
+
+fn first_keyword(upper: &str) -> String {
+    upper
+        .chars()
+        .take_while(|c| c.is_ascii_alphabetic())
+        .collect()
+}
+
+fn classify_cte(stripped_upper: &str) -> &'static str {
+    let ddl = ["CREATE", "DROP", "ALTER", "TRUNCATE", "RENAME"];
+    let dml = ["INSERT", "UPDATE", "DELETE", "MERGE", "REPLACE"];
+    for kw in &ddl {
+        if contains_keyword(stripped_upper, kw) {
+            return "ddl";
+        }
+    }
+    for kw in &dml {
+        if contains_keyword(stripped_upper, kw) {
+            return "write";
+        }
+    }
+    "select"
+}
+
+fn contains_keyword(haystack: &str, needle: &str) -> bool {
+    let bytes = haystack.as_bytes();
+    let nbytes = needle.as_bytes();
+    let nlen = nbytes.len();
+    if nlen == 0 || bytes.len() < nlen {
+        return false;
+    }
+    let is_word = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+    for i in 0..=bytes.len() - nlen {
+        if &bytes[i..i + nlen] == nbytes {
+            let prev_ok = i == 0 || !is_word(bytes[i - 1]);
+            let next_ok = i + nlen == bytes.len() || !is_word(bytes[i + nlen]);
+            if prev_ok && next_ok {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Replace string literals and SQL comments with whitespace so keyword
+/// scanning cannot be fooled by tokens that live inside a value, comment,
+/// or quoted identifier.
+pub fn strip_strings_and_comments(sql: &str) -> String {
+    let bytes = sql.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        // Line comment
+        if c == b'-' && i + 1 < bytes.len() && bytes[i + 1] == b'-' {
+            while i < bytes.len() && bytes[i] != b'\n' {
+                out.push(b' ');
+                i += 1;
+            }
+            continue;
+        }
+        // Block comment (non-nesting; sufficient for classification)
+        if c == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'*' {
+            out.push(b' ');
+            out.push(b' ');
+            i += 2;
+            while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                out.push(b' ');
+                i += 1;
+            }
+            if i + 1 < bytes.len() {
+                out.push(b' ');
+                out.push(b' ');
+                i += 2;
+            } else {
+                while i < bytes.len() {
+                    out.push(b' ');
+                    i += 1;
+                }
+            }
+            continue;
+        }
+        // Single-quoted string literal (SQL-style escaped quote: '')
+        if c == b'\'' {
+            out.push(b' ');
+            i += 1;
+            while i < bytes.len() {
+                if bytes[i] == b'\'' && i + 1 < bytes.len() && bytes[i + 1] == b'\'' {
+                    out.push(b' ');
+                    out.push(b' ');
+                    i += 2;
+                } else if bytes[i] == b'\'' {
+                    out.push(b' ');
+                    i += 1;
+                    break;
+                } else {
+                    out.push(b' ');
+                    i += 1;
+                }
+            }
+            continue;
+        }
+        // Double-quoted identifier (PostgreSQL / ANSI)
+        if c == b'"' {
+            out.push(b' ');
+            i += 1;
+            while i < bytes.len() && bytes[i] != b'"' {
+                out.push(b' ');
+                i += 1;
+            }
+            if i < bytes.len() {
+                out.push(b' ');
+                i += 1;
+            }
+            continue;
+        }
+        // Backtick-quoted identifier (MySQL)
+        if c == b'`' {
+            out.push(b' ');
+            i += 1;
+            while i < bytes.len() && bytes[i] != b'`' {
+                out.push(b' ');
+                i += 1;
+            }
+            if i < bytes.len() {
+                out.push(b' ');
+                i += 1;
+            }
+            continue;
+        }
+        out.push(c);
+        i += 1;
+    }
+    String::from_utf8(out).unwrap_or_default()
+}
+
+// ---------------------------------------------------------------------------
+// Session state
+// ---------------------------------------------------------------------------
+
+pub fn load_session_state_in(dir: &Path) -> Option<SessionState> {
+    let path = session_state_path_in(dir);
+    if !path.exists() {
+        return None;
+    }
+    let content = fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+pub fn save_session_state_in(dir: &Path, state: &SessionState) -> Result<(), String> {
+    ensure_dir(dir)?;
+    let path = session_state_path_in(dir);
+    let content = serde_json::to_string_pretty(state).map_err(|e| e.to_string())?;
+    fs::write(&path, content).map_err(|e| e.to_string())
+}
+
+/// Returns the active MCP session id, generating a new one if none exists or
+/// the gap since the last recorded activity exceeds `gap_minutes`.
+/// Updates `last_activity_at` on every call.
+pub fn compute_or_rotate_session_id_in(dir: &Path, gap_minutes: u32) -> String {
+    let now = chrono::Utc::now();
+    let now_str = now.to_rfc3339();
+    let mut state = load_session_state_in(dir).unwrap_or_else(|| SessionState {
+        session_id: new_uuid(),
+        last_activity_at: now_str.clone(),
+        client_hint: None,
+    });
+
+    let gap_exceeded = chrono::DateTime::parse_from_rfc3339(&state.last_activity_at)
+        .map(|dt| {
+            let diff = now.signed_duration_since(dt.with_timezone(&chrono::Utc));
+            diff.num_minutes() > gap_minutes as i64
+        })
+        .unwrap_or(true);
+
+    if gap_exceeded {
+        state.session_id = new_uuid();
+    }
+    state.last_activity_at = now_str;
+    let _ = save_session_state_in(dir, &state);
+    state.session_id
+}
+
+pub fn set_client_hint_in(dir: &Path, hint: Option<String>) {
+    let mut state = load_session_state_in(dir).unwrap_or_else(|| SessionState {
+        session_id: new_uuid(),
+        last_activity_at: chrono::Utc::now().to_rfc3339(),
+        client_hint: None,
+    });
+    state.client_hint = hint;
+    let _ = save_session_state_in(dir, &state);
+}
+
+pub fn get_client_hint_in(dir: &Path) -> Option<String> {
+    load_session_state_in(dir).and_then(|s| s.client_hint)
+}
+
+pub fn compute_or_rotate_session_id(gap_minutes: u32) -> String {
+    compute_or_rotate_session_id_in(&get_app_config_dir(), gap_minutes)
+}
+
+pub fn set_client_hint(hint: Option<String>) {
+    set_client_hint_in(&get_app_config_dir(), hint)
+}
+
+pub fn get_client_hint() -> Option<String> {
+    get_client_hint_in(&get_app_config_dir())
+}
+
+pub fn new_uuid() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+pub fn now_iso8601() -> String {
+    chrono::Utc::now().to_rfc3339()
+}

--- a/src-tauri/src/ai_activity_tests.rs
+++ b/src-tauri/src/ai_activity_tests.rs
@@ -1,0 +1,545 @@
+#[cfg(test)]
+mod tests {
+    use crate::ai_activity::{
+        append_event_in, classify_query_kind, clear_in, compute_or_rotate_session_id_in,
+        load_session_state_in, read_events_in, read_session_events_in, read_sessions_in,
+        rotate_if_needed_in, save_session_state_in, set_client_hint_in,
+        strip_strings_and_comments, AiActivityEvent, EventFilter, SessionState,
+    };
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn make_event(id: &str, session_id: &str, tool: &str, ts: &str) -> AiActivityEvent {
+        AiActivityEvent {
+            id: id.to_string(),
+            session_id: session_id.to_string(),
+            timestamp: ts.to_string(),
+            tool: tool.to_string(),
+            connection_id: Some("conn-1".to_string()),
+            connection_name: Some("local".to_string()),
+            query: Some("SELECT 1".to_string()),
+            query_kind: Some("select".to_string()),
+            duration_ms: 5,
+            status: "success".to_string(),
+            rows: Some(1),
+            error: None,
+            client_hint: Some("claude-desktop".to_string()),
+            approval_id: None,
+        }
+    }
+
+    fn append(dir: &Path, ev: AiActivityEvent) {
+        append_event_in(dir, &ev).expect("append");
+    }
+
+    // -----------------------------------------------------------------------
+    // Append + read roundtrip
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn append_then_read_returns_same_event() {
+        let tmp = TempDir::new().unwrap();
+        let ev = make_event("a", "sess-1", "list_tables", "2026-04-24T10:00:00Z");
+        append(tmp.path(), ev.clone());
+        let read = read_events_in(tmp.path(), &EventFilter::default()).unwrap();
+        assert_eq!(read.len(), 1);
+        assert_eq!(read[0], ev);
+    }
+
+    #[test]
+    fn read_returns_events_in_chronological_order() {
+        let tmp = TempDir::new().unwrap();
+        append(tmp.path(), make_event("1", "s", "run_query", "2026-04-24T10:00:00Z"));
+        append(tmp.path(), make_event("2", "s", "run_query", "2026-04-24T10:01:00Z"));
+        append(tmp.path(), make_event("3", "s", "run_query", "2026-04-24T10:02:00Z"));
+        let events = read_events_in(tmp.path(), &EventFilter::default()).unwrap();
+        let ids: Vec<&str> = events.iter().map(|e| e.id.as_str()).collect();
+        assert_eq!(ids, vec!["1", "2", "3"]);
+    }
+
+    #[test]
+    fn read_skips_unparsable_lines() {
+        let tmp = TempDir::new().unwrap();
+        append(tmp.path(), make_event("ok", "s", "list_tables", "2026-04-24T10:00:00Z"));
+        let path = tmp.path().join("ai_activity.jsonl");
+        let mut content = std::fs::read_to_string(&path).unwrap();
+        content.push_str("not-json\n\n{}\n");
+        std::fs::write(&path, content).unwrap();
+        let events = read_events_in(tmp.path(), &EventFilter::default()).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].id, "ok");
+    }
+
+    // -----------------------------------------------------------------------
+    // Filters
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn filter_by_session_id() {
+        let tmp = TempDir::new().unwrap();
+        append(tmp.path(), make_event("a", "s1", "run_query", "2026-04-24T10:00:00Z"));
+        append(tmp.path(), make_event("b", "s2", "run_query", "2026-04-24T10:01:00Z"));
+        let f = EventFilter {
+            session_id: Some("s2".into()),
+            ..Default::default()
+        };
+        let events = read_events_in(tmp.path(), &f).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].id, "b");
+    }
+
+    #[test]
+    fn filter_by_connection_id() {
+        let tmp = TempDir::new().unwrap();
+        let mut a = make_event("a", "s", "run_query", "2026-04-24T10:00:00Z");
+        a.connection_id = Some("c1".into());
+        let mut b = make_event("b", "s", "run_query", "2026-04-24T10:01:00Z");
+        b.connection_id = Some("c2".into());
+        append(tmp.path(), a);
+        append(tmp.path(), b);
+        let f = EventFilter {
+            connection_id: Some("c2".into()),
+            ..Default::default()
+        };
+        let events = read_events_in(tmp.path(), &f).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].id, "b");
+    }
+
+    #[test]
+    fn filter_by_tool() {
+        let tmp = TempDir::new().unwrap();
+        append(tmp.path(), make_event("a", "s", "list_tables", "2026-04-24T10:00:00Z"));
+        append(tmp.path(), make_event("b", "s", "run_query", "2026-04-24T10:01:00Z"));
+        let f = EventFilter {
+            tool: Some("run_query".into()),
+            ..Default::default()
+        };
+        let events = read_events_in(tmp.path(), &f).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].id, "b");
+    }
+
+    #[test]
+    fn filter_by_status() {
+        let tmp = TempDir::new().unwrap();
+        let mut a = make_event("a", "s", "run_query", "2026-04-24T10:00:00Z");
+        a.status = "error".into();
+        let b = make_event("b", "s", "run_query", "2026-04-24T10:01:00Z");
+        append(tmp.path(), a);
+        append(tmp.path(), b);
+        let f = EventFilter {
+            status: Some("error".into()),
+            ..Default::default()
+        };
+        let events = read_events_in(tmp.path(), &f).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].id, "a");
+    }
+
+    #[test]
+    fn filter_by_query_contains_is_case_insensitive() {
+        let tmp = TempDir::new().unwrap();
+        let mut a = make_event("a", "s", "run_query", "2026-04-24T10:00:00Z");
+        a.query = Some("SELECT * FROM ORDERS".into());
+        let mut b = make_event("b", "s", "run_query", "2026-04-24T10:01:00Z");
+        b.query = Some("SELECT * FROM users".into());
+        append(tmp.path(), a);
+        append(tmp.path(), b);
+        let f = EventFilter {
+            query_contains: Some("orders".into()),
+            ..Default::default()
+        };
+        let events = read_events_in(tmp.path(), &f).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].id, "a");
+    }
+
+    #[test]
+    fn filter_by_since_until_range() {
+        let tmp = TempDir::new().unwrap();
+        append(tmp.path(), make_event("1", "s", "run_query", "2026-04-24T09:00:00Z"));
+        append(tmp.path(), make_event("2", "s", "run_query", "2026-04-24T10:00:00Z"));
+        append(tmp.path(), make_event("3", "s", "run_query", "2026-04-24T11:00:00Z"));
+        let f = EventFilter {
+            since: Some("2026-04-24T10:00:00Z".into()),
+            until: Some("2026-04-24T10:30:00Z".into()),
+            ..Default::default()
+        };
+        let events = read_events_in(tmp.path(), &f).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].id, "2");
+    }
+
+    // -----------------------------------------------------------------------
+    // Sessions grouping
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn read_sessions_groups_by_session_id() {
+        let tmp = TempDir::new().unwrap();
+        append(tmp.path(), make_event("1", "s1", "list_tables", "2026-04-24T10:00:00Z"));
+        append(tmp.path(), make_event("2", "s1", "run_query", "2026-04-24T10:05:00Z"));
+        append(tmp.path(), make_event("3", "s2", "run_query", "2026-04-24T11:00:00Z"));
+        let sessions = read_sessions_in(tmp.path()).unwrap();
+        assert_eq!(sessions.len(), 2);
+        let s1 = sessions.iter().find(|s| s.session_id == "s1").unwrap();
+        assert_eq!(s1.event_count, 2);
+        assert_eq!(s1.run_query_count, 1);
+        assert_eq!(s1.started_at, "2026-04-24T10:00:00Z");
+        assert_eq!(s1.ended_at, "2026-04-24T10:05:00Z");
+    }
+
+    #[test]
+    fn read_session_events_filters_and_sorts() {
+        let tmp = TempDir::new().unwrap();
+        append(tmp.path(), make_event("a", "x", "run_query", "2026-04-24T10:01:00Z"));
+        append(tmp.path(), make_event("b", "x", "run_query", "2026-04-24T10:00:00Z"));
+        append(tmp.path(), make_event("c", "y", "run_query", "2026-04-24T10:02:00Z"));
+        let events = read_session_events_in(tmp.path(), "x").unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].id, "b");
+        assert_eq!(events[1].id, "a");
+    }
+
+    // -----------------------------------------------------------------------
+    // Rotation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rotation_triggers_when_threshold_reached() {
+        let tmp = TempDir::new().unwrap();
+        for i in 0..5 {
+            append(
+                tmp.path(),
+                make_event(&i.to_string(), "s", "run_query", "2026-04-24T10:00:00Z"),
+            );
+        }
+        let rotated = rotate_if_needed_in(tmp.path(), 5).unwrap();
+        assert!(rotated);
+        assert!(tmp.path().join("ai_activity.1.jsonl").exists());
+        assert!(!tmp.path().join("ai_activity.jsonl").exists());
+    }
+
+    #[test]
+    fn rotation_no_op_below_threshold() {
+        let tmp = TempDir::new().unwrap();
+        append(
+            tmp.path(),
+            make_event("0", "s", "run_query", "2026-04-24T10:00:00Z"),
+        );
+        let rotated = rotate_if_needed_in(tmp.path(), 100).unwrap();
+        assert!(!rotated);
+        assert!(tmp.path().join("ai_activity.jsonl").exists());
+        assert!(!tmp.path().join("ai_activity.1.jsonl").exists());
+    }
+
+    #[test]
+    fn rotation_keeps_5_archived_files_max() {
+        let tmp = TempDir::new().unwrap();
+        // Trigger 7 rotations; only 5 archives should remain (1..=5).
+        for cycle in 0..7 {
+            for i in 0..3 {
+                append(
+                    tmp.path(),
+                    make_event(
+                        &format!("{}-{}", cycle, i),
+                        "s",
+                        "run_query",
+                        "2026-04-24T10:00:00Z",
+                    ),
+                );
+            }
+            rotate_if_needed_in(tmp.path(), 3).unwrap();
+        }
+        for i in 1..=5 {
+            assert!(
+                tmp.path().join(format!("ai_activity.{}.jsonl", i)).exists(),
+                "archive {} should exist",
+                i
+            );
+        }
+        assert!(!tmp.path().join("ai_activity.6.jsonl").exists());
+    }
+
+    #[test]
+    fn read_includes_archived_events_oldest_first() {
+        let tmp = TempDir::new().unwrap();
+        for i in 0..3 {
+            append(
+                tmp.path(),
+                make_event(
+                    &format!("old-{}", i),
+                    "s",
+                    "run_query",
+                    "2026-04-24T09:00:00Z",
+                ),
+            );
+        }
+        rotate_if_needed_in(tmp.path(), 3).unwrap();
+        append(
+            tmp.path(),
+            make_event("new", "s", "run_query", "2026-04-24T10:00:00Z"),
+        );
+        let events = read_events_in(tmp.path(), &EventFilter::default()).unwrap();
+        assert_eq!(events.len(), 4);
+        assert_eq!(events.first().unwrap().id, "old-0");
+        assert_eq!(events.last().unwrap().id, "new");
+    }
+
+    #[test]
+    fn clear_removes_active_and_archived_files() {
+        let tmp = TempDir::new().unwrap();
+        for i in 0..3 {
+            append(
+                tmp.path(),
+                make_event(&i.to_string(), "s", "run_query", "2026-04-24T10:00:00Z"),
+            );
+        }
+        rotate_if_needed_in(tmp.path(), 3).unwrap();
+        append(
+            tmp.path(),
+            make_event("z", "s", "run_query", "2026-04-24T11:00:00Z"),
+        );
+        clear_in(tmp.path()).unwrap();
+        assert!(!tmp.path().join("ai_activity.jsonl").exists());
+        assert!(!tmp.path().join("ai_activity.1.jsonl").exists());
+        let events = read_events_in(tmp.path(), &EventFilter::default()).unwrap();
+        assert!(events.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // strip_strings_and_comments
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn strip_removes_line_comments() {
+        let s = strip_strings_and_comments("SELECT 1 -- DROP TABLE t\nFROM x");
+        assert!(!s.to_uppercase().contains("DROP"));
+        assert!(s.contains("FROM"));
+    }
+
+    #[test]
+    fn strip_removes_block_comments() {
+        let s = strip_strings_and_comments("SELECT /* DELETE FROM y */ 1");
+        assert!(!s.to_uppercase().contains("DELETE"));
+    }
+
+    #[test]
+    fn strip_handles_unterminated_block_comment() {
+        let s = strip_strings_and_comments("SELECT 1 /* DELETE");
+        assert!(!s.to_uppercase().contains("DELETE"));
+    }
+
+    #[test]
+    fn strip_removes_single_quoted_strings() {
+        let s = strip_strings_and_comments("SELECT 'DROP TABLE x' FROM t");
+        assert!(!s.to_uppercase().contains("DROP TABLE"));
+        assert!(s.contains("FROM"));
+    }
+
+    #[test]
+    fn strip_handles_escaped_single_quote() {
+        let s = strip_strings_and_comments("SELECT 'it''s ok DELETE' FROM t");
+        assert!(!s.to_uppercase().contains("DELETE"));
+    }
+
+    #[test]
+    fn strip_removes_double_quoted_identifiers() {
+        let s = strip_strings_and_comments("SELECT \"DROP\" FROM t");
+        assert!(!s.contains("\"DROP\""));
+    }
+
+    #[test]
+    fn strip_removes_backtick_identifiers() {
+        let s = strip_strings_and_comments("SELECT `DELETE` FROM t");
+        assert!(!s.contains("`DELETE`"));
+    }
+
+    // -----------------------------------------------------------------------
+    // classify_query_kind
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn classify_select() {
+        assert_eq!(classify_query_kind("SELECT 1"), "select");
+        assert_eq!(classify_query_kind("  select * from t"), "select");
+        assert_eq!(classify_query_kind("SHOW TABLES"), "select");
+        assert_eq!(classify_query_kind("EXPLAIN SELECT 1"), "select");
+        assert_eq!(classify_query_kind("DESCRIBE users"), "select");
+        assert_eq!(classify_query_kind("DESC users"), "select");
+        assert_eq!(classify_query_kind("PRAGMA table_info(t)"), "select");
+        assert_eq!(classify_query_kind("VALUES (1), (2)"), "select");
+    }
+
+    #[test]
+    fn classify_write() {
+        assert_eq!(classify_query_kind("INSERT INTO t VALUES (1)"), "write");
+        assert_eq!(classify_query_kind("UPDATE t SET x = 1"), "write");
+        assert_eq!(classify_query_kind("DELETE FROM t"), "write");
+        assert_eq!(classify_query_kind("MERGE INTO t USING s ON ..."), "write");
+        assert_eq!(classify_query_kind("REPLACE INTO t VALUES (1)"), "write");
+    }
+
+    #[test]
+    fn classify_ddl() {
+        assert_eq!(classify_query_kind("CREATE TABLE t (id INT)"), "ddl");
+        assert_eq!(classify_query_kind("DROP TABLE t"), "ddl");
+        assert_eq!(classify_query_kind("ALTER TABLE t ADD COLUMN x INT"), "ddl");
+        assert_eq!(classify_query_kind("TRUNCATE t"), "ddl");
+        assert_eq!(classify_query_kind("RENAME TABLE a TO b"), "ddl");
+        assert_eq!(classify_query_kind("GRANT SELECT ON t TO user"), "ddl");
+        assert_eq!(classify_query_kind("REVOKE SELECT ON t FROM user"), "ddl");
+        assert_eq!(classify_query_kind("COMMENT ON TABLE t IS 'x'"), "ddl");
+    }
+
+    #[test]
+    fn classify_unknown_for_empty_or_garbage() {
+        assert_eq!(classify_query_kind(""), "unknown");
+        assert_eq!(classify_query_kind("   "), "unknown");
+        assert_eq!(classify_query_kind("-- only comment"), "unknown");
+        assert_eq!(classify_query_kind("/* just a comment */"), "unknown");
+        assert_eq!(classify_query_kind("EXEC sp_helpdb"), "unknown");
+        assert_eq!(classify_query_kind("VACUUM"), "unknown");
+        assert_eq!(classify_query_kind("BEGIN"), "unknown");
+    }
+
+    #[test]
+    fn classify_cte_with_select() {
+        assert_eq!(
+            classify_query_kind("WITH u AS (SELECT 1) SELECT * FROM u"),
+            "select"
+        );
+    }
+
+    #[test]
+    fn classify_cte_with_update_is_write() {
+        assert_eq!(
+            classify_query_kind(
+                "WITH x AS (SELECT id FROM o) UPDATE orders SET status = 'x' FROM x"
+            ),
+            "write"
+        );
+    }
+
+    #[test]
+    fn classify_cte_with_delete_is_write() {
+        assert_eq!(
+            classify_query_kind("WITH x AS (SELECT 1) DELETE FROM o WHERE id IN x"),
+            "write"
+        );
+    }
+
+    #[test]
+    fn classify_cte_with_create_is_ddl() {
+        assert_eq!(
+            classify_query_kind("WITH t AS (SELECT 1) CREATE TABLE x AS SELECT * FROM t"),
+            "ddl"
+        );
+    }
+
+    #[test]
+    fn classify_handles_leading_comment_then_select() {
+        assert_eq!(
+            classify_query_kind("-- audit\nSELECT 1"),
+            "select"
+        );
+    }
+
+    #[test]
+    fn classify_keyword_in_string_literal_not_misread() {
+        // The literal mentions DELETE but the query is a SELECT.
+        assert_eq!(
+            classify_query_kind("SELECT 'DELETE FROM users' AS msg"),
+            "select"
+        );
+    }
+
+    #[test]
+    fn classify_keyword_in_quoted_identifier_not_misread() {
+        assert_eq!(classify_query_kind("SELECT \"DROP\" FROM t"), "select");
+        assert_eq!(classify_query_kind("SELECT `DELETE` FROM t"), "select");
+    }
+
+    #[test]
+    fn classify_is_case_insensitive() {
+        assert_eq!(classify_query_kind("Select 1"), "select");
+        assert_eq!(classify_query_kind("update t set a = 1"), "write");
+    }
+
+    #[test]
+    fn classify_word_boundary_avoids_false_positive() {
+        // CREATETABLE shouldn't match CREATE; it's gibberish.
+        assert_eq!(classify_query_kind("WITH x AS (SELECT createtable FROM y) SELECT * FROM x"), "select");
+    }
+
+    // -----------------------------------------------------------------------
+    // Session state / compute_or_rotate_session_id
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn compute_session_id_first_call_creates_state() {
+        let tmp = TempDir::new().unwrap();
+        assert!(load_session_state_in(tmp.path()).is_none());
+        let id = compute_or_rotate_session_id_in(tmp.path(), 10);
+        assert!(!id.is_empty());
+        let state = load_session_state_in(tmp.path()).unwrap();
+        assert_eq!(state.session_id, id);
+    }
+
+    #[test]
+    fn compute_session_id_within_gap_keeps_same() {
+        let tmp = TempDir::new().unwrap();
+        let id1 = compute_or_rotate_session_id_in(tmp.path(), 60);
+        let id2 = compute_or_rotate_session_id_in(tmp.path(), 60);
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn compute_session_id_over_gap_rotates() {
+        let tmp = TempDir::new().unwrap();
+        // Seed a state with last_activity 1 hour ago.
+        let one_hour_ago = (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
+        save_session_state_in(
+            tmp.path(),
+            &SessionState {
+                session_id: "old-id".into(),
+                last_activity_at: one_hour_ago,
+                client_hint: None,
+            },
+        )
+        .unwrap();
+        let id = compute_or_rotate_session_id_in(tmp.path(), 10);
+        assert_ne!(id, "old-id");
+    }
+
+    #[test]
+    fn compute_session_id_corrupt_state_starts_fresh() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join(".mcp_session_state.json"),
+            "not-valid-json",
+        )
+        .unwrap();
+        let id = compute_or_rotate_session_id_in(tmp.path(), 10);
+        assert!(!id.is_empty());
+    }
+
+    #[test]
+    fn set_client_hint_persists_to_state() {
+        let tmp = TempDir::new().unwrap();
+        compute_or_rotate_session_id_in(tmp.path(), 10);
+        set_client_hint_in(tmp.path(), Some("cursor".into()));
+        let state = load_session_state_in(tmp.path()).unwrap();
+        assert_eq!(state.client_hint.as_deref(), Some("cursor"));
+    }
+
+    #[test]
+    fn set_client_hint_creates_state_if_missing() {
+        let tmp = TempDir::new().unwrap();
+        set_client_hint_in(tmp.path(), Some("windsurf".into()));
+        let state = load_session_state_in(tmp.path()).unwrap();
+        assert_eq!(state.client_hint.as_deref(), Some("windsurf"));
+        assert!(!state.session_id.is_empty());
+    }
+}

--- a/src-tauri/src/ai_approval.rs
+++ b/src-tauri/src/ai_approval.rs
@@ -43,6 +43,17 @@ pub struct ApprovalDecision {
     pub edited_query: Option<String>,
 }
 
+/// Result of polling for an approval decision when liveness checking is in
+/// play. `HostUnavailable` signals that the GUI heartbeat went stale during
+/// polling — there is nobody left to write the decision file, so further
+/// waiting is pointless.
+#[derive(Debug, PartialEq)]
+pub enum PollOutcome {
+    Decided(ApprovalDecision),
+    TimedOut,
+    HostUnavailable,
+}
+
 // ---------------------------------------------------------------------------
 // Path helpers (testable: take a directory)
 // ---------------------------------------------------------------------------
@@ -150,18 +161,46 @@ pub async fn poll_decision_in(
     timeout_secs: u64,
     poll_interval_ms: u64,
 ) -> Result<Option<ApprovalDecision>, String> {
+    match poll_decision_with_liveness_in(base, approval_id, timeout_secs, poll_interval_ms, || {
+        true
+    })
+    .await?
+    {
+        PollOutcome::Decided(d) => Ok(Some(d)),
+        PollOutcome::TimedOut => Ok(None),
+        // Unreachable when `is_alive` always returns true, but map defensively.
+        PollOutcome::HostUnavailable => Ok(None),
+    }
+}
+
+/// Same as `poll_decision_in`, but also bails out with
+/// `PollOutcome::HostUnavailable` as soon as `is_alive()` returns false.
+/// Used by the MCP subprocess to detect that the Tabularis GUI exited
+/// mid-approval and fail without waiting for the full timeout.
+pub async fn poll_decision_with_liveness_in<F>(
+    base: &Path,
+    approval_id: &str,
+    timeout_secs: u64,
+    poll_interval_ms: u64,
+    is_alive: F,
+) -> Result<PollOutcome, String>
+where
+    F: Fn() -> bool,
+{
     let deadline = std::time::Instant::now() + Duration::from_secs(timeout_secs);
     loop {
         if let Some(decision) = read_decision_in(base, approval_id)? {
-            // Cleanup: best-effort.
             let _ = fs::remove_file(decision_file(base, approval_id));
             let _ = fs::remove_file(pending_file(base, approval_id));
-            return Ok(Some(decision));
+            return Ok(PollOutcome::Decided(decision));
+        }
+        if !is_alive() {
+            let _ = fs::remove_file(pending_file(base, approval_id));
+            return Ok(PollOutcome::HostUnavailable);
         }
         if std::time::Instant::now() >= deadline {
-            // Cleanup pending so we don't leak it.
             let _ = fs::remove_file(pending_file(base, approval_id));
-            return Ok(None);
+            return Ok(PollOutcome::TimedOut);
         }
         tokio::time::sleep(Duration::from_millis(poll_interval_ms)).await;
     }
@@ -228,6 +267,28 @@ pub async fn poll_decision(
         approval_id,
         timeout_secs,
         poll_interval_ms,
+    )
+    .await
+}
+
+/// Default-dir wrapper for liveness-aware polling. The MCP subprocess wires
+/// `is_alive` to the heartbeat module so it can short-circuit when the GUI
+/// is closed.
+pub async fn poll_decision_with_liveness<F>(
+    approval_id: &str,
+    timeout_secs: u64,
+    poll_interval_ms: u64,
+    is_alive: F,
+) -> Result<PollOutcome, String>
+where
+    F: Fn() -> bool,
+{
+    poll_decision_with_liveness_in(
+        &get_app_config_dir(),
+        approval_id,
+        timeout_secs,
+        poll_interval_ms,
+        is_alive,
     )
     .await
 }

--- a/src-tauri/src/ai_approval.rs
+++ b/src-tauri/src/ai_approval.rs
@@ -1,0 +1,245 @@
+//! Approval gate IPC for MCP write/DDL queries.
+//!
+//! The MCP subprocess cannot show UI. To gate sensitive queries on user
+//! approval we use a file-queue:
+//!   - MCP writes `{id}.pending.json` and polls for `{id}.decision.json`
+//!   - The main Tauri app watches the directory, opens an approval modal,
+//!     then writes `{id}.decision.json`
+//!
+//! Storage: `<config_dir>/pending_approvals/`.
+
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use crate::paths::get_app_config_dir;
+
+const DIR_NAME: &str = "pending_approvals";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PendingApproval {
+    pub id: String,
+    pub created_at: String,
+    pub session_id: String,
+    pub connection_id: String,
+    pub connection_name: String,
+    pub query: String,
+    pub query_kind: String,
+    pub client_hint: Option<String>,
+    pub explain_plan: Option<serde_json::Value>,
+    pub explain_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ApprovalDecision {
+    pub approval_id: String,
+    pub decided_at: String,
+    /// `"approve"` or `"deny"`.
+    pub decision: String,
+    pub reason: Option<String>,
+    pub edited_query: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Path helpers (testable: take a directory)
+// ---------------------------------------------------------------------------
+
+fn approvals_dir(base: &Path) -> PathBuf {
+    base.join(DIR_NAME)
+}
+
+fn ensure_dir(base: &Path) -> Result<PathBuf, String> {
+    let dir = approvals_dir(base);
+    if !dir.exists() {
+        fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    }
+    Ok(dir)
+}
+
+fn pending_file(base: &Path, id: &str) -> PathBuf {
+    approvals_dir(base).join(format!("{}.pending.json", id))
+}
+
+fn decision_file(base: &Path, id: &str) -> PathBuf {
+    approvals_dir(base).join(format!("{}.decision.json", id))
+}
+
+// ---------------------------------------------------------------------------
+// Writers / readers
+// ---------------------------------------------------------------------------
+
+pub fn write_pending_in(base: &Path, req: &PendingApproval) -> Result<PathBuf, String> {
+    let dir = ensure_dir(base)?;
+    let path = dir.join(format!("{}.pending.json", req.id));
+    let content = serde_json::to_string_pretty(req).map_err(|e| e.to_string())?;
+    fs::write(&path, content).map_err(|e| e.to_string())?;
+    Ok(path)
+}
+
+pub fn read_pending_in(base: &Path, id: &str) -> Result<Option<PendingApproval>, String> {
+    let path = pending_file(base, id);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = fs::read_to_string(&path).map_err(|e| e.to_string())?;
+    serde_json::from_str(&content)
+        .map(Some)
+        .map_err(|e| e.to_string())
+}
+
+pub fn list_pending_in(base: &Path) -> Result<Vec<PendingApproval>, String> {
+    let dir = approvals_dir(base);
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut out: Vec<PendingApproval> = Vec::new();
+    for entry in fs::read_dir(&dir).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path();
+        let name = match path.file_name().and_then(|s| s.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        if !name.ends_with(".pending.json") {
+            continue;
+        }
+        // Skip if already decided.
+        let id = name.trim_end_matches(".pending.json").to_string();
+        if decision_file(base, &id).exists() {
+            continue;
+        }
+        if let Ok(content) = fs::read_to_string(&path) {
+            if let Ok(p) = serde_json::from_str::<PendingApproval>(&content) {
+                out.push(p);
+            }
+        }
+    }
+    out.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+    Ok(out)
+}
+
+pub fn write_decision_in(base: &Path, decision: &ApprovalDecision) -> Result<(), String> {
+    ensure_dir(base)?;
+    let path = decision_file(base, &decision.approval_id);
+    let content = serde_json::to_string_pretty(decision).map_err(|e| e.to_string())?;
+    fs::write(&path, content).map_err(|e| e.to_string())
+}
+
+pub fn read_decision_in(base: &Path, id: &str) -> Result<Option<ApprovalDecision>, String> {
+    let path = decision_file(base, id);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = fs::read_to_string(&path).map_err(|e| e.to_string())?;
+    serde_json::from_str(&content)
+        .map(Some)
+        .map_err(|e| e.to_string())
+}
+
+/// Async polling helper. Returns `Ok(Some(decision))` once a decision file
+/// is written, or `Ok(None)` if `timeout_secs` elapses with none.
+///
+/// The returned future also clears both the pending and decision files so
+/// the directory does not accumulate consumed approvals.
+pub async fn poll_decision_in(
+    base: &Path,
+    approval_id: &str,
+    timeout_secs: u64,
+    poll_interval_ms: u64,
+) -> Result<Option<ApprovalDecision>, String> {
+    let deadline = std::time::Instant::now() + Duration::from_secs(timeout_secs);
+    loop {
+        if let Some(decision) = read_decision_in(base, approval_id)? {
+            // Cleanup: best-effort.
+            let _ = fs::remove_file(decision_file(base, approval_id));
+            let _ = fs::remove_file(pending_file(base, approval_id));
+            return Ok(Some(decision));
+        }
+        if std::time::Instant::now() >= deadline {
+            // Cleanup pending so we don't leak it.
+            let _ = fs::remove_file(pending_file(base, approval_id));
+            return Ok(None);
+        }
+        tokio::time::sleep(Duration::from_millis(poll_interval_ms)).await;
+    }
+}
+
+/// Remove pending+decision files older than `max_age_secs`.
+/// Returns the number of files deleted.
+pub fn cleanup_expired_in(base: &Path, max_age_secs: u64) -> Result<usize, String> {
+    let dir = approvals_dir(base);
+    if !dir.exists() {
+        return Ok(0);
+    }
+    let mut deleted = 0usize;
+    let now = std::time::SystemTime::now();
+    for entry in fs::read_dir(&dir).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path();
+        let metadata = match entry.metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        let modified = match metadata.modified() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        let age = match now.duration_since(modified) {
+            Ok(a) => a,
+            Err(_) => continue,
+        };
+        if age.as_secs() > max_age_secs && fs::remove_file(&path).is_ok() {
+            deleted += 1;
+        }
+    }
+    Ok(deleted)
+}
+
+// ---------------------------------------------------------------------------
+// Default-dir wrappers (used at runtime)
+// ---------------------------------------------------------------------------
+
+pub fn write_pending(req: &PendingApproval) -> Result<PathBuf, String> {
+    write_pending_in(&get_app_config_dir(), req)
+}
+
+pub fn list_pending() -> Result<Vec<PendingApproval>, String> {
+    list_pending_in(&get_app_config_dir())
+}
+
+pub fn read_pending(id: &str) -> Result<Option<PendingApproval>, String> {
+    read_pending_in(&get_app_config_dir(), id)
+}
+
+pub fn write_decision(decision: &ApprovalDecision) -> Result<(), String> {
+    write_decision_in(&get_app_config_dir(), decision)
+}
+
+pub async fn poll_decision(
+    approval_id: &str,
+    timeout_secs: u64,
+    poll_interval_ms: u64,
+) -> Result<Option<ApprovalDecision>, String> {
+    poll_decision_in(
+        &get_app_config_dir(),
+        approval_id,
+        timeout_secs,
+        poll_interval_ms,
+    )
+    .await
+}
+
+pub fn cleanup_expired(max_age_secs: u64) -> Result<usize, String> {
+    cleanup_expired_in(&get_app_config_dir(), max_age_secs)
+}
+
+pub fn approvals_dir_path() -> PathBuf {
+    approvals_dir(&get_app_config_dir())
+}
+
+pub fn new_approval_id() -> String {
+    uuid::Uuid::new_v4().to_string()
+}

--- a/src-tauri/src/ai_approval_tests.rs
+++ b/src-tauri/src/ai_approval_tests.rs
@@ -1,9 +1,12 @@
 #[cfg(test)]
 mod tests {
     use crate::ai_approval::{
-        cleanup_expired_in, list_pending_in, new_approval_id, poll_decision_in, read_decision_in,
-        read_pending_in, write_decision_in, write_pending_in, ApprovalDecision, PendingApproval,
+        cleanup_expired_in, list_pending_in, new_approval_id, poll_decision_in,
+        poll_decision_with_liveness_in, read_decision_in, read_pending_in, write_decision_in,
+        write_pending_in, ApprovalDecision, PendingApproval, PollOutcome,
     };
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
     use std::path::Path;
     use tempfile::TempDir;
     use tokio::time::Duration;
@@ -122,6 +125,68 @@ mod tests {
         assert!(res.is_none());
         // Pending file should be cleaned up on timeout to avoid leaks.
         assert!(read_pending_in(tmp.path(), "never").unwrap().is_none());
+    }
+
+    // Liveness-aware polling ----------------------------------------------
+
+    #[tokio::test]
+    async fn liveness_poll_returns_decision_when_alive() {
+        let tmp = TempDir::new().unwrap();
+        write_pending_in(tmp.path(), &make_pending("ok")).unwrap();
+        write_decision_in(tmp.path(), &make_decision("ok", "approve")).unwrap();
+        let outcome = poll_decision_with_liveness_in(tmp.path(), "ok", 5, 50, || true)
+            .await
+            .unwrap();
+        match outcome {
+            PollOutcome::Decided(d) => assert_eq!(d.decision, "approve"),
+            other => panic!("expected Decided, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn liveness_poll_exits_early_when_host_dead_before_start() {
+        let tmp = TempDir::new().unwrap();
+        write_pending_in(tmp.path(), &make_pending("dead")).unwrap();
+        // 60s timeout, but liveness=false → should return almost instantly.
+        let start = std::time::Instant::now();
+        let outcome = poll_decision_with_liveness_in(tmp.path(), "dead", 60, 50, || false)
+            .await
+            .unwrap();
+        assert!(start.elapsed() < Duration::from_secs(1));
+        assert_eq!(outcome, PollOutcome::HostUnavailable);
+        // Pending file should be cleaned up to avoid leaks.
+        assert!(read_pending_in(tmp.path(), "dead").unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn liveness_poll_exits_early_when_host_dies_mid_flight() {
+        let tmp = TempDir::new().unwrap();
+        write_pending_in(tmp.path(), &make_pending("flip")).unwrap();
+        let alive = Arc::new(AtomicBool::new(true));
+        let alive_for_flipper = alive.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            alive_for_flipper.store(false, Ordering::SeqCst);
+        });
+        let alive_for_check = alive.clone();
+        let start = std::time::Instant::now();
+        let outcome = poll_decision_with_liveness_in(tmp.path(), "flip", 60, 50, move || {
+            alive_for_check.load(Ordering::SeqCst)
+        })
+        .await
+        .unwrap();
+        assert!(start.elapsed() < Duration::from_secs(2));
+        assert_eq!(outcome, PollOutcome::HostUnavailable);
+    }
+
+    #[tokio::test]
+    async fn liveness_poll_times_out_when_alive_but_no_decision() {
+        let tmp = TempDir::new().unwrap();
+        write_pending_in(tmp.path(), &make_pending("slow")).unwrap();
+        let outcome = poll_decision_with_liveness_in(tmp.path(), "slow", 1, 50, || true)
+            .await
+            .unwrap();
+        assert_eq!(outcome, PollOutcome::TimedOut);
     }
 
     // Concurrency ----------------------------------------------------------

--- a/src-tauri/src/ai_approval_tests.rs
+++ b/src-tauri/src/ai_approval_tests.rs
@@ -1,0 +1,160 @@
+#[cfg(test)]
+mod tests {
+    use crate::ai_approval::{
+        cleanup_expired_in, list_pending_in, new_approval_id, poll_decision_in, read_decision_in,
+        read_pending_in, write_decision_in, write_pending_in, ApprovalDecision, PendingApproval,
+    };
+    use std::path::Path;
+    use tempfile::TempDir;
+    use tokio::time::Duration;
+
+    fn make_pending(id: &str) -> PendingApproval {
+        PendingApproval {
+            id: id.to_string(),
+            created_at: "2026-04-24T10:00:00Z".to_string(),
+            session_id: "sess-1".to_string(),
+            connection_id: "conn-1".to_string(),
+            connection_name: "local".to_string(),
+            query: "UPDATE orders SET status = 'x'".to_string(),
+            query_kind: "write".to_string(),
+            client_hint: Some("claude-desktop".to_string()),
+            explain_plan: Some(serde_json::json!({"node": "Seq Scan"})),
+            explain_error: None,
+        }
+    }
+
+    fn make_decision(id: &str, decision: &str) -> ApprovalDecision {
+        ApprovalDecision {
+            approval_id: id.to_string(),
+            decided_at: "2026-04-24T10:00:05Z".to_string(),
+            decision: decision.to_string(),
+            reason: None,
+            edited_query: None,
+        }
+    }
+
+    fn touch(path: &Path) {
+        std::fs::write(path, "x").unwrap();
+    }
+
+    #[test]
+    fn pending_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let p = make_pending("p1");
+        write_pending_in(tmp.path(), &p).unwrap();
+        let read = read_pending_in(tmp.path(), "p1").unwrap();
+        assert_eq!(read.unwrap(), p);
+    }
+
+    #[test]
+    fn list_pending_returns_only_undecided() {
+        let tmp = TempDir::new().unwrap();
+        write_pending_in(tmp.path(), &make_pending("a")).unwrap();
+        write_pending_in(tmp.path(), &make_pending("b")).unwrap();
+        // Mark `b` as decided.
+        write_decision_in(tmp.path(), &make_decision("b", "approve")).unwrap();
+        let list = list_pending_in(tmp.path()).unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].id, "a");
+    }
+
+    #[test]
+    fn list_pending_empty_dir_is_ok() {
+        let tmp = TempDir::new().unwrap();
+        let list = list_pending_in(tmp.path()).unwrap();
+        assert!(list.is_empty());
+    }
+
+    #[test]
+    fn list_pending_orders_by_created_at() {
+        let tmp = TempDir::new().unwrap();
+        let mut a = make_pending("a");
+        a.created_at = "2026-04-24T10:00:01Z".into();
+        let mut b = make_pending("b");
+        b.created_at = "2026-04-24T10:00:00Z".into();
+        write_pending_in(tmp.path(), &a).unwrap();
+        write_pending_in(tmp.path(), &b).unwrap();
+        let list = list_pending_in(tmp.path()).unwrap();
+        assert_eq!(list[0].id, "b");
+        assert_eq!(list[1].id, "a");
+    }
+
+    #[test]
+    fn read_decision_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let d = make_decision("xyz", "deny");
+        write_decision_in(tmp.path(), &d).unwrap();
+        assert_eq!(read_decision_in(tmp.path(), "xyz").unwrap(), Some(d));
+    }
+
+    // Polling --------------------------------------------------------------
+
+    #[tokio::test]
+    async fn poll_returns_immediate_decision() {
+        let tmp = TempDir::new().unwrap();
+        write_pending_in(tmp.path(), &make_pending("imm")).unwrap();
+        write_decision_in(tmp.path(), &make_decision("imm", "approve")).unwrap();
+        let res = poll_decision_in(tmp.path(), "imm", 5, 50).await.unwrap();
+        assert_eq!(res.unwrap().decision, "approve");
+        // Cleanup wipes both files.
+        assert!(read_decision_in(tmp.path(), "imm").unwrap().is_none());
+        assert!(read_pending_in(tmp.path(), "imm").unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn poll_returns_decision_after_delay() {
+        let tmp = TempDir::new().unwrap();
+        write_pending_in(tmp.path(), &make_pending("late")).unwrap();
+        let dir = tmp.path().to_path_buf();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            write_decision_in(&dir, &make_decision("late", "approve")).unwrap();
+        });
+        let res = poll_decision_in(tmp.path(), "late", 5, 50).await.unwrap();
+        assert!(res.is_some());
+    }
+
+    #[tokio::test]
+    async fn poll_times_out_returning_none() {
+        let tmp = TempDir::new().unwrap();
+        write_pending_in(tmp.path(), &make_pending("never")).unwrap();
+        let res = poll_decision_in(tmp.path(), "never", 1, 50).await.unwrap();
+        assert!(res.is_none());
+        // Pending file should be cleaned up on timeout to avoid leaks.
+        assert!(read_pending_in(tmp.path(), "never").unwrap().is_none());
+    }
+
+    // Concurrency ----------------------------------------------------------
+
+    #[test]
+    fn distinct_approval_ids_dont_collide() {
+        let tmp = TempDir::new().unwrap();
+        let id1 = new_approval_id();
+        let id2 = new_approval_id();
+        assert_ne!(id1, id2);
+        write_pending_in(tmp.path(), &make_pending(&id1)).unwrap();
+        write_pending_in(tmp.path(), &make_pending(&id2)).unwrap();
+        let list = list_pending_in(tmp.path()).unwrap();
+        assert_eq!(list.len(), 2);
+    }
+
+    // Cleanup --------------------------------------------------------------
+
+    #[test]
+    fn cleanup_removes_old_files_only() {
+        let tmp = TempDir::new().unwrap();
+        write_pending_in(tmp.path(), &make_pending("recent")).unwrap();
+        // Touch a fake old file with stale mtime by lowering it manually.
+        let dir = tmp.path().join("pending_approvals");
+        let stale_path = dir.join("stale.pending.json");
+        touch(&stale_path);
+        let old_time = std::time::SystemTime::now()
+            .checked_sub(Duration::from_secs(3600))
+            .unwrap();
+        let _ = filetime::set_file_mtime(&stale_path, filetime::FileTime::from_system_time(old_time));
+        let deleted = cleanup_expired_in(tmp.path(), 60).unwrap();
+        assert_eq!(deleted, 1);
+        assert!(!stale_path.exists());
+        assert!(read_pending_in(tmp.path(), "recent").unwrap().is_some());
+    }
+}

--- a/src-tauri/src/ai_approval_watcher.rs
+++ b/src-tauri/src/ai_approval_watcher.rs
@@ -1,0 +1,102 @@
+//! Watches the pending-approvals directory and emits `ai://pending_approval`
+//! Tauri events whenever the MCP subprocess writes a new pending request.
+//!
+//! Also runs a periodic cleanup that removes stale pending/decision files
+//! left behind by crashed MCP processes.
+
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::sync::mpsc;
+use std::time::Duration;
+use tauri::{AppHandle, Emitter, Runtime};
+
+use crate::ai_approval;
+
+const PENDING_APPROVAL_EVENT: &str = "ai://pending_approval";
+/// Stale pending+decision files older than this are deleted by the periodic
+/// cleanup task. 1 hour is comfortably longer than the maximum approval
+/// timeout (`mcp_approval_timeout_seconds` default: 120).
+const CLEANUP_MAX_AGE_SECS: u64 = 3_600;
+const CLEANUP_INTERVAL_SECS: u64 = 60;
+
+/// Spawn the watcher + cleanup tasks. The watcher returns immediately if it
+/// fails to initialise (e.g. unsupported filesystem); cleanup keeps running.
+pub fn spawn<R: Runtime>(app: AppHandle<R>) {
+    let app_for_watcher = app.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        if let Err(e) = run_watcher(app_for_watcher) {
+            log::warn!("AI approval watcher disabled: {}", e);
+        }
+    });
+
+    let app_for_cleanup = app.clone();
+    tauri::async_runtime::spawn(async move {
+        run_cleanup_loop(app_for_cleanup).await;
+    });
+}
+
+fn run_watcher<R: Runtime>(app: AppHandle<R>) -> Result<(), String> {
+    let dir = ai_approval::approvals_dir_path();
+    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+
+    let (tx, rx) = mpsc::channel::<notify::Result<Event>>();
+    let mut watcher: RecommendedWatcher =
+        notify::recommended_watcher(tx).map_err(|e| e.to_string())?;
+    watcher
+        .watch(&dir, RecursiveMode::NonRecursive)
+        .map_err(|e| e.to_string())?;
+
+    log::info!("AI approval watcher started on {}", dir.display());
+
+    // The watcher is dropped when this function returns; keep it alive for the
+    // process lifetime by looping forever.
+    for evt in rx {
+        match evt {
+            Ok(event) => handle_event(&app, &event),
+            Err(e) => log::warn!("approval watcher error: {}", e),
+        }
+    }
+    Ok(())
+}
+
+fn handle_event<R: Runtime>(app: &AppHandle<R>, event: &Event) {
+    if !matches!(event.kind, EventKind::Create(_) | EventKind::Modify(_)) {
+        return;
+    }
+    for path in &event.paths {
+        let name = match path.file_name().and_then(|s| s.to_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+        if !name.ends_with(".pending.json") {
+            continue;
+        }
+        let id = name.trim_end_matches(".pending.json").to_string();
+        // The file may not yet be fully flushed when notify fires Create —
+        // try to read; if it fails this iteration we'll catch it on the
+        // next Modify event.
+        if let Ok(Some(pending)) = ai_approval::read_pending(&id) {
+            if let Err(e) = app.emit(PENDING_APPROVAL_EVENT, &pending) {
+                log::warn!("Failed to emit {}: {}", PENDING_APPROVAL_EVENT, e);
+            }
+        }
+    }
+}
+
+async fn run_cleanup_loop<R: Runtime>(_app: AppHandle<R>) {
+    let mut ticker = tokio::time::interval(Duration::from_secs(CLEANUP_INTERVAL_SECS));
+    // Skip the immediate first tick.
+    ticker.tick().await;
+    loop {
+        ticker.tick().await;
+        let cleaned = tokio::task::spawn_blocking(|| {
+            ai_approval::cleanup_expired(CLEANUP_MAX_AGE_SECS)
+        })
+        .await
+        .ok()
+        .and_then(|r| r.ok())
+        .unwrap_or(0);
+        if cleaned > 0 {
+            log::info!("Cleaned {} stale approval file(s)", cleaned);
+        }
+    }
+}

--- a/src-tauri/src/ai_commands.rs
+++ b/src-tauri/src/ai_commands.rs
@@ -1,0 +1,139 @@
+//! Tauri commands exposed to the frontend for AI activity, approval gates,
+//! and notebook export. The MCP subprocess writes the underlying files; the
+//! main app only reads and decides on them through these endpoints.
+
+use crate::ai_activity::{self, AiActivityEvent, EventFilter, SessionSummary};
+use crate::ai_approval::{self, ApprovalDecision, PendingApproval};
+use crate::ai_notebook_export::{self, NotebookExport};
+
+#[tauri::command]
+pub async fn get_ai_activity(
+    filter: Option<EventFilter>,
+) -> Result<Vec<AiActivityEvent>, String> {
+    let f = filter.unwrap_or_default();
+    tokio::task::spawn_blocking(move || ai_activity::read_events(&f))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn get_ai_sessions() -> Result<Vec<SessionSummary>, String> {
+    tokio::task::spawn_blocking(ai_activity::read_sessions)
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn get_ai_session_events(session_id: String) -> Result<Vec<AiActivityEvent>, String> {
+    tokio::task::spawn_blocking(move || ai_activity::read_session_events(&session_id))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn clear_ai_activity() -> Result<(), String> {
+    tokio::task::spawn_blocking(ai_activity::clear)
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn export_ai_activity_json() -> Result<String, String> {
+    let events =
+        tokio::task::spawn_blocking(|| ai_activity::read_events(&EventFilter::default()))
+            .await
+            .map_err(|e| e.to_string())??;
+    let mut out = String::new();
+    for ev in events {
+        let line = serde_json::to_string(&ev).map_err(|e| e.to_string())?;
+        out.push_str(&line);
+        out.push('\n');
+    }
+    Ok(out)
+}
+
+#[tauri::command]
+pub async fn export_ai_activity_csv() -> Result<String, String> {
+    let events =
+        tokio::task::spawn_blocking(|| ai_activity::read_events(&EventFilter::default()))
+            .await
+            .map_err(|e| e.to_string())??;
+    let mut wtr = csv::Writer::from_writer(vec![]);
+    wtr.write_record([
+        "id",
+        "session_id",
+        "timestamp",
+        "tool",
+        "connection_id",
+        "connection_name",
+        "query",
+        "query_kind",
+        "duration_ms",
+        "status",
+        "rows",
+        "error",
+        "client_hint",
+        "approval_id",
+    ])
+    .map_err(|e| e.to_string())?;
+    for ev in events {
+        wtr.write_record([
+            ev.id,
+            ev.session_id,
+            ev.timestamp,
+            ev.tool,
+            ev.connection_id.unwrap_or_default(),
+            ev.connection_name.unwrap_or_default(),
+            ev.query.unwrap_or_default(),
+            ev.query_kind.unwrap_or_default(),
+            ev.duration_ms.to_string(),
+            ev.status,
+            ev.rows.map(|r| r.to_string()).unwrap_or_default(),
+            ev.error.unwrap_or_default(),
+            ev.client_hint.unwrap_or_default(),
+            ev.approval_id.unwrap_or_default(),
+        ])
+        .map_err(|e| e.to_string())?;
+    }
+    let bytes = wtr.into_inner().map_err(|e| e.to_string())?;
+    String::from_utf8(bytes).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn export_ai_session_as_notebook(session_id: String) -> Result<NotebookExport, String> {
+    tokio::task::spawn_blocking(move || ai_notebook_export::export_session(&session_id))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn list_pending_approvals() -> Result<Vec<PendingApproval>, String> {
+    tokio::task::spawn_blocking(ai_approval::list_pending)
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn decide_pending_approval(
+    approval_id: String,
+    decision: String,
+    reason: Option<String>,
+    edited_query: Option<String>,
+) -> Result<(), String> {
+    if decision != "approve" && decision != "deny" {
+        return Err(format!(
+            "Invalid decision '{}': expected 'approve' or 'deny'",
+            decision
+        ));
+    }
+    let payload = ApprovalDecision {
+        approval_id,
+        decided_at: ai_activity::now_iso8601(),
+        decision,
+        reason,
+        edited_query,
+    };
+    tokio::task::spawn_blocking(move || ai_approval::write_decision(&payload))
+        .await
+        .map_err(|e| e.to_string())?
+}

--- a/src-tauri/src/ai_notebook_export.rs
+++ b/src-tauri/src/ai_notebook_export.rs
@@ -1,0 +1,185 @@
+//! Build a `.tabularis-notebook` document from an audit log session.
+//!
+//! Produces the same JSON shape that the frontend's notebook editor reads
+//! and writes (see `src/types/notebook.ts` `NotebookFile`). Results are not
+//! embedded — notebook cells re-execute on load, which matches the existing
+//! notebook UX.
+
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+use crate::ai_activity::{read_session_events_in, AiActivityEvent};
+use crate::paths::get_app_config_dir;
+
+const NOTEBOOK_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct NotebookCellExport {
+    #[serde(rename = "type")]
+    pub cell_type: String,
+    pub content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct NotebookExport {
+    pub version: u32,
+    pub title: String,
+    pub created_at: String,
+    pub cells: Vec<NotebookCellExport>,
+}
+
+pub fn export_session_in(dir: &Path, session_id: &str) -> Result<NotebookExport, String> {
+    let events = read_session_events_in(dir, session_id)?;
+    if events.is_empty() {
+        return Err(format!("No events found for session {}", session_id));
+    }
+    Ok(build_notebook(session_id, &events))
+}
+
+pub fn export_session(session_id: &str) -> Result<NotebookExport, String> {
+    export_session_in(&get_app_config_dir(), session_id)
+}
+
+fn build_notebook(session_id: &str, events: &[AiActivityEvent]) -> NotebookExport {
+    let header = build_header_cell(session_id, events);
+    let mut cells: Vec<NotebookCellExport> = vec![header];
+
+    let mut query_index = 1usize;
+    for ev in events {
+        match ev.tool.as_str() {
+            "run_query" => {
+                if let Some(query) = ev.query.as_deref() {
+                    let name = derive_cell_name(query, query_index);
+                    cells.push(NotebookCellExport {
+                        cell_type: "sql".to_string(),
+                        content: query.to_string(),
+                        name: Some(name),
+                        schema: ev.connection_name.clone(),
+                    });
+                    query_index += 1;
+                }
+            }
+            "list_tables" | "describe_table" => {
+                cells.push(NotebookCellExport {
+                    cell_type: "markdown".to_string(),
+                    content: build_metadata_cell(ev),
+                    name: Some(format!("Context — {}", ev.tool)),
+                    schema: None,
+                });
+            }
+            _ => {}
+        }
+    }
+
+    NotebookExport {
+        version: NOTEBOOK_VERSION,
+        title: format!("AI Session {}", session_id),
+        created_at: events
+            .first()
+            .map(|e| e.timestamp.clone())
+            .unwrap_or_else(|| chrono::Utc::now().to_rfc3339()),
+        cells,
+    }
+}
+
+fn build_header_cell(session_id: &str, events: &[AiActivityEvent]) -> NotebookCellExport {
+    let started = events
+        .iter()
+        .map(|e| e.timestamp.clone())
+        .min()
+        .unwrap_or_default();
+    let ended = events
+        .iter()
+        .map(|e| e.timestamp.clone())
+        .max()
+        .unwrap_or_default();
+    let client_hint = events
+        .iter()
+        .find_map(|e| e.client_hint.clone())
+        .unwrap_or_else(|| "unknown client".to_string());
+    let mut connections: Vec<String> = events
+        .iter()
+        .filter_map(|e| e.connection_name.clone())
+        .collect();
+    connections.sort();
+    connections.dedup();
+    let conn_list = if connections.is_empty() {
+        "—".to_string()
+    } else {
+        connections.join(", ")
+    };
+
+    let content = format!(
+        "# AI Session {session_id}\n\n\
+         - **Client:** {client_hint}\n\
+         - **Connections:** {conn_list}\n\
+         - **Started:** {started}\n\
+         - **Ended:** {ended}\n\
+         - **Events:** {count}\n\n\
+         > Cell results are not included — re-run the cells to repopulate them.",
+        session_id = session_id,
+        client_hint = client_hint,
+        conn_list = conn_list,
+        started = started,
+        ended = ended,
+        count = events.len(),
+    );
+
+    NotebookCellExport {
+        cell_type: "markdown".to_string(),
+        content,
+        name: Some("Session metadata".to_string()),
+        schema: None,
+    }
+}
+
+fn build_metadata_cell(ev: &AiActivityEvent) -> String {
+    let conn = ev.connection_name.as_deref().unwrap_or("?");
+    let status = &ev.status;
+    let preview = ev
+        .query
+        .as_deref()
+        .map(|q| format!("\n\n```\n{}\n```", q))
+        .unwrap_or_default();
+    format!(
+        "**Tool:** `{tool}` on `{conn}` — *{status}*{preview}",
+        tool = ev.tool,
+        conn = conn,
+        status = status,
+        preview = preview
+    )
+}
+
+/// Derive a friendly cell name from the first single-line `--` comment in
+/// the query, or fall back to a positional name like `Query 3`.
+pub fn derive_cell_name(query: &str, fallback_index: usize) -> String {
+    for line in query.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("--") {
+            let comment = rest.trim();
+            if !comment.is_empty() {
+                return shorten(comment, 60);
+            }
+        } else if !trimmed.is_empty() {
+            // First non-comment line means we missed the chance.
+            break;
+        }
+    }
+    format!("Query {}", fallback_index)
+}
+
+fn shorten(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let mut out: String = s.chars().take(max).collect();
+        out.push('…');
+        out
+    }
+}

--- a/src-tauri/src/ai_notebook_export_tests.rs
+++ b/src-tauri/src/ai_notebook_export_tests.rs
@@ -1,0 +1,217 @@
+#[cfg(test)]
+mod tests {
+    use crate::ai_activity::{append_event_in, AiActivityEvent};
+    use crate::ai_notebook_export::{derive_cell_name, export_session_in};
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn ev(
+        id: &str,
+        sess: &str,
+        tool: &str,
+        ts: &str,
+        query: Option<&str>,
+        conn_name: &str,
+    ) -> AiActivityEvent {
+        AiActivityEvent {
+            id: id.to_string(),
+            session_id: sess.to_string(),
+            timestamp: ts.to_string(),
+            tool: tool.to_string(),
+            connection_id: Some("c1".to_string()),
+            connection_name: Some(conn_name.to_string()),
+            query: query.map(|s| s.to_string()),
+            query_kind: query.map(|_| "select".to_string()),
+            duration_ms: 1,
+            status: "success".to_string(),
+            rows: Some(0),
+            error: None,
+            client_hint: Some("claude-desktop".to_string()),
+            approval_id: None,
+        }
+    }
+
+    fn append(dir: &Path, e: AiActivityEvent) {
+        append_event_in(dir, &e).unwrap();
+    }
+
+    #[test]
+    fn export_single_query_session() {
+        let tmp = TempDir::new().unwrap();
+        append(
+            tmp.path(),
+            ev(
+                "1",
+                "s",
+                "run_query",
+                "2026-04-24T10:00:00Z",
+                Some("SELECT 1"),
+                "dev",
+            ),
+        );
+        let nb = export_session_in(tmp.path(), "s").unwrap();
+        // 1 header + 1 SQL cell.
+        assert_eq!(nb.cells.len(), 2);
+        assert_eq!(nb.cells[0].cell_type, "markdown");
+        assert!(nb.cells[0].content.contains("AI Session s"));
+        assert_eq!(nb.cells[1].cell_type, "sql");
+        assert_eq!(nb.cells[1].content, "SELECT 1");
+        assert_eq!(nb.cells[1].schema.as_deref(), Some("dev"));
+    }
+
+    #[test]
+    fn export_mixed_tools_creates_markdown_for_describe() {
+        let tmp = TempDir::new().unwrap();
+        append(
+            tmp.path(),
+            ev("1", "s", "list_tables", "2026-04-24T10:00:00Z", None, "dev"),
+        );
+        append(
+            tmp.path(),
+            ev(
+                "2",
+                "s",
+                "describe_table",
+                "2026-04-24T10:00:01Z",
+                None,
+                "dev",
+            ),
+        );
+        append(
+            tmp.path(),
+            ev(
+                "3",
+                "s",
+                "run_query",
+                "2026-04-24T10:00:02Z",
+                Some("SELECT 1"),
+                "dev",
+            ),
+        );
+        let nb = export_session_in(tmp.path(), "s").unwrap();
+        // header + list_tables md + describe_table md + sql cell.
+        assert_eq!(nb.cells.len(), 4);
+        assert_eq!(nb.cells[1].cell_type, "markdown");
+        assert!(nb.cells[1].content.contains("list_tables"));
+        assert_eq!(nb.cells[2].cell_type, "markdown");
+        assert!(nb.cells[2].content.contains("describe_table"));
+        assert_eq!(nb.cells[3].cell_type, "sql");
+    }
+
+    #[test]
+    fn export_unknown_session_returns_error() {
+        let tmp = TempDir::new().unwrap();
+        let err = export_session_in(tmp.path(), "missing").unwrap_err();
+        assert!(err.contains("missing"));
+    }
+
+    #[test]
+    fn export_orders_cells_chronologically() {
+        let tmp = TempDir::new().unwrap();
+        append(
+            tmp.path(),
+            ev(
+                "later",
+                "s",
+                "run_query",
+                "2026-04-24T10:00:02Z",
+                Some("SELECT 2"),
+                "dev",
+            ),
+        );
+        append(
+            tmp.path(),
+            ev(
+                "earlier",
+                "s",
+                "run_query",
+                "2026-04-24T10:00:01Z",
+                Some("SELECT 1"),
+                "dev",
+            ),
+        );
+        let nb = export_session_in(tmp.path(), "s").unwrap();
+        // Skip header at index 0.
+        assert_eq!(nb.cells[1].content, "SELECT 1");
+        assert_eq!(nb.cells[2].content, "SELECT 2");
+    }
+
+    #[test]
+    fn cell_name_uses_first_comment() {
+        assert_eq!(
+            derive_cell_name("-- top customers\nSELECT * FROM users", 1),
+            "top customers"
+        );
+    }
+
+    #[test]
+    fn cell_name_falls_back_to_index_when_no_comment() {
+        assert_eq!(derive_cell_name("SELECT 1", 7), "Query 7");
+    }
+
+    #[test]
+    fn cell_name_truncates_long_comments() {
+        let long = "x".repeat(200);
+        let q = format!("-- {}", long);
+        let name = derive_cell_name(&q, 1);
+        // 60 chars + ellipsis.
+        assert!(name.chars().count() <= 61);
+        assert!(name.ends_with('…'));
+    }
+
+    #[test]
+    fn cell_name_skips_blank_lines_before_comment() {
+        assert_eq!(
+            derive_cell_name("\n\n-- daily totals\nSELECT 1", 1),
+            "daily totals"
+        );
+    }
+
+    #[test]
+    fn cell_name_does_not_use_inline_comment_after_sql() {
+        assert_eq!(
+            derive_cell_name("SELECT 1 -- not a name", 4),
+            "Query 4"
+        );
+    }
+
+    #[test]
+    fn header_lists_distinct_connection_names() {
+        let tmp = TempDir::new().unwrap();
+        append(
+            tmp.path(),
+            ev(
+                "1",
+                "s",
+                "run_query",
+                "2026-04-24T10:00:00Z",
+                Some("SELECT 1"),
+                "dev",
+            ),
+        );
+        append(
+            tmp.path(),
+            ev(
+                "2",
+                "s",
+                "run_query",
+                "2026-04-24T10:00:01Z",
+                Some("SELECT 2"),
+                "staging",
+            ),
+        );
+        append(
+            tmp.path(),
+            ev(
+                "3",
+                "s",
+                "run_query",
+                "2026-04-24T10:00:02Z",
+                Some("SELECT 3"),
+                "dev",
+            ),
+        );
+        let nb = export_session_in(tmp.path(), "s").unwrap();
+        assert!(nb.cells[0].content.contains("dev, staging"));
+    }
+}

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -57,6 +57,33 @@ pub struct AppConfig {
     pub query_history_max_entries: Option<u32>,
     /// Whether to show the welcome screen on startup. Default: true (first launch).
     pub show_welcome: Option<bool>,
+
+    // ----- AI Audit Log -----
+    /// Record every MCP tool call to the audit log. Default: true.
+    pub ai_audit_enabled: Option<bool>,
+    /// Maximum entries per audit-log file before rotation. Default: 5000.
+    pub ai_audit_max_entries: Option<u32>,
+    /// Inactivity gap (in minutes) after which a new MCP session id is minted.
+    /// Default: 10.
+    pub ai_session_gap_minutes: Option<u32>,
+
+    // ----- MCP Read-only Mode -----
+    /// Default behaviour for MCP `run_query`: when true, every connection is
+    /// read-only unless explicitly listed as writable. Default: false.
+    pub mcp_readonly_default: Option<bool>,
+    /// Per-connection override list. Semantics depend on `mcp_readonly_default`:
+    /// when default is `false` this is the *inclusion* list of read-only
+    /// connections; when default is `true` this is the *exclusion* list of
+    /// connections that are allowed to write.
+    pub mcp_readonly_connections: Option<Vec<String>>,
+
+    // ----- MCP Approval Gate -----
+    /// `"off"` | `"writes_only"` | `"all"`. Default: `"writes_only"`.
+    pub mcp_approval_mode: Option<String>,
+    /// Maximum time the MCP subprocess waits for the user to decide. Default: 120.
+    pub mcp_approval_timeout_seconds: Option<u32>,
+    /// Run a pre-flight EXPLAIN before opening the approval modal. Default: true.
+    pub mcp_preflight_explain: Option<bool>,
 }
 
 static CONFIG_CACHE: Lazy<RwLock<AppConfig>> = Lazy::new(|| RwLock::new(AppConfig::default()));
@@ -76,6 +103,51 @@ pub fn get_cached_config() -> AppConfig {
         .read()
         .map(|cached| cached.clone())
         .unwrap_or_default()
+}
+
+// ---------- AI/MCP safety defaults ----------
+pub const DEFAULT_AI_AUDIT_ENABLED: bool = true;
+pub const DEFAULT_AI_AUDIT_MAX_ENTRIES: u32 = 5000;
+pub const DEFAULT_AI_SESSION_GAP_MINUTES: u32 = 10;
+pub const DEFAULT_MCP_READONLY_DEFAULT: bool = false;
+pub const DEFAULT_MCP_APPROVAL_MODE: &str = "writes_only";
+pub const DEFAULT_MCP_APPROVAL_TIMEOUT_SECONDS: u32 = 120;
+pub const DEFAULT_MCP_PREFLIGHT_EXPLAIN: bool = true;
+
+/// Load `config.json` directly from disk without an `AppHandle`.
+///
+/// Used by the standalone MCP subprocess (`tabularis --mcp`) which has no
+/// Tauri runtime. Falls back to `AppConfig::default()` when missing or
+/// unreadable.
+pub fn load_config_from_disk() -> AppConfig {
+    let path = crate::paths::get_app_config_dir().join("config.json");
+    if !path.exists() {
+        return AppConfig::default();
+    }
+    fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| serde_json::from_str::<AppConfig>(&s).ok())
+        .unwrap_or_default()
+}
+
+/// True when `connection_id` should be treated as read-only by MCP, taking
+/// the per-connection override list into account.
+pub fn is_connection_readonly(config: &AppConfig, connection_id: &str) -> bool {
+    let default_ro = config
+        .mcp_readonly_default
+        .unwrap_or(DEFAULT_MCP_READONLY_DEFAULT);
+    let listed = config
+        .mcp_readonly_connections
+        .as_ref()
+        .map(|v| v.iter().any(|s| s == connection_id))
+        .unwrap_or(false);
+    // When default is false the list flips that connection to read-only.
+    // When default is true the list flips that connection to writable.
+    if default_ro {
+        !listed
+    } else {
+        listed
+    }
 }
 
 // Internal load
@@ -222,6 +294,30 @@ pub fn save_config(app: AppHandle, config: AppConfig) -> Result<(), String> {
         }
         if config.show_welcome.is_some() {
             existing_config.show_welcome = config.show_welcome;
+        }
+        if config.ai_audit_enabled.is_some() {
+            existing_config.ai_audit_enabled = config.ai_audit_enabled;
+        }
+        if config.ai_audit_max_entries.is_some() {
+            existing_config.ai_audit_max_entries = config.ai_audit_max_entries;
+        }
+        if config.ai_session_gap_minutes.is_some() {
+            existing_config.ai_session_gap_minutes = config.ai_session_gap_minutes;
+        }
+        if config.mcp_readonly_default.is_some() {
+            existing_config.mcp_readonly_default = config.mcp_readonly_default;
+        }
+        if config.mcp_readonly_connections.is_some() {
+            existing_config.mcp_readonly_connections = config.mcp_readonly_connections;
+        }
+        if config.mcp_approval_mode.is_some() {
+            existing_config.mcp_approval_mode = config.mcp_approval_mode;
+        }
+        if config.mcp_approval_timeout_seconds.is_some() {
+            existing_config.mcp_approval_timeout_seconds = config.mcp_approval_timeout_seconds;
+        }
+        if config.mcp_preflight_explain.is_some() {
+            existing_config.mcp_preflight_explain = config.mcp_preflight_explain;
         }
 
         let content = serde_json::to_string_pretty(&existing_config).map_err(|e| e.to_string())?;
@@ -681,5 +777,99 @@ mod tests {
         let invalid = r#"{"editorFontSize": "not-a-number"}"#;
         let result = serde_json::from_str::<AppConfig>(invalid);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn ai_safety_fields_default_to_none() {
+        let config = AppConfig::default();
+        assert!(config.ai_audit_enabled.is_none());
+        assert!(config.ai_audit_max_entries.is_none());
+        assert!(config.ai_session_gap_minutes.is_none());
+        assert!(config.mcp_readonly_default.is_none());
+        assert!(config.mcp_readonly_connections.is_none());
+        assert!(config.mcp_approval_mode.is_none());
+        assert!(config.mcp_approval_timeout_seconds.is_none());
+        assert!(config.mcp_preflight_explain.is_none());
+    }
+
+    #[test]
+    fn ai_safety_fields_serialize_with_camel_case() {
+        let mut config = AppConfig::default();
+        config.ai_audit_enabled = Some(true);
+        config.ai_audit_max_entries = Some(1000);
+        config.ai_session_gap_minutes = Some(5);
+        config.mcp_readonly_default = Some(true);
+        config.mcp_readonly_connections = Some(vec!["c1".into()]);
+        config.mcp_approval_mode = Some("all".into());
+        config.mcp_approval_timeout_seconds = Some(60);
+        config.mcp_preflight_explain = Some(false);
+
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(json.contains("aiAuditEnabled"));
+        assert!(json.contains("aiAuditMaxEntries"));
+        assert!(json.contains("aiSessionGapMinutes"));
+        assert!(json.contains("mcpReadonlyDefault"));
+        assert!(json.contains("mcpReadonlyConnections"));
+        assert!(json.contains("mcpApprovalMode"));
+        assert!(json.contains("mcpApprovalTimeoutSeconds"));
+        assert!(json.contains("mcpPreflightExplain"));
+    }
+
+    #[test]
+    fn ai_safety_fields_round_trip() {
+        let json = r#"{
+            "aiAuditEnabled": false,
+            "aiAuditMaxEntries": 2000,
+            "aiSessionGapMinutes": 30,
+            "mcpReadonlyDefault": true,
+            "mcpReadonlyConnections": ["a", "b"],
+            "mcpApprovalMode": "writes_only",
+            "mcpApprovalTimeoutSeconds": 90,
+            "mcpPreflightExplain": true
+        }"#;
+        let config: AppConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.ai_audit_enabled, Some(false));
+        assert_eq!(config.ai_audit_max_entries, Some(2000));
+        assert_eq!(config.ai_session_gap_minutes, Some(30));
+        assert_eq!(config.mcp_readonly_default, Some(true));
+        assert_eq!(
+            config.mcp_readonly_connections.as_deref(),
+            Some(&["a".to_string(), "b".to_string()][..])
+        );
+        assert_eq!(config.mcp_approval_mode.as_deref(), Some("writes_only"));
+        assert_eq!(config.mcp_approval_timeout_seconds, Some(90));
+        assert_eq!(config.mcp_preflight_explain, Some(true));
+    }
+
+    #[test]
+    fn is_connection_readonly_default_false_no_override_returns_false() {
+        let config = AppConfig::default();
+        assert!(!is_connection_readonly(&config, "c1"));
+    }
+
+    #[test]
+    fn is_connection_readonly_default_false_with_inclusion_list() {
+        let mut config = AppConfig::default();
+        config.mcp_readonly_default = Some(false);
+        config.mcp_readonly_connections = Some(vec!["c1".into()]);
+        assert!(is_connection_readonly(&config, "c1"));
+        assert!(!is_connection_readonly(&config, "c2"));
+    }
+
+    #[test]
+    fn is_connection_readonly_default_true_with_exclusion_list() {
+        let mut config = AppConfig::default();
+        config.mcp_readonly_default = Some(true);
+        config.mcp_readonly_connections = Some(vec!["c1".into()]);
+        assert!(!is_connection_readonly(&config, "c1"));
+        assert!(is_connection_readonly(&config, "c2"));
+    }
+
+    #[test]
+    fn load_config_from_disk_returns_default_when_missing() {
+        // The default config dir is unlikely to have our test sentinels, so
+        // we just confirm the call returns a valid AppConfig (Default fallback
+        // path is exercised indirectly via parse failures + missing file).
+        let _ = load_config_from_disk();
     }
 }

--- a/src-tauri/src/heartbeat.rs
+++ b/src-tauri/src/heartbeat.rs
@@ -1,0 +1,116 @@
+//! GUI heartbeat used by the MCP subprocess to detect whether the Tabularis
+//! desktop app is currently running.
+//!
+//! The GUI refreshes `<config_dir>/tabularis.alive` every `TICK_INTERVAL`.
+//! The MCP subprocess calls `is_alive()` before queueing approval requests
+//! so that — when the GUI is closed — write/DDL queries fail fast with a
+//! clear error instead of hanging until `mcp_approval_timeout_seconds`
+//! (default 120s) elapses.
+//!
+//! The file is intentionally not removed on shutdown: stale-by-mtime is
+//! enough and survives crashes/SIGKILL transparently.
+
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use crate::paths::get_app_config_dir;
+
+const FILE_NAME: &str = "tabularis.alive";
+
+/// How often the GUI refreshes the heartbeat file.
+pub const TICK_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Heartbeats older than this are considered stale (3 missed ticks).
+pub const STALE_AFTER: Duration = Duration::from_secs(15);
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Heartbeat {
+    pub pid: u32,
+    pub updated_at: String,
+}
+
+pub fn heartbeat_path_in(base: &Path) -> PathBuf {
+    base.join(FILE_NAME)
+}
+
+pub fn write_now_in(base: &Path) -> Result<(), String> {
+    if !base.exists() {
+        fs::create_dir_all(base).map_err(|e| e.to_string())?;
+    }
+    let beat = Heartbeat {
+        pid: std::process::id(),
+        updated_at: crate::ai_activity::now_iso8601(),
+    };
+    let content = serde_json::to_string(&beat).map_err(|e| e.to_string())?;
+    fs::write(heartbeat_path_in(base), content).map_err(|e| e.to_string())
+}
+
+pub fn clear_in(base: &Path) -> Result<(), String> {
+    let path = heartbeat_path_in(base);
+    if path.exists() {
+        fs::remove_file(&path).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+/// Returns `true` if the heartbeat file exists and was modified within
+/// `max_age`. Filesystem errors are treated as "not alive" — fail-closed.
+pub fn is_alive_in_with_age(base: &Path, max_age: Duration) -> bool {
+    let path = heartbeat_path_in(base);
+    let metadata = match fs::metadata(&path) {
+        Ok(m) => m,
+        Err(_) => return false,
+    };
+    let modified = match metadata.modified() {
+        Ok(m) => m,
+        Err(_) => return false,
+    };
+    match SystemTime::now().duration_since(modified) {
+        Ok(age) => age <= max_age,
+        // mtime is in the future (clock skew): trust the file.
+        Err(_) => true,
+    }
+}
+
+pub fn is_alive_in(base: &Path) -> bool {
+    is_alive_in_with_age(base, STALE_AFTER)
+}
+
+// ---------------------------------------------------------------------------
+// Default-dir wrappers (used at runtime)
+// ---------------------------------------------------------------------------
+
+pub fn write_now() -> Result<(), String> {
+    write_now_in(&get_app_config_dir())
+}
+
+pub fn clear() -> Result<(), String> {
+    clear_in(&get_app_config_dir())
+}
+
+pub fn is_alive() -> bool {
+    is_alive_in(&get_app_config_dir())
+}
+
+/// Spawn the periodic heartbeat ticker. Writes the initial file synchronously
+/// so `is_alive()` is true the moment the GUI finishes booting, then refreshes
+/// every `TICK_INTERVAL` from a tokio task.
+pub fn spawn() {
+    if let Err(e) = write_now() {
+        log::warn!("Failed to write initial heartbeat: {}", e);
+    }
+    tauri::async_runtime::spawn(async move {
+        let mut ticker = tokio::time::interval(TICK_INTERVAL);
+        // The first tick fires immediately; we already wrote synchronously.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            if let Err(e) = write_now() {
+                log::warn!("Heartbeat refresh failed: {}", e);
+            }
+        }
+    });
+}

--- a/src-tauri/src/heartbeat_tests.rs
+++ b/src-tauri/src/heartbeat_tests.rs
@@ -1,0 +1,82 @@
+#[cfg(test)]
+mod tests {
+    use crate::heartbeat::{
+        clear_in, heartbeat_path_in, is_alive_in_with_age, write_now_in, Heartbeat,
+    };
+    use std::time::Duration;
+    use tempfile::TempDir;
+
+    #[test]
+    fn missing_file_is_not_alive() {
+        let tmp = TempDir::new().unwrap();
+        assert!(!is_alive_in_with_age(tmp.path(), Duration::from_secs(15)));
+    }
+
+    #[test]
+    fn fresh_heartbeat_is_alive() {
+        let tmp = TempDir::new().unwrap();
+        write_now_in(tmp.path()).unwrap();
+        assert!(is_alive_in_with_age(tmp.path(), Duration::from_secs(15)));
+    }
+
+    #[test]
+    fn stale_heartbeat_is_not_alive() {
+        let tmp = TempDir::new().unwrap();
+        write_now_in(tmp.path()).unwrap();
+        // Push mtime 1h into the past — well beyond any reasonable threshold.
+        let path = heartbeat_path_in(tmp.path());
+        let old = std::time::SystemTime::now()
+            .checked_sub(Duration::from_secs(3600))
+            .unwrap();
+        filetime::set_file_mtime(&path, filetime::FileTime::from_system_time(old)).unwrap();
+        assert!(!is_alive_in_with_age(tmp.path(), Duration::from_secs(15)));
+    }
+
+    #[test]
+    fn write_now_creates_directory_if_missing() {
+        let tmp = TempDir::new().unwrap();
+        let nested = tmp.path().join("nested").join("config");
+        assert!(!nested.exists());
+        write_now_in(&nested).unwrap();
+        assert!(heartbeat_path_in(&nested).exists());
+    }
+
+    #[test]
+    fn write_now_persists_pid_and_timestamp() {
+        let tmp = TempDir::new().unwrap();
+        write_now_in(tmp.path()).unwrap();
+        let raw = std::fs::read_to_string(heartbeat_path_in(tmp.path())).unwrap();
+        let beat: Heartbeat = serde_json::from_str(&raw).unwrap();
+        assert_eq!(beat.pid, std::process::id());
+        assert!(!beat.updated_at.is_empty());
+    }
+
+    #[test]
+    fn clear_removes_existing_file() {
+        let tmp = TempDir::new().unwrap();
+        write_now_in(tmp.path()).unwrap();
+        assert!(heartbeat_path_in(tmp.path()).exists());
+        clear_in(tmp.path()).unwrap();
+        assert!(!heartbeat_path_in(tmp.path()).exists());
+    }
+
+    #[test]
+    fn clear_missing_file_is_ok() {
+        let tmp = TempDir::new().unwrap();
+        clear_in(tmp.path()).unwrap();
+    }
+
+    #[test]
+    fn write_now_overwrites_existing_file() {
+        let tmp = TempDir::new().unwrap();
+        write_now_in(tmp.path()).unwrap();
+        let first = std::fs::read_to_string(heartbeat_path_in(tmp.path())).unwrap();
+        // Sleep is not needed; rfc3339 timestamps differ at ms granularity in
+        // practice. We only care that the second write succeeds and the file
+        // is still parseable.
+        write_now_in(tmp.path()).unwrap();
+        let second = std::fs::read_to_string(heartbeat_path_in(tmp.path())).unwrap();
+        assert!(serde_json::from_str::<Heartbeat>(&first).is_ok());
+        assert!(serde_json::from_str::<Heartbeat>(&second).is_ok());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,15 @@
 pub mod ai;
+pub mod ai_activity;
+#[cfg(test)]
+pub mod ai_activity_tests;
+pub mod ai_approval;
+#[cfg(test)]
+pub mod ai_approval_tests;
+pub mod ai_approval_watcher;
+pub mod ai_commands;
+pub mod ai_notebook_export;
+#[cfg(test)]
+pub mod ai_notebook_export_tests;
 pub mod cli;
 pub mod clipboard_import;
 pub mod commands;
@@ -172,6 +183,9 @@ pub fn run() {
                 });
             }
 
+            // Watch for pending MCP approval requests and run periodic cleanup.
+            ai_approval_watcher::spawn(app.handle().clone());
+
             // Open devtools automatically in debug mode
             if args.debug {
                 if let Some(window) = app.get_webview_window("main") {
@@ -331,6 +345,16 @@ pub fn run() {
             // MCP
             mcp::install::get_mcp_status,
             mcp::install::install_mcp_config,
+            // AI Activity / Approvals
+            ai_commands::get_ai_activity,
+            ai_commands::get_ai_sessions,
+            ai_commands::get_ai_session_events,
+            ai_commands::clear_ai_activity,
+            ai_commands::export_ai_activity_json,
+            ai_commands::export_ai_activity_csv,
+            ai_commands::export_ai_session_as_notebook,
+            ai_commands::list_pending_approvals,
+            ai_commands::decide_pending_approval,
             // Themes
             theme_commands::get_all_themes,
             theme_commands::get_theme,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,9 @@ pub mod explain_import;
 pub mod explain_import_tests;
 pub mod export;
 pub mod health_check;
+pub mod heartbeat;
+#[cfg(test)]
+pub mod heartbeat_tests;
 pub mod keychain_utils;
 pub mod log_commands;
 pub mod logger;
@@ -185,6 +188,11 @@ pub fn run() {
 
             // Watch for pending MCP approval requests and run periodic cleanup.
             ai_approval_watcher::spawn(app.handle().clone());
+
+            // Refresh the GUI heartbeat so the MCP subprocess can detect
+            // when Tabularis is closed and fail fast on approval-gated
+            // queries instead of waiting for the full approval timeout.
+            heartbeat::spawn();
 
             // Open devtools automatically in debug mode
             if args.debug {

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -1,15 +1,54 @@
+use crate::ai_activity::{self, AiActivityEvent};
+use crate::ai_approval::{self, PendingApproval};
 use crate::commands;
+use crate::config::{
+    self, AppConfig, DEFAULT_AI_AUDIT_ENABLED, DEFAULT_AI_AUDIT_MAX_ENTRIES,
+    DEFAULT_AI_SESSION_GAP_MINUTES, DEFAULT_MCP_APPROVAL_MODE,
+    DEFAULT_MCP_APPROVAL_TIMEOUT_SECONDS, DEFAULT_MCP_PREFLIGHT_EXPLAIN,
+};
 use crate::credential_cache;
 use crate::drivers::{mysql, postgres, sqlite};
 use crate::models::{ConnectionParams, SshConnection};
 use crate::paths;
 use crate::persistence;
-use serde_json::json;
+use serde_json::{json, Value};
 use std::io::{self, BufRead, Write};
 
 pub mod install;
+pub mod preflight;
 pub mod protocol;
 use protocol::*;
+
+const APPROVAL_POLL_INTERVAL_MS: u64 = 500;
+
+/// Async-friendly mirror of the data we want to record on every tool call.
+struct CallAudit {
+    tool: String,
+    connection_id: Option<String>,
+    connection_name: Option<String>,
+    query: Option<String>,
+    query_kind: Option<String>,
+    rows: Option<usize>,
+    status: String,
+    error: Option<String>,
+    approval_id: Option<String>,
+}
+
+impl CallAudit {
+    fn for_tool(tool: &str) -> Self {
+        Self {
+            tool: tool.to_string(),
+            connection_id: None,
+            connection_name: None,
+            query: None,
+            query_kind: None,
+            rows: None,
+            status: "success".to_string(),
+            error: None,
+            approval_id: None,
+        }
+    }
+}
 
 /// MCP-mode equivalent of `expand_ssh_connection_params` — no AppHandle needed.
 /// Loads SSH credentials from the config file and keychain directly.
@@ -245,9 +284,19 @@ async fn handle_request(req: JsonRpcRequest) -> Option<JsonRpcResponse> {
     })
 }
 
-fn handle_initialize(
-    _params: Option<serde_json::Value>,
-) -> Result<serde_json::Value, JsonRpcError> {
+fn handle_initialize(params: Option<Value>) -> Result<Value, JsonRpcError> {
+    // Capture client name for the audit log session metadata. Best-effort:
+    // if parsing fails we still complete the handshake.
+    if let Some(p) = &params {
+        if let Some(name) = p
+            .get("clientInfo")
+            .and_then(|c| c.get("name"))
+            .and_then(|v| v.as_str())
+        {
+            ai_activity::set_client_hint(Some(name.to_string()));
+        }
+    }
+
     let result = InitializeResult {
         protocol_version: "2024-11-05".to_string(),
         capabilities: ServerCapabilities {
@@ -263,7 +312,7 @@ fn handle_initialize(
     Ok(serde_json::to_value(result).unwrap())
 }
 
-async fn handle_list_resources() -> Result<serde_json::Value, JsonRpcError> {
+async fn handle_list_resources() -> Result<Value, JsonRpcError> {
     let config_path = paths::get_app_config_dir().join("connections.json");
     let connections = persistence::load_connections(&config_path).map_err(|e| JsonRpcError {
         code: -32000,
@@ -296,9 +345,7 @@ async fn handle_list_resources() -> Result<serde_json::Value, JsonRpcError> {
     }))
 }
 
-async fn handle_read_resource(
-    params: Option<serde_json::Value>,
-) -> Result<serde_json::Value, JsonRpcError> {
+async fn handle_read_resource(params: Option<Value>) -> Result<Value, JsonRpcError> {
     let params = params.ok_or(JsonRpcError {
         code: -32602,
         message: "Missing params".to_string(),
@@ -415,7 +462,7 @@ async fn handle_read_resource(
     })
 }
 
-fn handle_list_tools() -> Result<serde_json::Value, JsonRpcError> {
+fn handle_list_tools() -> Result<Value, JsonRpcError> {
     let tools = vec![
         Tool {
             name: "list_connections".to_string(),
@@ -471,198 +518,463 @@ fn handle_list_tools() -> Result<serde_json::Value, JsonRpcError> {
     }))
 }
 
-async fn handle_call_tool(
-    params: Option<serde_json::Value>,
-) -> Result<serde_json::Value, JsonRpcError> {
-    let params = params.ok_or(JsonRpcError {
-        code: -32602,
-        message: "Missing params".to_string(),
-        data: None,
-    })?;
-    let name = params["name"].as_str().unwrap_or("");
-    let args = params.get("arguments").and_then(|v| v.as_object());
+async fn handle_call_tool(params: Option<Value>) -> Result<Value, JsonRpcError> {
+    let start = std::time::Instant::now();
+    let app_config = config::load_config_from_disk();
+    let audit_enabled = app_config
+        .ai_audit_enabled
+        .unwrap_or(DEFAULT_AI_AUDIT_ENABLED);
+    let max_entries = app_config
+        .ai_audit_max_entries
+        .unwrap_or(DEFAULT_AI_AUDIT_MAX_ENTRIES) as usize;
+    let gap_minutes = app_config
+        .ai_session_gap_minutes
+        .unwrap_or(DEFAULT_AI_SESSION_GAP_MINUTES);
 
-    if name == "list_connections" {
-        let config_path = paths::get_app_config_dir().join("connections.json");
-        let connections =
-            persistence::load_connections(&config_path).map_err(|e| JsonRpcError {
-                code: -32000,
-                message: e,
+    let session_id = ai_activity::compute_or_rotate_session_id(gap_minutes);
+    let client_hint = ai_activity::get_client_hint();
+
+    let params_value = match params {
+        Some(p) => p,
+        None => {
+            let err = JsonRpcError {
+                code: -32602,
+                message: "Missing params".to_string(),
                 data: None,
-            })?;
+            };
+            if audit_enabled {
+                let mut audit = CallAudit::for_tool("unknown");
+                audit.status = "error".to_string();
+                audit.error = Some(err.message.clone());
+                emit_audit(&session_id, &client_hint, &audit, start, max_entries);
+            }
+            return Err(err);
+        }
+    };
+    let name = params_value["name"].as_str().unwrap_or("").to_string();
+    let args = params_value
+        .get("arguments")
+        .and_then(|v| v.as_object())
+        .cloned();
 
-        let list: Vec<_> = connections
-            .iter()
-            .map(|c| {
-                json!({
-                    "id": c.id,
-                    "name": c.name,
-                    "driver": c.params.driver,
-                    "host": c.params.host,
-                    "database": c.params.database.to_string()
-                })
-            })
-            .collect();
+    let mut audit = CallAudit::for_tool(&name);
+    let result = dispatch_tool(&name, args.as_ref(), &app_config, &session_id, &mut audit).await;
 
-        return Ok(json!({
-            "content": [{
-                "type": "text",
-                "text": serde_json::to_string_pretty(&list).unwrap()
-            }]
-        }));
+    match &result {
+        Ok(_) => {
+            if audit.status == "success" {
+                audit.status = "success".to_string();
+            }
+        }
+        Err(e) => {
+            // Inner code may have already set a more specific status (e.g.
+            // blocked_readonly, denied, timeout). Only fall back to "error"
+            // when nothing was set.
+            if audit.status == "success" {
+                audit.status = "error".to_string();
+            }
+            if audit.error.is_none() {
+                audit.error = Some(e.message.clone());
+            }
+        }
     }
 
-    let args = args.ok_or(JsonRpcError {
+    if audit_enabled {
+        emit_audit(&session_id, &client_hint, &audit, start, max_entries);
+    }
+
+    result
+}
+
+fn emit_audit(
+    session_id: &str,
+    client_hint: &Option<String>,
+    audit: &CallAudit,
+    start: std::time::Instant,
+    max_entries: usize,
+) {
+    let event = AiActivityEvent {
+        id: ai_activity::new_uuid(),
+        session_id: session_id.to_string(),
+        timestamp: ai_activity::now_iso8601(),
+        tool: audit.tool.clone(),
+        connection_id: audit.connection_id.clone(),
+        connection_name: audit.connection_name.clone(),
+        query: audit.query.clone(),
+        query_kind: audit.query_kind.clone(),
+        duration_ms: start.elapsed().as_millis() as u64,
+        status: audit.status.clone(),
+        rows: audit.rows,
+        error: audit.error.clone(),
+        client_hint: client_hint.clone(),
+        approval_id: audit.approval_id.clone(),
+    };
+    if let Err(e) = ai_activity::append_and_rotate(&event, max_entries) {
+        eprintln!("[MCP] Failed to write audit log: {}", e);
+    }
+}
+
+async fn dispatch_tool(
+    name: &str,
+    args: Option<&serde_json::Map<String, Value>>,
+    config: &AppConfig,
+    session_id: &str,
+    audit: &mut CallAudit,
+) -> Result<Value, JsonRpcError> {
+    match name {
+        "list_connections" => tool_list_connections(audit).await,
+        "list_tables" => {
+            let args = require_args(args)?;
+            tool_list_tables(args, audit).await
+        }
+        "describe_table" => {
+            let args = require_args(args)?;
+            tool_describe_table(args, audit).await
+        }
+        "run_query" => {
+            let args = require_args(args)?;
+            tool_run_query(args, config, session_id, audit).await
+        }
+        _ => Err(JsonRpcError {
+            code: -32601,
+            message: "Tool not found".to_string(),
+            data: None,
+        }),
+    }
+}
+
+fn require_args(
+    args: Option<&serde_json::Map<String, Value>>,
+) -> Result<&serde_json::Map<String, Value>, JsonRpcError> {
+    args.ok_or(JsonRpcError {
         code: -32602,
         message: "Missing arguments".to_string(),
         data: None,
-    })?;
-
-    if name == "list_tables" {
-        let conn_id = args
-            .get("connection_id")
-            .and_then(|v| v.as_str())
-            .ok_or(JsonRpcError {
-                code: -32602,
-                message: "Missing connection_id".to_string(),
-                data: None,
-            })?;
-        let schema = args.get("schema").and_then(|v| v.as_str());
-
-        let (conn, db_params) = resolve_db_params(conn_id).await?;
-
-        let tables = match conn.params.driver.as_str() {
-            "mysql" => mysql::get_tables(&db_params, schema).await,
-            "postgres" => {
-                let s = schema.unwrap_or("public");
-                postgres::get_tables(&db_params, s).await
-            }
-            "sqlite" => sqlite::get_tables(&db_params).await,
-            _ => Err("Unsupported driver".into()),
-        }
-        .map_err(|e| JsonRpcError {
-            code: -32000,
-            message: e,
-            data: None,
-        })?;
-
-        let names: Vec<&str> = tables.iter().map(|t| t.name.as_str()).collect();
-        return Ok(json!({
-            "content": [{
-                "type": "text",
-                "text": serde_json::to_string_pretty(&names).unwrap()
-            }]
-        }));
-    }
-
-    if name == "describe_table" {
-        let conn_id = args
-            .get("connection_id")
-            .and_then(|v| v.as_str())
-            .ok_or(JsonRpcError {
-                code: -32602,
-                message: "Missing connection_id".to_string(),
-                data: None,
-            })?;
-        let table_name = args
-            .get("table_name")
-            .and_then(|v| v.as_str())
-            .ok_or(JsonRpcError {
-                code: -32602,
-                message: "Missing table_name".to_string(),
-                data: None,
-            })?;
-        let schema = args.get("schema").and_then(|v| v.as_str());
-
-        let (conn, db_params) = resolve_db_params(conn_id).await?;
-
-        let (columns, foreign_keys, indexes) = match conn.params.driver.as_str() {
-            "mysql" => {
-                let cols = mysql::get_columns(&db_params, table_name, schema).await;
-                let fks = mysql::get_foreign_keys(&db_params, table_name, schema).await;
-                let idxs = mysql::get_indexes(&db_params, table_name, schema).await;
-                (cols, fks, idxs)
-            }
-            "postgres" => {
-                let s = schema.unwrap_or("public");
-                let cols = postgres::get_columns(&db_params, table_name, s).await;
-                let fks = postgres::get_foreign_keys(&db_params, table_name, s).await;
-                let idxs = postgres::get_indexes(&db_params, table_name, s).await;
-                (cols, fks, idxs)
-            }
-            "sqlite" => {
-                let cols = sqlite::get_columns(&db_params, table_name).await;
-                let fks = sqlite::get_foreign_keys(&db_params, table_name).await;
-                let idxs = sqlite::get_indexes(&db_params, table_name).await;
-                (cols, fks, idxs)
-            }
-            _ => {
-                return Err(JsonRpcError {
-                    code: -32000,
-                    message: "Unsupported driver".to_string(),
-                    data: None,
-                })
-            }
-        };
-
-        let result = json!({
-            "table": table_name,
-            "columns": columns.map_err(|e| JsonRpcError { code: -32000, message: e, data: None })?,
-            "foreign_keys": foreign_keys.map_err(|e| JsonRpcError { code: -32000, message: e, data: None })?,
-            "indexes": indexes.map_err(|e| JsonRpcError { code: -32000, message: e, data: None })?
-        });
-
-        return Ok(json!({
-            "content": [{
-                "type": "text",
-                "text": serde_json::to_string_pretty(&result).unwrap()
-            }]
-        }));
-    }
-
-    if name == "run_query" {
-        let conn_id = args
-            .get("connection_id")
-            .and_then(|v| v.as_str())
-            .ok_or(JsonRpcError {
-                code: -32602,
-                message: "Missing connection_id".to_string(),
-                data: None,
-            })?;
-        let query = args
-            .get("query")
-            .and_then(|v| v.as_str())
-            .ok_or(JsonRpcError {
-                code: -32602,
-                message: "Missing query".to_string(),
-                data: None,
-            })?;
-
-        let (conn, db_params) = resolve_db_params(conn_id).await?;
-
-        let result = match conn.params.driver.as_str() {
-            "mysql" => mysql::execute_query(&db_params, query, Some(100), 1, None).await,
-            "postgres" => postgres::execute_query(&db_params, query, Some(100), 1, None).await,
-            "sqlite" => sqlite::execute_query(&db_params, query, Some(100), 1).await,
-            _ => Err("Unsupported driver".into()),
-        }
-        .map_err(|e| JsonRpcError {
-            code: -32000,
-            message: e,
-            data: None,
-        })?;
-
-        return Ok(json!({
-            "content": [{
-                "type": "text",
-                "text": serde_json::to_string_pretty(&result).unwrap()
-            }]
-        }));
-    }
-
-    Err(JsonRpcError {
-        code: -32601,
-        message: "Tool not found".to_string(),
-        data: None,
     })
 }
+
+async fn tool_list_connections(_audit: &mut CallAudit) -> Result<Value, JsonRpcError> {
+    let config_path = paths::get_app_config_dir().join("connections.json");
+    let connections = persistence::load_connections(&config_path).map_err(|e| JsonRpcError {
+        code: -32000,
+        message: e,
+        data: None,
+    })?;
+
+    let list: Vec<_> = connections
+        .iter()
+        .map(|c| {
+            json!({
+                "id": c.id,
+                "name": c.name,
+                "driver": c.params.driver,
+                "host": c.params.host,
+                "database": c.params.database.to_string()
+            })
+        })
+        .collect();
+
+    Ok(json!({
+        "content": [{
+            "type": "text",
+            "text": serde_json::to_string_pretty(&list).unwrap()
+        }]
+    }))
+}
+
+async fn tool_list_tables(
+    args: &serde_json::Map<String, Value>,
+    audit: &mut CallAudit,
+) -> Result<Value, JsonRpcError> {
+    let conn_id = args
+        .get("connection_id")
+        .and_then(|v| v.as_str())
+        .ok_or(JsonRpcError {
+            code: -32602,
+            message: "Missing connection_id".to_string(),
+            data: None,
+        })?;
+    let schema = args.get("schema").and_then(|v| v.as_str());
+
+    audit.connection_id = Some(conn_id.to_string());
+
+    let (conn, db_params) = resolve_db_params(conn_id).await?;
+    audit.connection_name = Some(conn.name.clone());
+
+    let tables = match conn.params.driver.as_str() {
+        "mysql" => mysql::get_tables(&db_params, schema).await,
+        "postgres" => {
+            let s = schema.unwrap_or("public");
+            postgres::get_tables(&db_params, s).await
+        }
+        "sqlite" => sqlite::get_tables(&db_params).await,
+        _ => Err("Unsupported driver".into()),
+    }
+    .map_err(|e| JsonRpcError {
+        code: -32000,
+        message: e,
+        data: None,
+    })?;
+
+    let names: Vec<&str> = tables.iter().map(|t| t.name.as_str()).collect();
+    audit.rows = Some(names.len());
+    Ok(json!({
+        "content": [{
+            "type": "text",
+            "text": serde_json::to_string_pretty(&names).unwrap()
+        }]
+    }))
+}
+
+async fn tool_describe_table(
+    args: &serde_json::Map<String, Value>,
+    audit: &mut CallAudit,
+) -> Result<Value, JsonRpcError> {
+    let conn_id = args
+        .get("connection_id")
+        .and_then(|v| v.as_str())
+        .ok_or(JsonRpcError {
+            code: -32602,
+            message: "Missing connection_id".to_string(),
+            data: None,
+        })?;
+    let table_name = args
+        .get("table_name")
+        .and_then(|v| v.as_str())
+        .ok_or(JsonRpcError {
+            code: -32602,
+            message: "Missing table_name".to_string(),
+            data: None,
+        })?;
+    let schema = args.get("schema").and_then(|v| v.as_str());
+
+    audit.connection_id = Some(conn_id.to_string());
+
+    let (conn, db_params) = resolve_db_params(conn_id).await?;
+    audit.connection_name = Some(conn.name.clone());
+
+    let (columns, foreign_keys, indexes) = match conn.params.driver.as_str() {
+        "mysql" => {
+            let cols = mysql::get_columns(&db_params, table_name, schema).await;
+            let fks = mysql::get_foreign_keys(&db_params, table_name, schema).await;
+            let idxs = mysql::get_indexes(&db_params, table_name, schema).await;
+            (cols, fks, idxs)
+        }
+        "postgres" => {
+            let s = schema.unwrap_or("public");
+            let cols = postgres::get_columns(&db_params, table_name, s).await;
+            let fks = postgres::get_foreign_keys(&db_params, table_name, s).await;
+            let idxs = postgres::get_indexes(&db_params, table_name, s).await;
+            (cols, fks, idxs)
+        }
+        "sqlite" => {
+            let cols = sqlite::get_columns(&db_params, table_name).await;
+            let fks = sqlite::get_foreign_keys(&db_params, table_name).await;
+            let idxs = sqlite::get_indexes(&db_params, table_name).await;
+            (cols, fks, idxs)
+        }
+        _ => {
+            return Err(JsonRpcError {
+                code: -32000,
+                message: "Unsupported driver".to_string(),
+                data: None,
+            })
+        }
+    };
+
+    let result = json!({
+        "table": table_name,
+        "columns": columns.map_err(|e| JsonRpcError { code: -32000, message: e, data: None })?,
+        "foreign_keys": foreign_keys.map_err(|e| JsonRpcError { code: -32000, message: e, data: None })?,
+        "indexes": indexes.map_err(|e| JsonRpcError { code: -32000, message: e, data: None })?
+    });
+
+    Ok(json!({
+        "content": [{
+            "type": "text",
+            "text": serde_json::to_string_pretty(&result).unwrap()
+        }]
+    }))
+}
+
+async fn tool_run_query(
+    args: &serde_json::Map<String, Value>,
+    config: &AppConfig,
+    session_id: &str,
+    audit: &mut CallAudit,
+) -> Result<Value, JsonRpcError> {
+    let conn_id = args
+        .get("connection_id")
+        .and_then(|v| v.as_str())
+        .ok_or(JsonRpcError {
+            code: -32602,
+            message: "Missing connection_id".to_string(),
+            data: None,
+        })?;
+    let query = args
+        .get("query")
+        .and_then(|v| v.as_str())
+        .ok_or(JsonRpcError {
+            code: -32602,
+            message: "Missing query".to_string(),
+            data: None,
+        })?;
+
+    audit.connection_id = Some(conn_id.to_string());
+    audit.query = Some(query.to_string());
+    let kind = ai_activity::classify_query_kind(query);
+    audit.query_kind = Some(kind.to_string());
+
+    let (conn, db_params) = resolve_db_params(conn_id).await?;
+    audit.connection_name = Some(conn.name.clone());
+
+    // Read-only enforcement (fail-closed: unknown counts as write).
+    if config::is_connection_readonly(config, &conn.id) && kind != "select" {
+        audit.status = "blocked_readonly".to_string();
+        let msg = "Query blocked by Tabularis read-only mode. Enable writes for this connection in Settings → MCP → Read-only mode.".to_string();
+        audit.error = Some(msg.clone());
+        return Err(JsonRpcError {
+            code: -32000,
+            message: msg,
+            data: None,
+        });
+    }
+
+    // Approval gate
+    let approval_mode = config
+        .mcp_approval_mode
+        .clone()
+        .unwrap_or_else(|| DEFAULT_MCP_APPROVAL_MODE.to_string());
+    let needs_approval = match approval_mode.as_str() {
+        "off" => false,
+        "all" => true,
+        // writes_only — anything that isn't a clean select.
+        _ => kind != "select",
+    };
+
+    let mut effective_query: String = query.to_string();
+
+    if needs_approval {
+        let timeout_secs = config
+            .mcp_approval_timeout_seconds
+            .unwrap_or(DEFAULT_MCP_APPROVAL_TIMEOUT_SECONDS) as u64;
+        let want_explain = config
+            .mcp_preflight_explain
+            .unwrap_or(DEFAULT_MCP_PREFLIGHT_EXPLAIN);
+
+        // Pre-flight EXPLAIN — best effort, never blocks.
+        let (explain_plan, explain_error) = if want_explain {
+            let outcome =
+                preflight::preflight_explain(&conn.params.driver, &db_params, query, None).await;
+            (outcome.plan, outcome.error)
+        } else {
+            (None, None)
+        };
+
+        let approval_id = ai_approval::new_approval_id();
+        audit.approval_id = Some(approval_id.clone());
+
+        let pending = PendingApproval {
+            id: approval_id.clone(),
+            created_at: ai_activity::now_iso8601(),
+            session_id: session_id.to_string(),
+            connection_id: conn.id.clone(),
+            connection_name: conn.name.clone(),
+            query: query.to_string(),
+            query_kind: kind.to_string(),
+            client_hint: ai_activity::get_client_hint(),
+            explain_plan,
+            explain_error,
+        };
+
+        if let Err(e) = ai_approval::write_pending(&pending) {
+            audit.status = "error".to_string();
+            let msg = format!("Failed to enqueue approval request: {}", e);
+            audit.error = Some(msg.clone());
+            return Err(JsonRpcError {
+                code: -32000,
+                message: msg,
+                data: None,
+            });
+        }
+
+        match ai_approval::poll_decision(&approval_id, timeout_secs, APPROVAL_POLL_INTERVAL_MS)
+            .await
+        {
+            Ok(Some(decision)) => {
+                if decision.decision == "approve" {
+                    if let Some(edited) = decision
+                        .edited_query
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                    {
+                        effective_query = edited.to_string();
+                    }
+                } else {
+                    let reason = decision
+                        .reason
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .map(|r| format!(": {}", r))
+                        .unwrap_or_default();
+                    audit.status = "denied".to_string();
+                    let msg = format!("Query denied by user{}", reason);
+                    audit.error = Some(msg.clone());
+                    return Err(JsonRpcError {
+                        code: -32000,
+                        message: msg,
+                        data: None,
+                    });
+                }
+            }
+            Ok(None) => {
+                audit.status = "timeout".to_string();
+                let msg = format!(
+                    "Approval timed out after {}s — open Tabularis to approve writes",
+                    timeout_secs
+                );
+                audit.error = Some(msg.clone());
+                return Err(JsonRpcError {
+                    code: -32000,
+                    message: msg,
+                    data: None,
+                });
+            }
+            Err(e) => {
+                audit.status = "error".to_string();
+                audit.error = Some(e.clone());
+                return Err(JsonRpcError {
+                    code: -32000,
+                    message: e,
+                    data: None,
+                });
+            }
+        }
+    }
+
+    let result = match conn.params.driver.as_str() {
+        "mysql" => mysql::execute_query(&db_params, &effective_query, Some(100), 1, None).await,
+        "postgres" => {
+            postgres::execute_query(&db_params, &effective_query, Some(100), 1, None).await
+        }
+        "sqlite" => sqlite::execute_query(&db_params, &effective_query, Some(100), 1).await,
+        _ => Err("Unsupported driver".into()),
+    }
+    .map_err(|e| JsonRpcError {
+        code: -32000,
+        message: e,
+        data: None,
+    })?;
+
+    audit.rows = Some(result.rows.len());
+
+    Ok(json!({
+        "content": [{
+            "type": "text",
+            "text": serde_json::to_string_pretty(&result).unwrap()
+        }]
+    }))
+}
+

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -1,5 +1,5 @@
 use crate::ai_activity::{self, AiActivityEvent};
-use crate::ai_approval::{self, PendingApproval};
+use crate::ai_approval::{self, PendingApproval, PollOutcome};
 use crate::commands;
 use crate::config::{
     self, AppConfig, DEFAULT_AI_AUDIT_ENABLED, DEFAULT_AI_AUDIT_MAX_ENTRIES,
@@ -8,6 +8,7 @@ use crate::config::{
 };
 use crate::credential_cache;
 use crate::drivers::{mysql, postgres, sqlite};
+use crate::heartbeat;
 use crate::models::{ConnectionParams, SshConnection};
 use crate::paths;
 use crate::persistence;
@@ -855,6 +856,20 @@ async fn tool_run_query(
     let mut effective_query: String = query.to_string();
 
     if needs_approval {
+        // Fail fast if the GUI is not running — otherwise we'd queue a
+        // pending approval that nobody can approve and wait the full
+        // `mcp_approval_timeout_seconds` (default 120s) for nothing.
+        if !heartbeat::is_alive() {
+            audit.status = "host_unavailable".to_string();
+            let msg = "Tabularis app is not running — open it to approve writes".to_string();
+            audit.error = Some(msg.clone());
+            return Err(JsonRpcError {
+                code: -32000,
+                message: msg,
+                data: None,
+            });
+        }
+
         let timeout_secs = config
             .mcp_approval_timeout_seconds
             .unwrap_or(DEFAULT_MCP_APPROVAL_TIMEOUT_SECONDS) as u64;
@@ -898,10 +913,15 @@ async fn tool_run_query(
             });
         }
 
-        match ai_approval::poll_decision(&approval_id, timeout_secs, APPROVAL_POLL_INTERVAL_MS)
-            .await
+        match ai_approval::poll_decision_with_liveness(
+            &approval_id,
+            timeout_secs,
+            APPROVAL_POLL_INTERVAL_MS,
+            heartbeat::is_alive,
+        )
+        .await
         {
-            Ok(Some(decision)) => {
+            Ok(PollOutcome::Decided(decision)) => {
                 if decision.decision == "approve" {
                     if let Some(edited) = decision
                         .edited_query
@@ -929,12 +949,23 @@ async fn tool_run_query(
                     });
                 }
             }
-            Ok(None) => {
+            Ok(PollOutcome::TimedOut) => {
                 audit.status = "timeout".to_string();
                 let msg = format!(
                     "Approval timed out after {}s — open Tabularis to approve writes",
                     timeout_secs
                 );
+                audit.error = Some(msg.clone());
+                return Err(JsonRpcError {
+                    code: -32000,
+                    message: msg,
+                    data: None,
+                });
+            }
+            Ok(PollOutcome::HostUnavailable) => {
+                audit.status = "host_unavailable".to_string();
+                let msg =
+                    "Tabularis app closed during approval — open it to approve writes".to_string();
                 audit.error = Some(msg.clone());
                 return Err(JsonRpcError {
                     code: -32000,

--- a/src-tauri/src/mcp/preflight.rs
+++ b/src-tauri/src/mcp/preflight.rs
@@ -1,0 +1,57 @@
+//! Pre-flight EXPLAIN dispatch for the MCP approval gate.
+//!
+//! Wraps the existing per-driver `explain_query` functions and returns the
+//! plan as a `serde_json::Value` so it can be embedded in a `PendingApproval`
+//! file and rendered by the frontend's Visual Explain component.
+//!
+//! The wrapper is intentionally non-blocking: if EXPLAIN fails (DDL, missing
+//! permission, syntax error) we return the error string and let the caller
+//! decide whether to still surface the approval modal.
+
+use serde_json::Value;
+
+use crate::drivers::{mysql, postgres, sqlite};
+use crate::models::ConnectionParams;
+
+/// Result of a pre-flight EXPLAIN attempt.
+pub struct PreflightOutcome {
+    pub plan: Option<Value>,
+    pub error: Option<String>,
+}
+
+/// Run EXPLAIN against the given driver and return the plan as JSON.
+pub async fn preflight_explain(
+    driver: &str,
+    params: &ConnectionParams,
+    query: &str,
+    schema: Option<&str>,
+) -> PreflightOutcome {
+    let plan_result = match driver {
+        "postgres" => postgres::explain_query(params, query, false, schema).await,
+        "mysql" => mysql::explain_query(params, query, false, schema).await,
+        "sqlite" => sqlite::explain_query(params, query).await,
+        other => {
+            return PreflightOutcome {
+                plan: None,
+                error: Some(format!("EXPLAIN not supported for driver: {}", other)),
+            };
+        }
+    };
+
+    match plan_result {
+        Ok(plan) => match serde_json::to_value(&plan) {
+            Ok(v) => PreflightOutcome {
+                plan: Some(v),
+                error: None,
+            },
+            Err(e) => PreflightOutcome {
+                plan: None,
+                error: Some(e.to_string()),
+            },
+        },
+        Err(e) => PreflightOutcome {
+            plan: None,
+            error: Some(e),
+        },
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { ConnectionHealthMonitor } from "./components/ConnectionHealthMonitor";
 import { UpdateNotificationModal } from "./components/modals/UpdateNotificationModal";
 import { CommunityModal } from "./components/modals/CommunityModal";
 import { WhatsNewModal } from "./components/modals/WhatsNewModal";
+import { AiApprovalGate } from "./components/modals/AiApprovalGate";
 import { useUpdate } from "./hooks/useUpdate";
 import { useChangelog } from "./hooks/useChangelog";
 import { useSettings } from "./hooks/useSettings";
@@ -147,6 +148,8 @@ export function App() {
         entries={whatsNewEntries}
         isLoading={isChangelogLoading}
       />
+
+      <AiApprovalGate />
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { PluginModalProvider } from "./contexts/PluginModalProvider";
 import { AlertProvider } from "./contexts/AlertProvider";
 import { Connections } from "./pages/Connections";
 import { Editor } from "./pages/Editor";
+import { McpPage } from "./pages/McpPage";
 import { Settings } from "./pages/Settings";
 import { SchemaDiagramPage } from "./pages/SchemaDiagramPage";
 import { TaskManagerPage } from "./pages/TaskManagerPage";
@@ -111,6 +112,7 @@ export function App() {
                       />
                       <Route path="connections" element={<Connections />} />
                       <Route path="editor" element={<Editor />} />
+                      <Route path="mcp" element={<McpPage />} />
                       <Route path="settings" element={<Settings />} />
                     </Route>
                     <Route

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -7,7 +7,6 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { DISCORD_URL } from "../../config/links";
 import { useDatabase } from "../../hooks/useDatabase";
 import { useTheme } from "../../hooks/useTheme";
-import { McpModal } from "../modals/McpModal";
 import { SlotAnchor } from "../ui/SlotAnchor";
 
 // Sub-components
@@ -38,7 +37,6 @@ export const Sidebar = () => {
 
   const [isExplorerCollapsed, setIsExplorerCollapsed] = useState(false);
   const [sidebarTab, setSidebarTab] = useState<SidebarTab>("structure");
-  const [isMcpModalOpen, setIsMcpModalOpen] = useState(false);
   const [showShortcutHints, setShowShortcutHints] = useState(false);
   const { isMac } = useKeybindings();
 
@@ -163,6 +161,7 @@ export const Sidebar = () => {
     if (
       location.pathname === "/" ||
       location.pathname === "/connections" ||
+      location.pathname === "/mcp" ||
       location.pathname === "/settings"
     ) {
       navigate("/editor");
@@ -193,6 +192,7 @@ export const Sidebar = () => {
   const shouldShowExplorer =
     !!explorerConnId &&
     location.pathname !== "/settings" &&
+    location.pathname !== "/mcp" &&
     location.pathname !== "/connections";
 
   return (
@@ -275,17 +275,11 @@ export const Sidebar = () => {
             </span>
           </button>
 
-          <button
-            onClick={() => setIsMcpModalOpen(true)}
-            className="flex items-center justify-center w-12 h-12 rounded-lg transition-colors mb-2 relative group text-secondary hover:bg-surface-secondary hover:text-primary"
-          >
-            <div className="relative">
-              <Cpu size={24} />
-            </div>
-            <span className="absolute left-14 bg-surface-secondary text-primary text-xs px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap z-30 pointer-events-none">
-              MCP Server
-            </span>
-          </button>
+          <NavItem
+            to="/mcp"
+            icon={Cpu}
+            label={t("sidebar.mcpServer")}
+          />
 
           <NavItem
             to="/settings"
@@ -353,13 +347,6 @@ export const Sidebar = () => {
             </button>
           ))}
         </div>
-      )}
-
-      {isMcpModalOpen && (
-        <McpModal
-          isOpen={isMcpModalOpen}
-          onClose={() => setIsMcpModalOpen(false)}
-        />
       )}
     </div>
   );

--- a/src/components/modals/AiApprovalGate.tsx
+++ b/src/components/modals/AiApprovalGate.tsx
@@ -1,0 +1,43 @@
+import { usePendingApprovals } from "../../hooks/useAiActivity";
+import { AiApprovalModal } from "./AiApprovalModal";
+
+/// Listens for `ai://pending_approval` events emitted by the file watcher
+/// and presents one approval modal at a time. Mounted once at the App
+/// level, so it shows over any current page.
+export function AiApprovalGate() {
+  const { pending, decide } = usePendingApprovals();
+  const current = pending[0];
+  if (!current) return null;
+
+  const handleClose = () => {
+    // Closing without an explicit decision is treated as deny — the MCP
+    // subprocess is blocked waiting on us, so silent dismissal would just
+    // burn the timeout.
+    decide({
+      approvalId: current.id,
+      decision: "deny",
+      reason: "dismissed",
+    }).catch(() => {});
+  };
+
+  return (
+    <AiApprovalModal
+      approval={current}
+      onApprove={(editedQuery) =>
+        decide({
+          approvalId: current.id,
+          decision: "approve",
+          editedQuery,
+        })
+      }
+      onDeny={(reason) =>
+        decide({
+          approvalId: current.id,
+          decision: "deny",
+          reason,
+        })
+      }
+      onClose={handleClose}
+    />
+  );
+}

--- a/src/components/modals/AiApprovalModal.tsx
+++ b/src/components/modals/AiApprovalModal.tsx
@@ -1,0 +1,233 @@
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Check, ShieldAlert, X, Pencil } from "lucide-react";
+import Editor from "@monaco-editor/react";
+import { useTheme } from "../../hooks/useTheme";
+import { loadMonacoTheme } from "../../themes/themeUtils";
+import type { ExplainPlan } from "../../types/explain";
+import type { PendingApproval } from "../../types/ai";
+import { QueryKindBadge } from "../settings/ai-activity/QueryKindBadge";
+import { VisualExplainView } from "../explain/VisualExplainView";
+import type { ExplainViewMode } from "./visual-explain/ExplainSummaryBar";
+import { isDestructiveApproval } from "../../utils/aiActivity";
+
+interface AiApprovalModalProps {
+  approval: PendingApproval;
+  onApprove: (editedQuery?: string) => Promise<void> | void;
+  onDeny: (reason?: string) => Promise<void> | void;
+  onClose: () => void;
+}
+
+export function AiApprovalModal({
+  approval,
+  onApprove,
+  onDeny,
+  onClose,
+}: AiApprovalModalProps) {
+  const { t } = useTranslation();
+  const { currentTheme } = useTheme();
+  const [editing, setEditing] = useState(false);
+  const [editedQuery, setEditedQuery] = useState(approval.query);
+  const [reason, setReason] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [viewMode, setViewMode] = useState<ExplainViewMode>("graph");
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+
+  // Reset local state if a new pending arrives.
+  useEffect(() => {
+    setEditedQuery(approval.query);
+    setEditing(false);
+    setReason("");
+  }, [approval.id, approval.query]);
+
+  const explainPlan = useMemo<ExplainPlan | null>(() => {
+    if (!approval.explainPlan || typeof approval.explainPlan !== "object") {
+      return null;
+    }
+    return approval.explainPlan as ExplainPlan;
+  }, [approval.explainPlan]);
+
+  useEffect(() => {
+    if (explainPlan?.root.id && !selectedNodeId) {
+      setSelectedNodeId(explainPlan.root.id);
+    }
+  }, [explainPlan, selectedNodeId]);
+
+  const destructive = isDestructiveApproval(approval);
+
+  const handleApprove = async () => {
+    setSubmitting(true);
+    try {
+      const final = editing && editedQuery.trim() !== approval.query.trim()
+        ? editedQuery
+        : undefined;
+      await onApprove(final);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDeny = async () => {
+    setSubmitting(true);
+    try {
+      await onDeny(reason.trim() || undefined);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[120] backdrop-blur-sm">
+      <div className="bg-elevated border border-strong rounded-xl shadow-2xl w-[860px] max-w-[95vw] max-h-[92vh] overflow-hidden flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-default bg-base">
+          <div className="flex items-center gap-3 min-w-0">
+            <div
+              className={`p-2 rounded-lg ${
+                destructive ? "bg-red-900/30" : "bg-purple-900/30"
+              }`}
+            >
+              <ShieldAlert
+                size={20}
+                className={destructive ? "text-red-400" : "text-purple-400"}
+              />
+            </div>
+            <div className="min-w-0">
+              <h2 className="text-lg font-semibold text-primary truncate">
+                {t("aiApproval.title")}
+              </h2>
+              <p className="text-xs text-muted truncate">
+                {approval.clientHint
+                  ? t("aiApproval.subtitleWithClient", {
+                      client: approval.clientHint,
+                      connection: approval.connectionName,
+                    })
+                  : t("aiApproval.subtitle", {
+                      connection: approval.connectionName,
+                    })}
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            <QueryKindBadge kind={approval.queryKind} />
+            <button
+              onClick={onClose}
+              className="text-secondary hover:text-primary transition-colors"
+              aria-label={t("common.close")}
+            >
+              <X size={20} />
+            </button>
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="p-5 space-y-4 overflow-y-auto">
+          <section>
+            <div className="flex items-center justify-between mb-2">
+              <label className="text-xs uppercase font-bold text-muted">
+                {t("aiApproval.query")}
+              </label>
+              <button
+                onClick={() => setEditing((v) => !v)}
+                className="flex items-center gap-1 px-2 py-1 text-xs text-muted hover:text-primary hover:bg-surface-tertiary rounded transition-colors"
+              >
+                <Pencil size={11} />
+                {editing
+                  ? t("aiApproval.lockQuery")
+                  : t("aiApproval.editQuery")}
+              </button>
+            </div>
+            <div className="rounded-lg overflow-hidden border border-default">
+              <Editor
+                height="180px"
+                defaultLanguage="sql"
+                theme={currentTheme.id}
+                value={editing ? editedQuery : approval.query}
+                onChange={(v) => setEditedQuery(v ?? "")}
+                beforeMount={(monaco) => loadMonacoTheme(currentTheme, monaco)}
+                options={{
+                  readOnly: !editing,
+                  minimap: { enabled: false },
+                  scrollBeyondLastLine: false,
+                  fontSize: 12,
+                  padding: { top: 12, bottom: 12 },
+                  wordWrap: "on",
+                }}
+              />
+            </div>
+          </section>
+
+          <section>
+            <label className="text-xs uppercase font-bold text-muted mb-2 block">
+              {t("aiApproval.preflightPlan")}
+            </label>
+            {explainPlan ? (
+              <div className="rounded-lg border border-default bg-base h-[280px] overflow-hidden">
+                <VisualExplainView
+                  plan={explainPlan}
+                  isLoading={false}
+                  error={null}
+                  viewMode={viewMode}
+                  onViewModeChange={setViewMode}
+                  selectedNodeId={selectedNodeId}
+                  onSelectNode={setSelectedNodeId}
+                  aiEnabled={false}
+                />
+              </div>
+            ) : (
+              <div className="rounded-lg border border-default bg-base p-4 text-xs text-muted">
+                {approval.explainError
+                  ? t("aiApproval.explainFailed", {
+                      error: approval.explainError,
+                    })
+                  : t("aiApproval.explainUnavailable")}
+              </div>
+            )}
+          </section>
+
+          <section>
+            <label className="text-xs uppercase font-bold text-muted mb-2 block">
+              {t("aiApproval.reasonLabel")}
+            </label>
+            <input
+              type="text"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder={t("aiApproval.reasonPlaceholder")}
+              className="w-full px-3 py-2 bg-base border border-strong rounded-lg text-sm text-primary focus:outline-none focus:border-blue-500"
+            />
+          </section>
+        </div>
+
+        {/* Footer */}
+        <div className="p-4 border-t border-default bg-base/50 flex justify-between gap-3">
+          <button
+            onClick={handleDeny}
+            disabled={submitting}
+            className="flex items-center gap-2 px-4 py-2 bg-red-600 hover:bg-red-500 disabled:opacity-50 text-white rounded-lg text-sm font-medium transition-colors"
+          >
+            <X size={14} />
+            {t("aiApproval.deny")}
+          </button>
+          <div className="flex items-center gap-3">
+            <button
+              onClick={onClose}
+              disabled={submitting}
+              className="px-4 py-2 text-secondary hover:text-primary transition-colors text-sm"
+            >
+              {t("common.close")}
+            </button>
+            <button
+              onClick={handleApprove}
+              disabled={submitting}
+              className="flex items-center gap-2 px-4 py-2 bg-green-600 hover:bg-green-500 disabled:opacity-50 text-white rounded-lg text-sm font-medium transition-colors"
+            >
+              <Check size={14} />
+              {t("aiApproval.approve")}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/modals/AiApprovalModal.tsx
+++ b/src/components/modals/AiApprovalModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Check, ShieldAlert, X, Pencil } from "lucide-react";
+import { Check, ShieldAlert, X, Pencil, Maximize2, Minimize2 } from "lucide-react";
 import Editor from "@monaco-editor/react";
 import { useTheme } from "../../hooks/useTheme";
 import { loadMonacoTheme } from "../../themes/themeUtils";
@@ -32,13 +32,28 @@ export function AiApprovalModal({
   const [submitting, setSubmitting] = useState(false);
   const [viewMode, setViewMode] = useState<ExplainViewMode>("graph");
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [planExpanded, setPlanExpanded] = useState(false);
 
   // Reset local state if a new pending arrives.
   useEffect(() => {
     setEditedQuery(approval.query);
     setEditing(false);
     setReason("");
+    setPlanExpanded(false);
   }, [approval.id, approval.query]);
+
+  // Close the expanded plan overlay with Escape without dismissing the parent modal.
+  useEffect(() => {
+    if (!planExpanded) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        setPlanExpanded(false);
+      }
+    };
+    window.addEventListener("keydown", handler, true);
+    return () => window.removeEventListener("keydown", handler, true);
+  }, [planExpanded]);
 
   const explainPlan = useMemo<ExplainPlan | null>(() => {
     if (!approval.explainPlan || typeof approval.explainPlan !== "object") {
@@ -158,11 +173,23 @@ export function AiApprovalModal({
           </section>
 
           <section>
-            <label className="text-xs uppercase font-bold text-muted mb-2 block">
-              {t("aiApproval.preflightPlan")}
-            </label>
+            <div className="flex items-center justify-between mb-2">
+              <label className="text-xs uppercase font-bold text-muted">
+                {t("aiApproval.preflightPlan")}
+              </label>
+              {explainPlan && (
+                <button
+                  onClick={() => setPlanExpanded(true)}
+                  className="flex items-center gap-1 px-2 py-1 text-xs text-muted hover:text-primary hover:bg-surface-tertiary rounded transition-colors"
+                  title={t("aiApproval.expandPlan")}
+                >
+                  <Maximize2 size={11} />
+                  {t("aiApproval.expandPlan")}
+                </button>
+              )}
+            </div>
             {explainPlan ? (
-              <div className="rounded-lg border border-default bg-base h-[280px] overflow-hidden">
+              <div className="rounded-lg border border-default bg-base h-[360px] overflow-hidden">
                 <VisualExplainView
                   plan={explainPlan}
                   isLoading={false}
@@ -228,6 +255,45 @@ export function AiApprovalModal({
           </div>
         </div>
       </div>
+
+      {planExpanded && explainPlan && (
+        <div
+          className="fixed inset-0 bg-black/70 flex items-center justify-center z-[130] backdrop-blur-sm"
+          onClick={() => setPlanExpanded(false)}
+        >
+          <div
+            className="bg-elevated border border-strong rounded-xl shadow-2xl w-[95vw] h-[90vh] overflow-hidden flex flex-col"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between p-3 border-b border-default bg-base">
+              <h3 className="text-sm font-semibold text-primary">
+                {t("aiApproval.preflightPlan")}
+              </h3>
+              <button
+                onClick={() => setPlanExpanded(false)}
+                className="flex items-center gap-1 px-2 py-1 text-xs text-muted hover:text-primary hover:bg-surface-tertiary rounded transition-colors"
+                title={t("aiApproval.collapsePlan")}
+                aria-label={t("aiApproval.collapsePlan")}
+              >
+                <Minimize2 size={12} />
+                {t("aiApproval.collapsePlan")}
+              </button>
+            </div>
+            <div className="flex-1 min-h-0 bg-base">
+              <VisualExplainView
+                plan={explainPlan}
+                isLoading={false}
+                error={null}
+                viewMode={viewMode}
+                onViewModeChange={setViewMode}
+                selectedNodeId={selectedNodeId}
+                onSelectNode={setSelectedNodeId}
+                aiEnabled={false}
+              />
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/modals/McpModal.tsx
+++ b/src/components/modals/McpModal.tsx
@@ -13,6 +13,7 @@ import {
   WindsurfIcon,
   AntigravityIcon,
 } from "../icons/ClientIcons";
+import { McpSafetySection } from "./mcp/McpSafetySection";
 
 interface McpClientStatus {
   client_id: string;
@@ -279,6 +280,11 @@ export const McpModal = ({ isOpen, onClose }: McpModalProps) => {
                   </p>
                 </div>
               )}
+
+              {/* Safety controls — read-only mode + approval gate */}
+              <div className="pt-2 border-t border-default">
+                <McpSafetySection />
+              </div>
             </>
           )}
         </div>

--- a/src/components/modals/VisualExplainModal.tsx
+++ b/src/components/modals/VisualExplainModal.tsx
@@ -23,6 +23,10 @@ interface VisualExplainModalProps {
   query: string;
   connectionId: string;
   schema?: string;
+  /// Display label to use when the connection isn't loaded in the active
+  /// database context (e.g. opened from the AI Activity panel). Falls back
+  /// to the live connection name if available, then to `connectionId`.
+  connectionLabel?: string;
 }
 
 export const VisualExplainModal = ({
@@ -31,6 +35,7 @@ export const VisualExplainModal = ({
   query,
   connectionId,
   schema,
+  connectionLabel,
 }: VisualExplainModalProps) => {
   const { t } = useTranslation();
   const { settings } = useSettings();
@@ -50,7 +55,8 @@ export const VisualExplainModal = ({
   const driverManifest =
     allDrivers.find((driver) => driver.id === effectiveDriver) ?? null;
   const driverLabel = driverManifest?.name ?? effectiveDriver;
-  const connectionLabel = connectionData?.connectionName ?? connectionId;
+  const resolvedConnectionLabel =
+    connectionData?.connectionName ?? connectionLabel ?? connectionId;
   const schemaLabel = schema ?? connectionData?.activeSchema ?? null;
   const databaseLabel = connectionData?.databaseName ?? schema ?? "";
   const locationLabel =
@@ -111,7 +117,7 @@ export const VisualExplainModal = ({
                 <div className="inline-flex items-center gap-2 rounded-lg border border-default bg-surface-secondary/50 px-2.5 py-1 text-xs text-secondary">
                   <span className="text-primary">{getDriverIcon(driverManifest, 14)}</span>
                   <span className="font-medium text-primary">
-                    {connectionLabel}
+                    {resolvedConnectionLabel}
                   </span>
                 </div>
                 {locationLabel && (

--- a/src/components/modals/mcp/McpSafetySection.tsx
+++ b/src/components/modals/mcp/McpSafetySection.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { invoke } from "@tauri-apps/api/core";
+import { ShieldCheck, Lock } from "lucide-react";
+import { useSettings } from "../../../hooks/useSettings";
+import {
+  SettingRow,
+  SettingSection,
+  SettingToggle,
+  SettingButtonGroup,
+  SettingNumberInput,
+} from "../../settings/SettingControls";
+import type { McpApprovalMode } from "../../../types/ai";
+
+interface ConnectionItem {
+  id: string;
+  name: string;
+}
+
+/// Settings block embedded in McpModal: read-only + approval gate controls.
+export function McpSafetySection() {
+  const { t } = useTranslation();
+  const { settings, updateSetting } = useSettings();
+  const [connections, setConnections] = useState<ConnectionItem[]>([]);
+
+  useEffect(() => {
+    invoke<ConnectionItem[]>("get_connections")
+      .then((list) => setConnections(list.map((c) => ({ id: c.id, name: c.name }))))
+      .catch(() => setConnections([]));
+  }, []);
+
+  const readonlyDefault = settings.mcpReadonlyDefault ?? false;
+  const overrideList = settings.mcpReadonlyConnections ?? [];
+  const approvalMode = (settings.mcpApprovalMode ?? "writes_only") as McpApprovalMode;
+  const approvalTimeout = settings.mcpApprovalTimeoutSeconds ?? 120;
+  const preflightExplain = settings.mcpPreflightExplain ?? true;
+
+  const toggleConnection = (id: string) => {
+    const next = overrideList.includes(id)
+      ? overrideList.filter((c) => c !== id)
+      : [...overrideList, id];
+    updateSetting("mcpReadonlyConnections", next);
+  };
+
+  return (
+    <>
+      <SettingSection
+        title={t("mcp.safety.readOnlyTitle")}
+        icon={<Lock size={14} className="text-yellow-400" />}
+      >
+        <SettingRow
+          label={t("mcp.safety.readOnlyDefault")}
+          description={t("mcp.safety.readOnlyDefaultDesc")}
+        >
+          <SettingToggle
+            checked={readonlyDefault}
+            onChange={(v) => updateSetting("mcpReadonlyDefault", v)}
+          />
+        </SettingRow>
+
+        {connections.length > 0 && (
+          <SettingRow
+            label={
+              readonlyDefault
+                ? t("mcp.safety.allowList")
+                : t("mcp.safety.readOnlyList")
+            }
+            description={
+              readonlyDefault
+                ? t("mcp.safety.allowListDesc")
+                : t("mcp.safety.readOnlyListDesc")
+            }
+            vertical
+          >
+            <div className="space-y-1.5 max-h-48 overflow-auto pr-2">
+              {connections.map((c) => {
+                const checked = overrideList.includes(c.id);
+                return (
+                  <label
+                    key={c.id}
+                    className="flex items-center gap-2 text-sm text-secondary cursor-pointer hover:text-primary"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggleConnection(c.id)}
+                      className="accent-blue-500"
+                    />
+                    <span className="font-mono text-xs">{c.name}</span>
+                  </label>
+                );
+              })}
+            </div>
+          </SettingRow>
+        )}
+      </SettingSection>
+
+      <SettingSection
+        title={t("mcp.safety.approvalTitle")}
+        icon={<ShieldCheck size={14} className="text-purple-400" />}
+      >
+        <SettingRow
+          label={t("mcp.safety.approvalMode")}
+          description={t("mcp.safety.approvalModeDesc")}
+        >
+          <SettingButtonGroup<McpApprovalMode>
+            value={approvalMode}
+            onChange={(v) => updateSetting("mcpApprovalMode", v)}
+            options={[
+              { value: "off", label: t("mcp.safety.modeOff") },
+              { value: "writes_only", label: t("mcp.safety.modeWritesOnly") },
+              { value: "all", label: t("mcp.safety.modeAll") },
+            ]}
+          />
+        </SettingRow>
+
+        <SettingRow
+          label={t("mcp.safety.approvalTimeout")}
+          description={t("mcp.safety.approvalTimeoutDesc")}
+        >
+          <SettingNumberInput
+            value={approvalTimeout}
+            onChange={(v) => updateSetting("mcpApprovalTimeoutSeconds", v ?? 120)}
+            min={10}
+            max={600}
+            suffix={t("settings.seconds")}
+            fallback={120}
+          />
+        </SettingRow>
+
+        <SettingRow
+          label={t("mcp.safety.preflightExplain")}
+          description={t("mcp.safety.preflightExplainDesc")}
+        >
+          <SettingToggle
+            checked={preflightExplain}
+            onChange={(v) => updateSetting("mcpPreflightExplain", v)}
+          />
+        </SettingRow>
+      </SettingSection>
+    </>
+  );
+}

--- a/src/components/settings/AiActivityPanel.tsx
+++ b/src/components/settings/AiActivityPanel.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Activity, Layers } from "lucide-react";
+import clsx from "clsx";
+import { AiActivityEventsTab } from "./ai-activity/AiActivityEventsTab";
+import { AiActivitySessionsTab } from "./ai-activity/AiActivitySessionsTab";
+
+type AiActivityTab = "events" | "sessions";
+
+const TABS: Array<{
+  id: AiActivityTab;
+  icon: React.ComponentType<{ size: number }>;
+  labelKey: string;
+}> = [
+  { id: "events", icon: Activity, labelKey: "aiActivity.tabs.events" },
+  { id: "sessions", icon: Layers, labelKey: "aiActivity.tabs.sessions" },
+];
+
+export function AiActivityPanel() {
+  const { t } = useTranslation();
+  const [tab, setTab] = useState<AiActivityTab>("events");
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold text-primary">
+          {t("aiActivity.title")}
+        </h2>
+        <p className="text-xs text-muted mt-1">
+          {t("aiActivity.description")}
+        </p>
+      </div>
+
+      <div className="flex gap-1 border-b border-default">
+        {TABS.map(({ id, icon: Icon, labelKey }) => (
+          <button
+            key={id}
+            onClick={() => setTab(id)}
+            className={clsx(
+              "flex items-center gap-2 px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
+              tab === id
+                ? "text-primary border-blue-500"
+                : "text-muted border-transparent hover:text-primary",
+            )}
+          >
+            <Icon size={14} />
+            {t(labelKey)}
+          </button>
+        ))}
+      </div>
+
+      {tab === "events" ? <AiActivityEventsTab /> : <AiActivitySessionsTab />}
+    </div>
+  );
+}

--- a/src/components/settings/ai-activity/AiActivityEventsTab.tsx
+++ b/src/components/settings/ai-activity/AiActivityEventsTab.tsx
@@ -1,0 +1,353 @@
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Copy, Eye, GitGraph, Trash2, Download, RefreshCw } from "lucide-react";
+import { save as saveDialog } from "@tauri-apps/plugin-dialog";
+import { writeTextFile } from "@tauri-apps/plugin-fs";
+import {
+  clearAiActivity,
+  exportAiActivityCsv,
+  exportAiActivityJson,
+  useAiActivityEvents,
+} from "../../../hooks/useAiActivity";
+import { formatDurationMs, truncateQuery } from "../../../utils/aiActivity";
+import type { AiActivityEvent, AiEventFilter } from "../../../types/ai";
+import { useAlert } from "../../../hooks/useAlert";
+import { StatusBadge } from "./StatusBadge";
+import { QueryKindBadge } from "./QueryKindBadge";
+import { EventDetailModal } from "./EventDetailModal";
+import { VisualExplainModal } from "../../modals/VisualExplainModal";
+
+interface ExplainTarget {
+  query: string;
+  connectionId: string;
+  connectionName: string | null;
+}
+
+export function AiActivityEventsTab() {
+  const { t } = useTranslation();
+  const { showAlert } = useAlert();
+  const [filter, setFilter] = useState<AiEventFilter>({});
+  const [detail, setDetail] = useState<AiActivityEvent | null>(null);
+  const [explainTarget, setExplainTarget] = useState<ExplainTarget | null>(
+    null,
+  );
+  const { events, loading, refetch } = useAiActivityEvents(filter);
+
+  const stats = useMemo(() => {
+    const errors = events.filter(
+      (e) => e.status === "error" || e.status === "denied" || e.status === "timeout",
+    ).length;
+    const blocked = events.filter((e) =>
+      e.status.startsWith("blocked"),
+    ).length;
+    return { total: events.length, errors, blocked };
+  }, [events]);
+
+  const handleClear = async () => {
+    if (!confirm(t("aiActivity.clearConfirm"))) return;
+    try {
+      await clearAiActivity();
+      await refetch();
+    } catch (err) {
+      showAlert(String(err), { kind: "error", title: t("common.error") });
+    }
+  };
+
+  const handleExport = async (format: "json" | "csv") => {
+    try {
+      const content =
+        format === "json" ? await exportAiActivityJson() : await exportAiActivityCsv();
+      const target = await saveDialog({
+        defaultPath:
+          format === "json" ? "ai-activity.jsonl" : "ai-activity.csv",
+        filters: [
+          {
+            name: format === "json" ? "JSON Lines" : "CSV",
+            extensions: [format === "json" ? "jsonl" : "csv"],
+          },
+        ],
+      });
+      if (typeof target === "string" && target.length > 0) {
+        await writeTextFile(target, content);
+        showAlert(t("aiActivity.exportSuccess", { path: target }), {
+          kind: "info",
+        });
+      }
+    } catch (err) {
+      showAlert(String(err), { kind: "error", title: t("common.error") });
+    }
+  };
+
+  const handleOpenInVisualExplain = (ev: AiActivityEvent) => {
+    if (!ev.query || !ev.connectionId) return;
+    setExplainTarget({
+      query: ev.query,
+      connectionId: ev.connectionId,
+      connectionName: ev.connectionName,
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      <FiltersBar
+        filter={filter}
+        onFilterChange={setFilter}
+        onRefresh={refetch}
+        onClear={handleClear}
+        onExportJson={() => handleExport("json")}
+        onExportCsv={() => handleExport("csv")}
+      />
+
+      <div className="flex items-center gap-3 text-xs text-muted">
+        <span>
+          {t("aiActivity.eventsCount", { count: stats.total })}
+        </span>
+        {stats.blocked > 0 && (
+          <span className="text-yellow-400">
+            · {t("aiActivity.blockedCount", { count: stats.blocked })}
+          </span>
+        )}
+        {stats.errors > 0 && (
+          <span className="text-red-400">
+            · {t("aiActivity.errorsCount", { count: stats.errors })}
+          </span>
+        )}
+      </div>
+
+      <EventsTable
+        events={events}
+        loading={loading}
+        onView={setDetail}
+        onCopyQuery={(q) => {
+          navigator.clipboard.writeText(q);
+          showAlert(t("aiActivity.copied"), { kind: "info" });
+        }}
+        onOpenInVisualExplain={handleOpenInVisualExplain}
+      />
+
+      {detail && (
+        <EventDetailModal event={detail} onClose={() => setDetail(null)} />
+      )}
+
+      <VisualExplainModal
+        isOpen={explainTarget !== null}
+        onClose={() => setExplainTarget(null)}
+        query={explainTarget?.query ?? ""}
+        connectionId={explainTarget?.connectionId ?? ""}
+        connectionLabel={explainTarget?.connectionName ?? undefined}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components — kept inside the file because they only make sense inside
+// the events tab and never get reused.
+// ---------------------------------------------------------------------------
+
+interface FiltersBarProps {
+  filter: AiEventFilter;
+  onFilterChange: (f: AiEventFilter) => void;
+  onRefresh: () => void;
+  onClear: () => void;
+  onExportJson: () => void;
+  onExportCsv: () => void;
+}
+
+function FiltersBar({
+  filter,
+  onFilterChange,
+  onRefresh,
+  onClear,
+  onExportJson,
+  onExportCsv,
+}: FiltersBarProps) {
+  const { t } = useTranslation();
+  const update = (patch: Partial<AiEventFilter>) =>
+    onFilterChange({ ...filter, ...patch });
+
+  return (
+    <div className="bg-surface-secondary/40 rounded-lg p-3 flex flex-wrap items-center gap-2 border border-default">
+      <input
+        type="text"
+        placeholder={t("aiActivity.searchQuery")}
+        value={filter.queryContains ?? ""}
+        onChange={(e) =>
+          update({ queryContains: e.target.value || undefined })
+        }
+        className="flex-1 min-w-[180px] bg-base border border-strong rounded px-3 py-1.5 text-xs text-primary focus:outline-none focus:border-blue-500"
+      />
+      <select
+        value={filter.tool ?? ""}
+        onChange={(e) => update({ tool: e.target.value || undefined })}
+        className="bg-base border border-strong rounded px-2 py-1.5 text-xs text-primary focus:outline-none focus:border-blue-500"
+      >
+        <option value="">{t("aiActivity.allTools")}</option>
+        <option value="list_connections">list_connections</option>
+        <option value="list_tables">list_tables</option>
+        <option value="describe_table">describe_table</option>
+        <option value="run_query">run_query</option>
+      </select>
+      <select
+        value={filter.status ?? ""}
+        onChange={(e) =>
+          update({
+            status: (e.target.value || undefined) as AiEventFilter["status"],
+          })
+        }
+        className="bg-base border border-strong rounded px-2 py-1.5 text-xs text-primary focus:outline-none focus:border-blue-500"
+      >
+        <option value="">{t("aiActivity.allStatuses")}</option>
+        <option value="success">{t("aiActivity.status.success")}</option>
+        <option value="error">{t("aiActivity.status.error")}</option>
+        <option value="denied">{t("aiActivity.status.denied")}</option>
+        <option value="timeout">{t("aiActivity.status.timeout")}</option>
+        <option value="blocked_readonly">
+          {t("aiActivity.status.blocked_readonly")}
+        </option>
+      </select>
+      <button
+        onClick={onRefresh}
+        className="p-1.5 text-muted hover:text-primary hover:bg-surface-tertiary rounded transition-colors"
+        title={t("common.refresh", { defaultValue: "Refresh" })}
+      >
+        <RefreshCw size={14} />
+      </button>
+      <button
+        onClick={onExportCsv}
+        className="flex items-center gap-1 px-2.5 py-1.5 text-xs text-muted hover:text-primary hover:bg-surface-tertiary rounded transition-colors"
+      >
+        <Download size={12} /> CSV
+      </button>
+      <button
+        onClick={onExportJson}
+        className="flex items-center gap-1 px-2.5 py-1.5 text-xs text-muted hover:text-primary hover:bg-surface-tertiary rounded transition-colors"
+      >
+        <Download size={12} /> JSON
+      </button>
+      <button
+        onClick={onClear}
+        className="flex items-center gap-1 px-2.5 py-1.5 text-xs text-red-400 hover:text-red-300 hover:bg-red-900/20 rounded transition-colors"
+      >
+        <Trash2 size={12} /> {t("aiActivity.clearAll")}
+      </button>
+    </div>
+  );
+}
+
+interface EventsTableProps {
+  events: AiActivityEvent[];
+  loading: boolean;
+  onView: (event: AiActivityEvent) => void;
+  onCopyQuery: (query: string) => void;
+  onOpenInVisualExplain: (event: AiActivityEvent) => void;
+}
+
+function EventsTable({
+  events,
+  loading,
+  onView,
+  onCopyQuery,
+  onOpenInVisualExplain,
+}: EventsTableProps) {
+  const { t } = useTranslation();
+  if (loading && events.length === 0) {
+    return (
+      <div className="text-center py-12 text-muted text-sm">
+        {t("common.loading")}
+      </div>
+    );
+  }
+  if (events.length === 0) {
+    return (
+      <div className="text-center py-12 text-muted text-sm">
+        {t("aiActivity.empty")}
+      </div>
+    );
+  }
+  return (
+    <div className="border border-default rounded-lg overflow-hidden">
+      <div className="max-h-[500px] overflow-auto">
+        <table className="w-full text-xs">
+          <thead className="bg-surface-secondary sticky top-0">
+            <tr className="text-muted text-left">
+              <th className="px-3 py-2 font-medium">
+                {t("aiActivity.col.timestamp")}
+              </th>
+              <th className="px-3 py-2 font-medium">{t("aiActivity.col.tool")}</th>
+              <th className="px-3 py-2 font-medium">
+                {t("aiActivity.col.connection")}
+              </th>
+              <th className="px-3 py-2 font-medium">{t("aiActivity.col.query")}</th>
+              <th className="px-3 py-2 font-medium">{t("aiActivity.col.kind")}</th>
+              <th className="px-3 py-2 font-medium text-right">
+                {t("aiActivity.col.duration")}
+              </th>
+              <th className="px-3 py-2 font-medium">{t("aiActivity.col.status")}</th>
+              <th className="px-3 py-2 font-medium text-right">
+                {t("aiActivity.col.actions")}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {events.map((ev) => (
+              <tr
+                key={ev.id}
+                className="border-t border-default hover:bg-surface-tertiary/30"
+              >
+                <td className="px-3 py-2 text-muted font-mono whitespace-nowrap">
+                  {ev.timestamp.replace("T", " ").slice(0, 19)}
+                </td>
+                <td className="px-3 py-2 text-primary font-mono">{ev.tool}</td>
+                <td className="px-3 py-2 text-muted">
+                  {ev.connectionName ?? "—"}
+                </td>
+                <td className="px-3 py-2 text-secondary font-mono max-w-[260px] truncate">
+                  {truncateQuery(ev.query, 80) || "—"}
+                </td>
+                <td className="px-3 py-2">
+                  <QueryKindBadge kind={ev.queryKind} />
+                </td>
+                <td className="px-3 py-2 text-muted text-right whitespace-nowrap">
+                  {formatDurationMs(ev.durationMs)}
+                </td>
+                <td className="px-3 py-2">
+                  <StatusBadge status={ev.status} />
+                </td>
+                <td className="px-3 py-2">
+                  <div className="flex items-center justify-end gap-1">
+                    <button
+                      onClick={() => onView(ev)}
+                      className="p-1 text-muted hover:text-primary hover:bg-surface-tertiary rounded"
+                      title={t("aiActivity.viewDetails")}
+                    >
+                      <Eye size={12} />
+                    </button>
+                    {ev.query && (
+                      <button
+                        onClick={() => onCopyQuery(ev.query!)}
+                        className="p-1 text-muted hover:text-primary hover:bg-surface-tertiary rounded"
+                        title={t("aiActivity.copyQuery")}
+                      >
+                        <Copy size={12} />
+                      </button>
+                    )}
+                    {ev.tool === "run_query" && ev.query && ev.connectionId && (
+                      <button
+                        onClick={() => onOpenInVisualExplain(ev)}
+                        className="p-1 text-muted hover:text-green-400 hover:bg-green-900/20 rounded"
+                        title={t("aiActivity.openVisualExplain")}
+                      >
+                        <GitGraph size={12} />
+                      </button>
+                    )}
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/ai-activity/AiActivityEventsTab.tsx
+++ b/src/components/settings/ai-activity/AiActivityEventsTab.tsx
@@ -1,6 +1,9 @@
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
   Copy,
   Download,
   Eye,
@@ -17,7 +20,13 @@ import {
   exportAiActivityJson,
   useAiActivityEvents,
 } from "../../../hooks/useAiActivity";
-import { formatDurationMs, truncateQuery } from "../../../utils/aiActivity";
+import {
+  formatDurationMs,
+  sortAiEvents,
+  truncateQuery,
+  type EventSortField,
+  type SortDirection,
+} from "../../../utils/aiActivity";
 import type { AiActivityEvent, AiEventFilter } from "../../../types/ai";
 import { useAlert } from "../../../hooks/useAlert";
 import { StatusBadge } from "./StatusBadge";
@@ -108,6 +117,7 @@ export function AiActivityEventsTab() {
         onClear={handleClear}
         onExportJson={() => handleExport("json")}
         onExportCsv={() => handleExport("csv")}
+        refreshing={loading}
       />
 
       <div className="flex flex-wrap items-center gap-2 text-xs">
@@ -160,10 +170,11 @@ export function AiActivityEventsTab() {
 interface FiltersBarProps {
   filter: AiEventFilter;
   onFilterChange: (f: AiEventFilter) => void;
-  onRefresh: () => void;
+  onRefresh: () => void | Promise<void>;
   onClear: () => void;
   onExportJson: () => void;
   onExportCsv: () => void;
+  refreshing: boolean;
 }
 
 function FiltersBar({
@@ -173,6 +184,7 @@ function FiltersBar({
   onClear,
   onExportJson,
   onExportCsv,
+  refreshing,
 }: FiltersBarProps) {
   const { t } = useTranslation();
   const update = (patch: Partial<AiEventFilter>) =>
@@ -204,8 +216,8 @@ function FiltersBar({
 
   return (
     <div className="rounded-lg border border-default bg-surface-secondary/25 p-3">
-      <div className="grid grid-cols-1 gap-2 lg:grid-cols-[minmax(220px,1fr)_180px_190px_auto]">
-        <div className="relative min-w-0">
+      <div className="flex flex-col gap-2 lg:flex-row lg:items-center">
+        <div className="relative min-w-0 flex-1 lg:max-w-md">
           <Search
             size={14}
             className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted"
@@ -220,51 +232,63 @@ function FiltersBar({
             className="h-9 w-full rounded border border-strong bg-base pl-9 pr-3 text-sm text-primary placeholder:text-muted focus:border-blue-500 focus:outline-none"
           />
         </div>
-        <Select
-          value={filter.tool ?? ""}
-          options={toolOptions}
-          labels={toolLabels}
-          onChange={(value) => update({ tool: value || undefined })}
-          placeholder={t("aiActivity.allTools")}
-          searchable={false}
-          className="min-w-0"
-        />
-        <Select
-          value={filter.status ?? ""}
-          options={statusOptions}
-          labels={statusLabels}
-          onChange={(value) =>
-            update({
-              status: (value || undefined) as AiEventFilter["status"],
-            })
-          }
-          placeholder={t("aiActivity.allStatuses")}
-          searchable={false}
-          className="min-w-0"
-        />
-        <div className="flex items-center justify-end gap-1">
+        <div className="grid grid-cols-2 gap-2 lg:flex lg:flex-1 lg:items-center lg:gap-2">
+          <Select
+            value={filter.tool ?? ""}
+            options={toolOptions}
+            labels={toolLabels}
+            onChange={(value) => update({ tool: value || undefined })}
+            placeholder={t("aiActivity.allTools")}
+            searchable={false}
+            className="min-w-0 lg:w-[180px]"
+          />
+          <Select
+            value={filter.status ?? ""}
+            options={statusOptions}
+            labels={statusLabels}
+            onChange={(value) =>
+              update({
+                status: (value || undefined) as AiEventFilter["status"],
+              })
+            }
+            placeholder={t("aiActivity.allStatuses")}
+            searchable={false}
+            className="min-w-0 lg:w-[190px]"
+          />
+        </div>
+        <div className="flex items-center justify-end gap-1 lg:ml-auto">
           <button
-            onClick={onRefresh}
-            className="flex h-9 w-9 items-center justify-center rounded text-muted transition-colors hover:bg-surface-tertiary hover:text-primary"
+            onClick={() => onRefresh()}
+            disabled={refreshing}
+            className="flex h-9 w-9 items-center justify-center rounded border border-strong bg-base text-muted transition-colors hover:bg-surface-tertiary hover:text-primary disabled:cursor-not-allowed disabled:opacity-60"
             title={t("common.refresh", { defaultValue: "Refresh" })}
+            aria-label={t("common.refresh", { defaultValue: "Refresh" })}
           >
-            <RefreshCw size={14} />
+            <RefreshCw size={14} className={refreshing ? "animate-spin" : ""} />
           </button>
-          <button
-            onClick={onExportCsv}
-            className="flex h-9 items-center gap-1.5 rounded px-2.5 text-xs text-muted transition-colors hover:bg-surface-tertiary hover:text-primary"
-          >
-            <Download size={12} /> CSV
-          </button>
-          <button
-            onClick={onExportJson}
-            className="flex h-9 items-center gap-1.5 rounded px-2.5 text-xs text-muted transition-colors hover:bg-surface-tertiary hover:text-primary"
-          >
-            <Download size={12} /> JSON
-          </button>
+          <div className="mx-1 h-6 w-px bg-default" aria-hidden />
+          <div className="flex items-center overflow-hidden rounded border border-strong bg-base">
+            <button
+              onClick={onExportCsv}
+              className="flex h-9 items-center gap-1.5 px-2.5 text-xs text-muted transition-colors hover:bg-surface-tertiary hover:text-primary"
+              title={t("aiActivity.exportCsv", { defaultValue: "Export CSV" })}
+            >
+              <Download size={12} /> CSV
+            </button>
+            <div className="h-5 w-px bg-default" aria-hidden />
+            <button
+              onClick={onExportJson}
+              className="flex h-9 items-center gap-1.5 px-2.5 text-xs text-muted transition-colors hover:bg-surface-tertiary hover:text-primary"
+              title={t("aiActivity.exportJson", { defaultValue: "Export JSON" })}
+            >
+              <Download size={12} /> JSON
+            </button>
+          </div>
+          <div className="mx-1 h-6 w-px bg-default" aria-hidden />
           <button
             onClick={onClear}
-            className="flex h-9 items-center gap-1.5 rounded px-2.5 text-xs text-red-400 transition-colors hover:bg-red-900/20 hover:text-red-300"
+            className="flex h-9 items-center gap-1.5 rounded border border-red-900/40 bg-red-900/10 px-2.5 text-xs text-red-400 transition-colors hover:bg-red-900/30 hover:text-red-300"
+            title={t("aiActivity.clearAll")}
           >
             <Trash2 size={12} /> {t("aiActivity.clearAll")}
           </button>
@@ -290,6 +314,23 @@ function EventsTable({
   onOpenInVisualExplain,
 }: EventsTableProps) {
   const { t } = useTranslation();
+  const [sortField, setSortField] = useState<EventSortField>("timestamp");
+  const [sortDir, setSortDir] = useState<SortDirection>("desc");
+
+  const sortedEvents = useMemo(
+    () => sortAiEvents(events, sortField, sortDir),
+    [events, sortField, sortDir],
+  );
+
+  const toggleSort = (field: EventSortField) => {
+    if (field === sortField) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortField(field);
+      setSortDir(field === "timestamp" || field === "duration" ? "desc" : "asc");
+    }
+  };
+
   if (loading && events.length === 0) {
     return (
       <div className="text-center py-12 text-muted text-sm">
@@ -310,34 +351,65 @@ function EventsTable({
         <table className="w-full table-fixed text-xs">
           <thead className="sticky top-0 z-10 bg-surface-secondary">
             <tr className="text-left text-muted">
-              <th className="w-[9.5rem] px-3 py-2 font-medium">
-                {t("aiActivity.col.timestamp")}
-              </th>
-              <th className="w-[8.5rem] px-3 py-2 font-medium">
-                {t("aiActivity.col.tool")}
-              </th>
-              <th className="w-[8rem] px-3 py-2 font-medium">
-                {t("aiActivity.col.connection")}
-              </th>
+              <SortableHeader
+                field="timestamp"
+                label={t("aiActivity.col.timestamp")}
+                activeField={sortField}
+                direction={sortDir}
+                onToggle={toggleSort}
+                className="w-[9.5rem]"
+              />
+              <SortableHeader
+                field="tool"
+                label={t("aiActivity.col.tool")}
+                activeField={sortField}
+                direction={sortDir}
+                onToggle={toggleSort}
+                className="w-[8.5rem]"
+              />
+              <SortableHeader
+                field="connection"
+                label={t("aiActivity.col.connection")}
+                activeField={sortField}
+                direction={sortDir}
+                onToggle={toggleSort}
+                className="w-[8rem]"
+              />
               <th className="px-3 py-2 font-medium">
                 {t("aiActivity.col.query")}
               </th>
-              <th className="w-[5.5rem] px-3 py-2 font-medium">
-                {t("aiActivity.col.kind")}
-              </th>
-              <th className="w-[5.5rem] px-3 py-2 text-right font-medium">
-                {t("aiActivity.col.duration")}
-              </th>
-              <th className="w-[9.5rem] px-3 py-2 font-medium">
-                {t("aiActivity.col.status")}
-              </th>
+              <SortableHeader
+                field="kind"
+                label={t("aiActivity.col.kind")}
+                activeField={sortField}
+                direction={sortDir}
+                onToggle={toggleSort}
+                className="w-[5.5rem]"
+              />
+              <SortableHeader
+                field="duration"
+                label={t("aiActivity.col.duration")}
+                activeField={sortField}
+                direction={sortDir}
+                onToggle={toggleSort}
+                className="w-[5.5rem]"
+                align="right"
+              />
+              <SortableHeader
+                field="status"
+                label={t("aiActivity.col.status")}
+                activeField={sortField}
+                direction={sortDir}
+                onToggle={toggleSort}
+                className="w-[9.5rem]"
+              />
               <th className="w-[5.25rem] px-3 py-2 text-right font-medium">
                 {t("aiActivity.col.actions")}
               </th>
             </tr>
           </thead>
           <tbody>
-            {events.map((ev) => (
+            {sortedEvents.map((ev) => (
               <tr
                 key={ev.id}
                 className="border-t border-default transition-colors hover:bg-surface-tertiary/25"
@@ -401,5 +473,59 @@ function EventsTable({
         </table>
       </div>
     </div>
+  );
+}
+
+interface SortableHeaderProps {
+  field: EventSortField;
+  label: string;
+  activeField: EventSortField;
+  direction: SortDirection;
+  onToggle: (field: EventSortField) => void;
+  className?: string;
+  align?: "left" | "right";
+}
+
+function SortableHeader({
+  field,
+  label,
+  activeField,
+  direction,
+  onToggle,
+  className,
+  align = "left",
+}: SortableHeaderProps) {
+  const { t } = useTranslation();
+  const isActive = field === activeField;
+  const Icon = isActive ? (direction === "asc" ? ArrowUp : ArrowDown) : ArrowUpDown;
+  const ariaSort = isActive
+    ? direction === "asc"
+      ? "ascending"
+      : "descending"
+    : "none";
+  const nextLabel = isActive
+    ? direction === "asc"
+      ? t("aiActivity.sort.toggleDescending", { defaultValue: "Sort descending" })
+      : t("aiActivity.sort.toggleAscending", { defaultValue: "Sort ascending" })
+    : t("aiActivity.sort.sortBy", { defaultValue: "Sort by {{field}}", field: label });
+  return (
+    <th
+      className={`${className ?? ""} px-3 py-2 font-medium ${
+        align === "right" ? "text-right" : "text-left"
+      }`}
+      aria-sort={ariaSort}
+    >
+      <button
+        type="button"
+        onClick={() => onToggle(field)}
+        title={nextLabel}
+        className={`inline-flex items-center gap-1 rounded px-1 py-0.5 -mx-1 transition-colors hover:text-primary ${
+          isActive ? "text-primary" : ""
+        } ${align === "right" ? "flex-row-reverse" : ""}`}
+      >
+        <span>{label}</span>
+        <Icon size={11} className={isActive ? "" : "opacity-60"} />
+      </button>
+    </th>
   );
 }

--- a/src/components/settings/ai-activity/AiActivityEventsTab.tsx
+++ b/src/components/settings/ai-activity/AiActivityEventsTab.tsx
@@ -1,6 +1,14 @@
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Copy, Eye, GitGraph, Trash2, Download, RefreshCw } from "lucide-react";
+import {
+  Copy,
+  Download,
+  Eye,
+  GitGraph,
+  RefreshCw,
+  Search,
+  Trash2,
+} from "lucide-react";
 import { save as saveDialog } from "@tauri-apps/plugin-dialog";
 import { writeTextFile } from "@tauri-apps/plugin-fs";
 import {
@@ -16,6 +24,7 @@ import { StatusBadge } from "./StatusBadge";
 import { QueryKindBadge } from "./QueryKindBadge";
 import { EventDetailModal } from "./EventDetailModal";
 import { VisualExplainModal } from "../../modals/VisualExplainModal";
+import { Select } from "../../ui/Select";
 
 interface ExplainTarget {
   query: string;
@@ -35,7 +44,10 @@ export function AiActivityEventsTab() {
 
   const stats = useMemo(() => {
     const errors = events.filter(
-      (e) => e.status === "error" || e.status === "denied" || e.status === "timeout",
+      (e) =>
+        e.status === "error" ||
+        e.status === "denied" ||
+        e.status === "timeout",
     ).length;
     const blocked = events.filter((e) =>
       e.status.startsWith("blocked"),
@@ -88,7 +100,7 @@ export function AiActivityEventsTab() {
   };
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 min-w-0">
       <FiltersBar
         filter={filter}
         onFilterChange={setFilter}
@@ -98,18 +110,18 @@ export function AiActivityEventsTab() {
         onExportCsv={() => handleExport("csv")}
       />
 
-      <div className="flex items-center gap-3 text-xs text-muted">
-        <span>
+      <div className="flex flex-wrap items-center gap-2 text-xs">
+        <span className="inline-flex items-center rounded-full border border-default bg-base/50 px-2.5 py-1 text-muted">
           {t("aiActivity.eventsCount", { count: stats.total })}
         </span>
         {stats.blocked > 0 && (
-          <span className="text-yellow-400">
-            · {t("aiActivity.blockedCount", { count: stats.blocked })}
+          <span className="inline-flex items-center rounded-full border border-yellow-500/30 bg-yellow-500/10 px-2.5 py-1 text-yellow-300">
+            {t("aiActivity.blockedCount", { count: stats.blocked })}
           </span>
         )}
         {stats.errors > 0 && (
-          <span className="text-red-400">
-            · {t("aiActivity.errorsCount", { count: stats.errors })}
+          <span className="inline-flex items-center rounded-full border border-red-500/30 bg-red-500/10 px-2.5 py-1 text-red-300">
+            {t("aiActivity.errorsCount", { count: stats.errors })}
           </span>
         )}
       </div>
@@ -165,72 +177,99 @@ function FiltersBar({
   const { t } = useTranslation();
   const update = (patch: Partial<AiEventFilter>) =>
     onFilterChange({ ...filter, ...patch });
+  const toolOptions = [
+    "",
+    "list_connections",
+    "list_tables",
+    "describe_table",
+    "run_query",
+  ];
+  const statusOptions = [
+    "",
+    "success",
+    "error",
+    "denied",
+    "timeout",
+    "blocked_readonly",
+  ];
+  const toolLabels = { "": t("aiActivity.allTools") };
+  const statusLabels = {
+    "": t("aiActivity.allStatuses"),
+    success: t("aiActivity.status.success"),
+    error: t("aiActivity.status.error"),
+    denied: t("aiActivity.status.denied"),
+    timeout: t("aiActivity.status.timeout"),
+    blocked_readonly: t("aiActivity.status.blocked_readonly"),
+  };
 
   return (
-    <div className="bg-surface-secondary/40 rounded-lg p-3 flex flex-wrap items-center gap-2 border border-default">
-      <input
-        type="text"
-        placeholder={t("aiActivity.searchQuery")}
-        value={filter.queryContains ?? ""}
-        onChange={(e) =>
-          update({ queryContains: e.target.value || undefined })
-        }
-        className="flex-1 min-w-[180px] bg-base border border-strong rounded px-3 py-1.5 text-xs text-primary focus:outline-none focus:border-blue-500"
-      />
-      <select
-        value={filter.tool ?? ""}
-        onChange={(e) => update({ tool: e.target.value || undefined })}
-        className="bg-base border border-strong rounded px-2 py-1.5 text-xs text-primary focus:outline-none focus:border-blue-500"
-      >
-        <option value="">{t("aiActivity.allTools")}</option>
-        <option value="list_connections">list_connections</option>
-        <option value="list_tables">list_tables</option>
-        <option value="describe_table">describe_table</option>
-        <option value="run_query">run_query</option>
-      </select>
-      <select
-        value={filter.status ?? ""}
-        onChange={(e) =>
-          update({
-            status: (e.target.value || undefined) as AiEventFilter["status"],
-          })
-        }
-        className="bg-base border border-strong rounded px-2 py-1.5 text-xs text-primary focus:outline-none focus:border-blue-500"
-      >
-        <option value="">{t("aiActivity.allStatuses")}</option>
-        <option value="success">{t("aiActivity.status.success")}</option>
-        <option value="error">{t("aiActivity.status.error")}</option>
-        <option value="denied">{t("aiActivity.status.denied")}</option>
-        <option value="timeout">{t("aiActivity.status.timeout")}</option>
-        <option value="blocked_readonly">
-          {t("aiActivity.status.blocked_readonly")}
-        </option>
-      </select>
-      <button
-        onClick={onRefresh}
-        className="p-1.5 text-muted hover:text-primary hover:bg-surface-tertiary rounded transition-colors"
-        title={t("common.refresh", { defaultValue: "Refresh" })}
-      >
-        <RefreshCw size={14} />
-      </button>
-      <button
-        onClick={onExportCsv}
-        className="flex items-center gap-1 px-2.5 py-1.5 text-xs text-muted hover:text-primary hover:bg-surface-tertiary rounded transition-colors"
-      >
-        <Download size={12} /> CSV
-      </button>
-      <button
-        onClick={onExportJson}
-        className="flex items-center gap-1 px-2.5 py-1.5 text-xs text-muted hover:text-primary hover:bg-surface-tertiary rounded transition-colors"
-      >
-        <Download size={12} /> JSON
-      </button>
-      <button
-        onClick={onClear}
-        className="flex items-center gap-1 px-2.5 py-1.5 text-xs text-red-400 hover:text-red-300 hover:bg-red-900/20 rounded transition-colors"
-      >
-        <Trash2 size={12} /> {t("aiActivity.clearAll")}
-      </button>
+    <div className="rounded-lg border border-default bg-surface-secondary/25 p-3">
+      <div className="grid grid-cols-1 gap-2 lg:grid-cols-[minmax(220px,1fr)_180px_190px_auto]">
+        <div className="relative min-w-0">
+          <Search
+            size={14}
+            className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted"
+          />
+          <input
+            type="text"
+            placeholder={t("aiActivity.searchQuery")}
+            value={filter.queryContains ?? ""}
+            onChange={(e) =>
+              update({ queryContains: e.target.value || undefined })
+            }
+            className="h-9 w-full rounded border border-strong bg-base pl-9 pr-3 text-sm text-primary placeholder:text-muted focus:border-blue-500 focus:outline-none"
+          />
+        </div>
+        <Select
+          value={filter.tool ?? ""}
+          options={toolOptions}
+          labels={toolLabels}
+          onChange={(value) => update({ tool: value || undefined })}
+          placeholder={t("aiActivity.allTools")}
+          searchable={false}
+          className="min-w-0"
+        />
+        <Select
+          value={filter.status ?? ""}
+          options={statusOptions}
+          labels={statusLabels}
+          onChange={(value) =>
+            update({
+              status: (value || undefined) as AiEventFilter["status"],
+            })
+          }
+          placeholder={t("aiActivity.allStatuses")}
+          searchable={false}
+          className="min-w-0"
+        />
+        <div className="flex items-center justify-end gap-1">
+          <button
+            onClick={onRefresh}
+            className="flex h-9 w-9 items-center justify-center rounded text-muted transition-colors hover:bg-surface-tertiary hover:text-primary"
+            title={t("common.refresh", { defaultValue: "Refresh" })}
+          >
+            <RefreshCw size={14} />
+          </button>
+          <button
+            onClick={onExportCsv}
+            className="flex h-9 items-center gap-1.5 rounded px-2.5 text-xs text-muted transition-colors hover:bg-surface-tertiary hover:text-primary"
+          >
+            <Download size={12} /> CSV
+          </button>
+          <button
+            onClick={onExportJson}
+            className="flex h-9 items-center gap-1.5 rounded px-2.5 text-xs text-muted transition-colors hover:bg-surface-tertiary hover:text-primary"
+          >
+            <Download size={12} /> JSON
+          </button>
+          <button
+            onClick={onClear}
+            className="flex h-9 items-center gap-1.5 rounded px-2.5 text-xs text-red-400 transition-colors hover:bg-red-900/20 hover:text-red-300"
+          >
+            <Trash2 size={12} /> {t("aiActivity.clearAll")}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }
@@ -266,25 +305,33 @@ function EventsTable({
     );
   }
   return (
-    <div className="border border-default rounded-lg overflow-hidden">
+    <div className="overflow-hidden rounded-lg border border-default bg-base/30">
       <div className="max-h-[500px] overflow-auto">
-        <table className="w-full text-xs">
-          <thead className="bg-surface-secondary sticky top-0">
-            <tr className="text-muted text-left">
-              <th className="px-3 py-2 font-medium">
+        <table className="w-full table-fixed text-xs">
+          <thead className="sticky top-0 z-10 bg-surface-secondary">
+            <tr className="text-left text-muted">
+              <th className="w-[9.5rem] px-3 py-2 font-medium">
                 {t("aiActivity.col.timestamp")}
               </th>
-              <th className="px-3 py-2 font-medium">{t("aiActivity.col.tool")}</th>
-              <th className="px-3 py-2 font-medium">
+              <th className="w-[8.5rem] px-3 py-2 font-medium">
+                {t("aiActivity.col.tool")}
+              </th>
+              <th className="w-[8rem] px-3 py-2 font-medium">
                 {t("aiActivity.col.connection")}
               </th>
-              <th className="px-3 py-2 font-medium">{t("aiActivity.col.query")}</th>
-              <th className="px-3 py-2 font-medium">{t("aiActivity.col.kind")}</th>
-              <th className="px-3 py-2 font-medium text-right">
+              <th className="px-3 py-2 font-medium">
+                {t("aiActivity.col.query")}
+              </th>
+              <th className="w-[5.5rem] px-3 py-2 font-medium">
+                {t("aiActivity.col.kind")}
+              </th>
+              <th className="w-[5.5rem] px-3 py-2 text-right font-medium">
                 {t("aiActivity.col.duration")}
               </th>
-              <th className="px-3 py-2 font-medium">{t("aiActivity.col.status")}</th>
-              <th className="px-3 py-2 font-medium text-right">
+              <th className="w-[9.5rem] px-3 py-2 font-medium">
+                {t("aiActivity.col.status")}
+              </th>
+              <th className="w-[5.25rem] px-3 py-2 text-right font-medium">
                 {t("aiActivity.col.actions")}
               </th>
             </tr>
@@ -293,32 +340,37 @@ function EventsTable({
             {events.map((ev) => (
               <tr
                 key={ev.id}
-                className="border-t border-default hover:bg-surface-tertiary/30"
+                className="border-t border-default transition-colors hover:bg-surface-tertiary/25"
               >
-                <td className="px-3 py-2 text-muted font-mono whitespace-nowrap">
+                <td className="whitespace-nowrap px-3 py-2.5 font-mono text-muted">
                   {ev.timestamp.replace("T", " ").slice(0, 19)}
                 </td>
-                <td className="px-3 py-2 text-primary font-mono">{ev.tool}</td>
-                <td className="px-3 py-2 text-muted">
+                <td className="truncate px-3 py-2.5 font-mono text-primary">
+                  {ev.tool}
+                </td>
+                <td className="truncate px-3 py-2.5 text-muted">
                   {ev.connectionName ?? "—"}
                 </td>
-                <td className="px-3 py-2 text-secondary font-mono max-w-[260px] truncate">
+                <td
+                  className="truncate px-3 py-2.5 font-mono text-secondary"
+                  title={ev.query ?? undefined}
+                >
                   {truncateQuery(ev.query, 80) || "—"}
                 </td>
-                <td className="px-3 py-2">
+                <td className="px-3 py-2.5">
                   <QueryKindBadge kind={ev.queryKind} />
                 </td>
-                <td className="px-3 py-2 text-muted text-right whitespace-nowrap">
+                <td className="whitespace-nowrap px-3 py-2.5 text-right text-muted">
                   {formatDurationMs(ev.durationMs)}
                 </td>
-                <td className="px-3 py-2">
+                <td className="px-3 py-2.5">
                   <StatusBadge status={ev.status} />
                 </td>
-                <td className="px-3 py-2">
+                <td className="px-3 py-2.5">
                   <div className="flex items-center justify-end gap-1">
                     <button
                       onClick={() => onView(ev)}
-                      className="p-1 text-muted hover:text-primary hover:bg-surface-tertiary rounded"
+                      className="rounded p-1 text-muted hover:bg-surface-tertiary hover:text-primary"
                       title={t("aiActivity.viewDetails")}
                     >
                       <Eye size={12} />
@@ -326,7 +378,7 @@ function EventsTable({
                     {ev.query && (
                       <button
                         onClick={() => onCopyQuery(ev.query!)}
-                        className="p-1 text-muted hover:text-primary hover:bg-surface-tertiary rounded"
+                        className="rounded p-1 text-muted hover:bg-surface-tertiary hover:text-primary"
                         title={t("aiActivity.copyQuery")}
                       >
                         <Copy size={12} />
@@ -335,7 +387,7 @@ function EventsTable({
                     {ev.tool === "run_query" && ev.query && ev.connectionId && (
                       <button
                         onClick={() => onOpenInVisualExplain(ev)}
-                        className="p-1 text-muted hover:text-green-400 hover:bg-green-900/20 rounded"
+                        className="rounded p-1 text-muted hover:bg-green-900/20 hover:text-green-400"
                         title={t("aiActivity.openVisualExplain")}
                       >
                         <GitGraph size={12} />

--- a/src/components/settings/ai-activity/AiActivitySessionsTab.tsx
+++ b/src/components/settings/ai-activity/AiActivitySessionsTab.tsx
@@ -1,0 +1,197 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ChevronRight, FileDown, RefreshCw } from "lucide-react";
+import { save as saveDialog } from "@tauri-apps/plugin-dialog";
+import { writeTextFile } from "@tauri-apps/plugin-fs";
+import {
+  exportSessionAsNotebook,
+  useAiSessionEvents,
+  useAiSessions,
+} from "../../../hooks/useAiActivity";
+import { useAlert } from "../../../hooks/useAlert";
+import {
+  defaultExportFilename,
+  formatDurationMs,
+  notebookFileFromExport,
+  truncateQuery,
+} from "../../../utils/aiActivity";
+import type { AiSessionSummary } from "../../../types/ai";
+import { StatusBadge } from "./StatusBadge";
+
+export function AiActivitySessionsTab() {
+  const { t } = useTranslation();
+  const { sessions, loading, refetch } = useAiSessions();
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-muted">
+          {t("aiActivity.sessionsCount", { count: sessions.length })}
+        </span>
+        <button
+          onClick={refetch}
+          className="p-1.5 text-muted hover:text-primary hover:bg-surface-tertiary rounded transition-colors"
+          title={t("common.refresh", { defaultValue: "Refresh" })}
+        >
+          <RefreshCw size={14} />
+        </button>
+      </div>
+
+      {loading && sessions.length === 0 ? (
+        <div className="text-center py-12 text-muted text-sm">
+          {t("common.loading")}
+        </div>
+      ) : sessions.length === 0 ? (
+        <div className="text-center py-12 text-muted text-sm">
+          {t("aiActivity.empty")}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {sessions.map((s) => (
+            <SessionCard
+              key={s.sessionId}
+              session={s}
+              expanded={activeSessionId === s.sessionId}
+              onToggle={() =>
+                setActiveSessionId((cur) =>
+                  cur === s.sessionId ? null : s.sessionId,
+                )
+              }
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface SessionCardProps {
+  session: AiSessionSummary;
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+function SessionCard({ session, expanded, onToggle }: SessionCardProps) {
+  const { t } = useTranslation();
+  const { showAlert } = useAlert();
+
+  const handleExport = async () => {
+    try {
+      const exp = await exportSessionAsNotebook(session.sessionId);
+      const file = notebookFileFromExport(exp);
+      const target = await saveDialog({
+        defaultPath: defaultExportFilename(session.sessionId, exp),
+        filters: [
+          {
+            name: "Tabularis Notebook",
+            extensions: ["tabularis-notebook"],
+          },
+        ],
+      });
+      if (typeof target === "string" && target.length > 0) {
+        await writeTextFile(target, JSON.stringify(file, null, 2));
+        showAlert(t("aiActivity.exportSuccess", { path: target }), {
+          kind: "info",
+        });
+      }
+    } catch (err) {
+      showAlert(String(err), { kind: "error", title: t("common.error") });
+    }
+  };
+
+  return (
+    <div className="border border-default rounded-lg overflow-hidden bg-surface-secondary/30">
+      <button
+        onClick={onToggle}
+        className="w-full flex items-center justify-between p-3 hover:bg-surface-tertiary/30 transition-colors text-left"
+      >
+        <div className="flex items-start gap-3 min-w-0">
+          <ChevronRight
+            size={14}
+            className={`mt-0.5 text-muted shrink-0 transition-transform ${expanded ? "rotate-90" : ""}`}
+          />
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 text-sm">
+              <span className="font-mono text-primary truncate">
+                {session.sessionId.slice(0, 8)}…
+              </span>
+              {session.clientHint && (
+                <span className="px-1.5 py-0.5 text-[10px] uppercase font-medium rounded bg-blue-900/20 text-blue-400 border border-blue-900/40">
+                  {session.clientHint}
+                </span>
+              )}
+            </div>
+            <div className="text-xs text-muted mt-1 flex flex-wrap gap-x-3">
+              <span>
+                {t("aiActivity.events")}: {session.eventCount}
+              </span>
+              <span>
+                {t("aiActivity.runQueries")}: {session.runQueryCount}
+              </span>
+              {session.connectionNames.length > 0 && (
+                <span className="truncate max-w-[260px]">
+                  {t("aiActivity.connections")}:{" "}
+                  {session.connectionNames.join(", ")}
+                </span>
+              )}
+              <span>
+                {session.startedAt.replace("T", " ").slice(0, 19)}
+              </span>
+            </div>
+          </div>
+        </div>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            handleExport();
+          }}
+          className="flex items-center gap-1.5 px-2.5 py-1 text-xs text-muted hover:text-primary hover:bg-surface-tertiary rounded transition-colors shrink-0"
+        >
+          <FileDown size={12} />
+          {t("aiActivity.exportNotebook")}
+        </button>
+      </button>
+      {expanded && <SessionEventList sessionId={session.sessionId} />}
+    </div>
+  );
+}
+
+function SessionEventList({ sessionId }: { sessionId: string }) {
+  const { t } = useTranslation();
+  const { events, loading } = useAiSessionEvents(sessionId);
+  if (loading) {
+    return (
+      <div className="px-4 py-3 text-xs text-muted">{t("common.loading")}</div>
+    );
+  }
+  if (events.length === 0) {
+    return (
+      <div className="px-4 py-3 text-xs text-muted">
+        {t("aiActivity.empty")}
+      </div>
+    );
+  }
+  return (
+    <div className="border-t border-default bg-base/40">
+      {events.map((ev) => (
+        <div
+          key={ev.id}
+          className="flex items-center gap-3 px-4 py-2 text-xs border-b border-default last:border-b-0"
+        >
+          <span className="text-muted font-mono whitespace-nowrap w-32">
+            {ev.timestamp.replace("T", " ").slice(11, 19)}
+          </span>
+          <span className="text-primary font-mono w-32 shrink-0">{ev.tool}</span>
+          <span className="text-secondary font-mono truncate flex-1">
+            {truncateQuery(ev.query, 100) || ev.connectionName || "—"}
+          </span>
+          <span className="text-muted whitespace-nowrap">
+            {formatDurationMs(ev.durationMs)}
+          </span>
+          <StatusBadge status={ev.status} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/settings/ai-activity/AiActivitySessionsTab.tsx
+++ b/src/components/settings/ai-activity/AiActivitySessionsTab.tsx
@@ -1,6 +1,13 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ChevronRight, FileDown, RefreshCw } from "lucide-react";
+import {
+  ArrowDown,
+  ArrowUp,
+  ChevronRight,
+  FileDown,
+  RefreshCw,
+  Search,
+} from "lucide-react";
 import { save as saveDialog } from "@tauri-apps/plugin-dialog";
 import { writeTextFile } from "@tauri-apps/plugin-fs";
 import {
@@ -13,42 +20,132 @@ import {
   defaultExportFilename,
   formatDurationMs,
   notebookFileFromExport,
+  sessionMatchesSearch,
+  sortAiSessions,
   truncateQuery,
+  type SessionSortField,
+  type SortDirection,
 } from "../../../utils/aiActivity";
 import type { AiSessionSummary } from "../../../types/ai";
 import { StatusBadge } from "./StatusBadge";
+import { Select } from "../../ui/Select";
 
 export function AiActivitySessionsTab() {
   const { t } = useTranslation();
   const { sessions, loading, refetch } = useAiSessions();
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [sortField, setSortField] = useState<SessionSortField>("started");
+  const [sortDir, setSortDir] = useState<SortDirection>("desc");
+
+  const sortOptions: SessionSortField[] = ["started", "events", "runQueries"];
+  const sortLabels: Record<SessionSortField, string> = {
+    started: t("aiActivity.sort.started", { defaultValue: "Started" }),
+    events: t("aiActivity.sort.eventCount", { defaultValue: "Events" }),
+    runQueries: t("aiActivity.sort.runQueries", { defaultValue: "Run queries" }),
+  };
+
+  const visibleSessions = useMemo(() => {
+    const filtered = sessions.filter((s) => sessionMatchesSearch(s, search));
+    return sortAiSessions(filtered, sortField, sortDir);
+  }, [sessions, search, sortField, sortDir]);
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <span className="text-xs text-muted">
-          {t("aiActivity.sessionsCount", { count: sessions.length })}
+      <div className="rounded-lg border border-default bg-surface-secondary/25 p-3">
+        <div className="grid grid-cols-1 gap-2 lg:grid-cols-[minmax(220px,1fr)_180px_auto_auto]">
+          <div className="relative min-w-0">
+            <Search
+              size={14}
+              className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted"
+            />
+            <input
+              type="text"
+              placeholder={t("aiActivity.searchSessions", {
+                defaultValue: "Search session, client, connection…",
+              })}
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="h-9 w-full rounded border border-strong bg-base pl-9 pr-3 text-sm text-primary placeholder:text-muted focus:border-blue-500 focus:outline-none"
+            />
+          </div>
+          <Select
+            value={sortField}
+            options={sortOptions}
+            labels={sortLabels}
+            onChange={(value) => setSortField(value as SessionSortField)}
+            placeholder={t("aiActivity.sort.sortByPlaceholder", {
+              defaultValue: "Sort by…",
+            })}
+            searchable={false}
+            className="min-w-0"
+          />
+          <button
+            onClick={() => setSortDir((d) => (d === "asc" ? "desc" : "asc"))}
+            className="flex h-9 items-center gap-1.5 rounded border border-strong bg-base px-2.5 text-xs text-muted transition-colors hover:bg-surface-tertiary hover:text-primary"
+            title={
+              sortDir === "asc"
+                ? t("aiActivity.sort.toggleDescending", {
+                    defaultValue: "Sort descending",
+                  })
+                : t("aiActivity.sort.toggleAscending", {
+                    defaultValue: "Sort ascending",
+                  })
+            }
+            aria-label={
+              sortDir === "asc"
+                ? t("aiActivity.sort.toggleDescending", {
+                    defaultValue: "Sort descending",
+                  })
+                : t("aiActivity.sort.toggleAscending", {
+                    defaultValue: "Sort ascending",
+                  })
+            }
+          >
+            {sortDir === "asc" ? <ArrowUp size={12} /> : <ArrowDown size={12} />}
+            {sortDir === "asc"
+              ? t("aiActivity.sort.ascending", { defaultValue: "Asc" })
+              : t("aiActivity.sort.descending", { defaultValue: "Desc" })}
+          </button>
+          <button
+            onClick={refetch}
+            className="flex h-9 w-9 items-center justify-center rounded text-muted transition-colors hover:bg-surface-tertiary hover:text-primary"
+            title={t("common.refresh", { defaultValue: "Refresh" })}
+          >
+            <RefreshCw size={14} />
+          </button>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 text-xs">
+        <span className="inline-flex items-center rounded-full border border-default bg-base/50 px-2.5 py-1 text-muted">
+          {t("aiActivity.sessionsCount", { count: visibleSessions.length })}
         </span>
-        <button
-          onClick={refetch}
-          className="p-1.5 text-muted hover:text-primary hover:bg-surface-tertiary rounded transition-colors"
-          title={t("common.refresh", { defaultValue: "Refresh" })}
-        >
-          <RefreshCw size={14} />
-        </button>
+        {search && visibleSessions.length !== sessions.length && (
+          <span className="text-muted">
+            {t("aiActivity.filteredFrom", {
+              defaultValue: "of {{total}}",
+              total: sessions.length,
+            })}
+          </span>
+        )}
       </div>
 
       {loading && sessions.length === 0 ? (
         <div className="text-center py-12 text-muted text-sm">
           {t("common.loading")}
         </div>
-      ) : sessions.length === 0 ? (
+      ) : visibleSessions.length === 0 ? (
         <div className="text-center py-12 text-muted text-sm">
-          {t("aiActivity.empty")}
+          {sessions.length === 0
+            ? t("aiActivity.empty")
+            : t("aiActivity.noMatches", {
+                defaultValue: "No sessions match the current filters.",
+              })}
         </div>
       ) : (
         <div className="space-y-2">
-          {sessions.map((s) => (
+          {visibleSessions.map((s) => (
             <SessionCard
               key={s.sessionId}
               session={s}

--- a/src/components/settings/ai-activity/EventDetailModal.tsx
+++ b/src/components/settings/ai-activity/EventDetailModal.tsx
@@ -1,0 +1,103 @@
+import { useTranslation } from "react-i18next";
+import { X } from "lucide-react";
+import type { AiActivityEvent } from "../../../types/ai";
+import { formatDurationMs } from "../../../utils/aiActivity";
+import { StatusBadge } from "./StatusBadge";
+import { QueryKindBadge } from "./QueryKindBadge";
+
+interface EventDetailModalProps {
+  event: AiActivityEvent;
+  onClose: () => void;
+}
+
+export function EventDetailModal({ event, onClose }: EventDetailModalProps) {
+  const { t } = useTranslation();
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[100] backdrop-blur-sm">
+      <div className="bg-elevated border border-strong rounded-xl shadow-2xl w-[640px] max-h-[80vh] overflow-hidden flex flex-col">
+        <div className="flex items-center justify-between p-4 border-b border-default bg-base">
+          <div>
+            <h2 className="text-base font-semibold text-primary">
+              {t("aiActivity.detailTitle")}
+            </h2>
+            <p className="text-xs text-muted font-mono">{event.id}</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-secondary hover:text-primary transition-colors"
+          >
+            <X size={18} />
+          </button>
+        </div>
+        <div className="p-5 space-y-3 overflow-y-auto text-sm">
+          <DetailRow label={t("aiActivity.col.timestamp")} value={event.timestamp} />
+          <DetailRow label={t("aiActivity.col.tool")} value={event.tool} />
+          <DetailRow
+            label={t("aiActivity.col.connection")}
+            value={
+              event.connectionName
+                ? `${event.connectionName} (${event.connectionId ?? "?"})`
+                : "—"
+            }
+          />
+          <DetailRow
+            label={t("aiActivity.col.duration")}
+            value={formatDurationMs(event.durationMs)}
+          />
+          <div className="flex gap-3">
+            <div className="text-xs text-muted uppercase font-bold w-32 shrink-0">
+              {t("aiActivity.col.status")}
+            </div>
+            <div className="flex items-center gap-2">
+              <StatusBadge status={event.status} />
+              {event.queryKind && <QueryKindBadge kind={event.queryKind} />}
+            </div>
+          </div>
+          {event.clientHint && (
+            <DetailRow label={t("aiActivity.client")} value={event.clientHint} />
+          )}
+          {event.rows !== null && event.rows !== undefined && (
+            <DetailRow
+              label={t("aiActivity.rowsReturned")}
+              value={String(event.rows)}
+            />
+          )}
+          {event.approvalId && (
+            <DetailRow label={t("aiActivity.approvalId")} value={event.approvalId} />
+          )}
+          {event.error && (
+            <div>
+              <div className="text-xs text-muted uppercase font-bold mb-1">
+                {t("common.error")}
+              </div>
+              <pre className="bg-red-900/10 border border-red-900/30 rounded p-3 text-xs text-red-400 whitespace-pre-wrap break-words">
+                {event.error}
+              </pre>
+            </div>
+          )}
+          {event.query && (
+            <div>
+              <div className="text-xs text-muted uppercase font-bold mb-1">
+                {t("aiActivity.col.query")}
+              </div>
+              <pre className="bg-base border border-default rounded p-3 text-xs text-secondary font-mono whitespace-pre-wrap break-words max-h-64 overflow-auto">
+                {event.query}
+              </pre>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex gap-3">
+      <div className="text-xs text-muted uppercase font-bold w-32 shrink-0">
+        {label}
+      </div>
+      <div className="text-primary text-sm break-all">{value}</div>
+    </div>
+  );
+}

--- a/src/components/settings/ai-activity/QueryKindBadge.tsx
+++ b/src/components/settings/ai-activity/QueryKindBadge.tsx
@@ -1,0 +1,26 @@
+import { useTranslation } from "react-i18next";
+import clsx from "clsx";
+import { getQueryKindBadgeStyle } from "../../../utils/aiActivity";
+
+interface QueryKindBadgeProps {
+  kind: string | null;
+}
+
+export function QueryKindBadge({ kind }: QueryKindBadgeProps) {
+  const { t } = useTranslation();
+  if (!kind) return null;
+  const style = getQueryKindBadgeStyle(kind);
+  const label = t(`aiActivity.queryKind.${kind}`, { defaultValue: kind });
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center px-2 py-0.5 rounded text-[10px] font-mono uppercase border",
+        style.bg,
+        style.text,
+        style.border,
+      )}
+    >
+      {label}
+    </span>
+  );
+}

--- a/src/components/settings/ai-activity/StatusBadge.tsx
+++ b/src/components/settings/ai-activity/StatusBadge.tsx
@@ -1,0 +1,25 @@
+import { useTranslation } from "react-i18next";
+import clsx from "clsx";
+import { getStatusBadgeStyle } from "../../../utils/aiActivity";
+
+interface StatusBadgeProps {
+  status: string;
+}
+
+export function StatusBadge({ status }: StatusBadgeProps) {
+  const { t } = useTranslation();
+  const style = getStatusBadgeStyle(status);
+  const label = t(`aiActivity.status.${status}`, { defaultValue: status });
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium border whitespace-nowrap",
+        style.bg,
+        style.text,
+        style.border,
+      )}
+    >
+      {label}
+    </span>
+  );
+}

--- a/src/contexts/SettingsContext.ts
+++ b/src/contexts/SettingsContext.ts
@@ -47,6 +47,15 @@ export interface Settings {
   pingInterval?: number;
   queryHistoryMaxEntries?: number;
   showWelcome?: boolean;
+  // AI / MCP safety
+  aiAuditEnabled?: boolean;
+  aiAuditMaxEntries?: number;
+  aiSessionGapMinutes?: number;
+  mcpReadonlyDefault?: boolean;
+  mcpReadonlyConnections?: string[];
+  mcpApprovalMode?: "off" | "writes_only" | "all";
+  mcpApprovalTimeoutSeconds?: number;
+  mcpPreflightExplain?: boolean;
 }
 
 export interface SettingsContextType {
@@ -87,4 +96,12 @@ export const DEFAULT_SETTINGS: Settings = {
   editorShowLineNumbers: true,
   pingInterval: 30,
   queryHistoryMaxEntries: 500,
+  aiAuditEnabled: true,
+  aiAuditMaxEntries: 5000,
+  aiSessionGapMinutes: 10,
+  mcpReadonlyDefault: false,
+  mcpReadonlyConnections: [],
+  mcpApprovalMode: "writes_only",
+  mcpApprovalTimeoutSeconds: 120,
+  mcpPreflightExplain: true,
 };

--- a/src/hooks/useAiActivity.ts
+++ b/src/hooks/useAiActivity.ts
@@ -1,0 +1,226 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import type {
+  AiActivityEvent,
+  AiEventFilter,
+  AiNotebookExport,
+  AiSessionSummary,
+  ApprovalDecisionPayload,
+  PendingApproval,
+} from "../types/ai";
+
+const PENDING_APPROVAL_EVENT = "ai://pending_approval";
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+export interface UseAiActivityEventsResult {
+  events: AiActivityEvent[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+}
+
+export function useAiActivityEvents(
+  filter: AiEventFilter = {},
+): UseAiActivityEventsResult {
+  const [events, setEvents] = useState<AiActivityEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Stabilise the filter reference so `useCallback` below does not re-bind on
+  // every render (callers can pass an inline object literal safely).
+  const filterKey = JSON.stringify(filter);
+  const stableFilter = useMemo(() => filter, [filterKey]);
+
+  const refetch = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await invoke<AiActivityEvent[]>("get_ai_activity", {
+        filter: stableFilter,
+      });
+      setEvents(data);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [stableFilter]);
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  return { events, loading, error, refetch };
+}
+
+// ---------------------------------------------------------------------------
+// Sessions
+// ---------------------------------------------------------------------------
+
+export interface UseAiSessionsResult {
+  sessions: AiSessionSummary[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+}
+
+export function useAiSessions(): UseAiSessionsResult {
+  const [sessions, setSessions] = useState<AiSessionSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refetch = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await invoke<AiSessionSummary[]>("get_ai_sessions");
+      setSessions(data);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  return { sessions, loading, error, refetch };
+}
+
+// ---------------------------------------------------------------------------
+// Single session events
+// ---------------------------------------------------------------------------
+
+export interface UseAiSessionEventsResult {
+  events: AiActivityEvent[];
+  loading: boolean;
+  error: string | null;
+}
+
+export function useAiSessionEvents(
+  sessionId: string | null,
+): UseAiSessionEventsResult {
+  const [events, setEvents] = useState<AiActivityEvent[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!sessionId) {
+      setEvents([]);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    invoke<AiActivityEvent[]>("get_ai_session_events", { sessionId })
+      .then((data) => {
+        if (!cancelled) setEvents(data);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
+
+  return { events, loading, error };
+}
+
+// ---------------------------------------------------------------------------
+// Pending approvals
+// ---------------------------------------------------------------------------
+
+export interface UsePendingApprovalsResult {
+  pending: PendingApproval[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+  decide: (payload: ApprovalDecisionPayload) => Promise<void>;
+}
+
+export function usePendingApprovals(): UsePendingApprovalsResult {
+  const [pending, setPending] = useState<PendingApproval[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const refetchRef = useRef<() => Promise<void>>(async () => {});
+
+  const refetch = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await invoke<PendingApproval[]>("list_pending_approvals");
+      setPending(data);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+  refetchRef.current = refetch;
+
+  useEffect(() => {
+    refetch();
+    const unlisten = listen<PendingApproval>(PENDING_APPROVAL_EVENT, () => {
+      refetchRef.current();
+    });
+    return () => {
+      unlisten.then((fn) => fn()).catch(() => {});
+    };
+  }, [refetch]);
+
+  const decide = useCallback(
+    async ({
+      approvalId,
+      decision,
+      reason,
+      editedQuery,
+    }: ApprovalDecisionPayload) => {
+      await invoke("decide_pending_approval", {
+        approvalId,
+        decision,
+        reason,
+        editedQuery,
+      });
+      // Optimistically drop the approval from the list — the file watcher
+      // will reconcile if anything else changes.
+      setPending((prev) => prev.filter((p) => p.id !== approvalId));
+    },
+    [],
+  );
+
+  return { pending, loading, error, refetch, decide };
+}
+
+// ---------------------------------------------------------------------------
+// Mutations
+// ---------------------------------------------------------------------------
+
+export async function clearAiActivity(): Promise<void> {
+  await invoke("clear_ai_activity");
+}
+
+export async function exportAiActivityJson(): Promise<string> {
+  return invoke<string>("export_ai_activity_json");
+}
+
+export async function exportAiActivityCsv(): Promise<string> {
+  return invoke<string>("export_ai_activity_csv");
+}
+
+export async function exportSessionAsNotebook(
+  sessionId: string,
+): Promise<AiNotebookExport> {
+  return invoke<AiNotebookExport>("export_ai_session_as_notebook", {
+    sessionId,
+  });
+}

--- a/src/hooks/useAiActivity.ts
+++ b/src/hooks/useAiActivity.ts
@@ -33,6 +33,7 @@ export function useAiActivityEvents(
   // Stabilise the filter reference so `useCallback` below does not re-bind on
   // every render (callers can pass an inline object literal safely).
   const filterKey = JSON.stringify(filter);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- filterKey captures filter content
   const stableFilter = useMemo(() => filter, [filterKey]);
 
   const refetch = useCallback(async () => {
@@ -107,33 +108,46 @@ export function useAiSessionEvents(
   sessionId: string | null,
 ): UseAiSessionEventsResult {
   const [events, setEvents] = useState<AiActivityEvent[]>([]);
+  const [loadedSessionId, setLoadedSessionId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const fetchSession = useCallback(
+    async (id: string, isCancelled: () => boolean) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await invoke<AiActivityEvent[]>("get_ai_session_events", {
+          sessionId: id,
+        });
+        if (!isCancelled()) {
+          setEvents(data);
+          setLoadedSessionId(id);
+        }
+      } catch (err) {
+        if (!isCancelled()) setError(String(err));
+      } finally {
+        if (!isCancelled()) setLoading(false);
+      }
+    },
+    [],
+  );
+
   useEffect(() => {
-    if (!sessionId) {
-      setEvents([]);
-      return;
-    }
+    if (!sessionId) return;
     let cancelled = false;
-    setLoading(true);
-    setError(null);
-    invoke<AiActivityEvent[]>("get_ai_session_events", { sessionId })
-      .then((data) => {
-        if (!cancelled) setEvents(data);
-      })
-      .catch((err) => {
-        if (!cancelled) setError(String(err));
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
+    fetchSession(sessionId, () => cancelled);
     return () => {
       cancelled = true;
     };
-  }, [sessionId]);
+  }, [sessionId, fetchSession]);
 
-  return { events, loading, error };
+  // Derive an empty list when no session is selected (or while a new session
+  // is loading) instead of clearing state inside the effect body.
+  const visibleEvents =
+    sessionId !== null && sessionId === loadedSessionId ? events : [];
+
+  return { events: visibleEvents, loading, error };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -169,7 +169,26 @@
     "errorTitle": "Installation fehlgeschlagen",
     "clients": "KI-CLIENTS",
     "manualCommand": "MANUELLER BEFEHL",
-    "manualCommandText": "Führe diesen Befehl im Terminal aus und starte anschließend Claude Code neu."
+    "manualCommandText": "Führe diesen Befehl im Terminal aus und starte anschließend Claude Code neu.",
+    "safety": {
+      "readOnlyTitle": "Nur-Lese-Modus",
+      "readOnlyDefault": "Alle MCP-Abfragen nur lesen",
+      "readOnlyDefaultDesc": "Blockiere jede Nicht-SELECT-Anweisung über MCP, außer für die unten erlaubten Verbindungen.",
+      "readOnlyList": "Nur-Lese-Verbindungen",
+      "readOnlyListDesc": "Diese Verbindungen lehnen Schreibvorgänge ab. Andere verhalten sich normal.",
+      "allowList": "Schreibvorgänge erlauben",
+      "allowListDesc": "Andere bleiben nur lesbar. Nur markierte dürfen schreiben.",
+      "approvalTitle": "Freigabe",
+      "approvalMode": "Freigabe erforderlich",
+      "approvalModeDesc": "Pausiert Schreibvorgänge (oder jede Abfrage) und fragt den Nutzer vor der Ausführung.",
+      "modeOff": "Aus",
+      "modeWritesOnly": "Nur Schreibvorgänge",
+      "modeAll": "Alle Abfragen",
+      "approvalTimeout": "Zeitlimit",
+      "approvalTimeoutDesc": "Wie lange gewartet wird, bevor abgebrochen wird.",
+      "preflightExplain": "Vorab-EXPLAIN",
+      "preflightExplainDesc": "Führt vor dem Modal ein EXPLAIN aus, damit der Plan sichtbar ist."
+    }
   },
   "connections": {
     "title": "Verbindungen",
@@ -495,7 +514,8 @@
       "notebookRunAll": "Alle Zellen ausführen",
       "categories_notebook": "Notebook",
       "pasteImportClipboard": "Aus Zwischenablage importieren"
-    }
+    },
+    "aiActivity": "KI-Aktivität"
   },
   "update": {
     "newVersionAvailable": "Neue Version verfügbar",
@@ -1243,5 +1263,79 @@
     "targetColumnPlaceholder": "Ziel wählen...",
     "skipColumn": "Überspringen (nicht importieren)",
     "createNewColumn": "Neue Spalte erstellen"
+  },
+  "aiActivity": {
+    "title": "KI-Aktivität",
+    "description": "Protokoll aller MCP-Aufrufe und ausstehender Freigaben. Lokal gespeichert.",
+    "tabs": {
+      "events": "Ereignisse",
+      "sessions": "Sitzungen"
+    },
+    "empty": "Noch keine MCP-Aktivität.",
+    "eventsCount_one": "{{count}} Ereignis",
+    "eventsCount_other": "{{count}} Ereignisse",
+    "blockedCount_one": "{{count}} blockiert",
+    "blockedCount_other": "{{count}} blockiert",
+    "errorsCount_one": "{{count}} Fehler",
+    "errorsCount_other": "{{count}} Fehler",
+    "sessionsCount_one": "{{count}} Sitzung",
+    "sessionsCount_other": "{{count}} Sitzungen",
+    "events": "Ereignisse",
+    "runQueries": "Abfragen",
+    "connections": "Verbindungen",
+    "client": "Client",
+    "rowsReturned": "Zeilen zurück",
+    "approvalId": "Freigabe-ID",
+    "searchQuery": "In Abfrage suchen…",
+    "allTools": "Alle Tools",
+    "allStatuses": "Alle Status",
+    "clearAll": "Leeren",
+    "clearConfirm": "Den gesamten KI-Aktivitätsverlauf löschen? Unwiderruflich.",
+    "exportNotebook": "Als Notebook exportieren",
+    "exportSuccess": "Exportiert nach {{path}}",
+    "viewDetails": "Details anzeigen",
+    "copyQuery": "Abfrage kopieren",
+    "openVisualExplain": "In Visual Explain öffnen",
+    "copied": "In Zwischenablage kopiert",
+    "detailTitle": "Ereignisdetails",
+    "col": {
+      "timestamp": "Zeit",
+      "tool": "Tool",
+      "connection": "Verbindung",
+      "query": "Abfrage",
+      "kind": "Typ",
+      "duration": "Dauer",
+      "status": "Status",
+      "actions": "Aktionen"
+    },
+    "status": {
+      "success": "Erfolg",
+      "blocked_readonly": "Blockiert (nur lesen)",
+      "blocked_pending_approval": "Ausstehend",
+      "denied": "Abgelehnt",
+      "error": "Fehler",
+      "timeout": "Zeitüberschreitung"
+    },
+    "queryKind": {
+      "select": "Lesen",
+      "write": "Schreiben",
+      "ddl": "DDL",
+      "unknown": "Unbekannt"
+    }
+  },
+  "aiApproval": {
+    "title": "KI möchte in die Datenbank schreiben",
+    "subtitle": "Auf {{connection}} — vor Ausführung prüfen.",
+    "subtitleWithClient": "{{client}} auf {{connection}} — vor Ausführung prüfen.",
+    "query": "Abfrage",
+    "editQuery": "Vor Freigabe bearbeiten",
+    "lockQuery": "Sperren",
+    "preflightPlan": "Vorab-Ausführungsplan",
+    "explainUnavailable": "EXPLAIN nicht verfügbar.",
+    "explainFailed": "EXPLAIN fehlgeschlagen: {{error}}",
+    "reasonLabel": "Grund (optional)",
+    "reasonPlaceholder": "z.B. In Prod riskant, bestätigen…",
+    "approve": "Freigeben",
+    "deny": "Ablehnen"
   }
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -170,6 +170,11 @@
     "clients": "KI-CLIENTS",
     "manualCommand": "MANUELLER BEFEHL",
     "manualCommandText": "Führe diesen Befehl im Terminal aus und starte anschließend Claude Code neu.",
+    "tabs": {
+      "setup": "Einrichtung",
+      "activity": "Aktivität",
+      "safety": "Sicherheit"
+    },
     "safety": {
       "readOnlyTitle": "Nur-Lese-Modus",
       "readOnlyDefault": "Alle MCP-Abfragen nur lesen",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1313,6 +1313,20 @@
       "status": "Status",
       "actions": "Aktionen"
     },
+    "sort": {
+      "sortBy": "Sortieren nach {{field}}",
+      "sortByPlaceholder": "Sortieren nach…",
+      "toggleAscending": "Aufsteigend sortieren",
+      "toggleDescending": "Absteigend sortieren",
+      "ascending": "Aufst.",
+      "descending": "Abst.",
+      "started": "Start",
+      "eventCount": "Ereignisse",
+      "runQueries": "Ausgeführte Abfragen"
+    },
+    "searchSessions": "Suche Sitzung, Client, Verbindung…",
+    "filteredFrom": "von {{total}}",
+    "noMatches": "Keine Sitzung entspricht den Filtern.",
     "status": {
       "success": "Erfolg",
       "blocked_readonly": "Blockiert (nur lesen)",
@@ -1336,6 +1350,8 @@
     "editQuery": "Vor Freigabe bearbeiten",
     "lockQuery": "Sperren",
     "preflightPlan": "Vorab-Ausführungsplan",
+    "expandPlan": "Vergrößern",
+    "collapsePlan": "Verkleinern",
     "explainUnavailable": "EXPLAIN nicht verfügbar.",
     "explainFailed": "EXPLAIN fehlgeschlagen: {{error}}",
     "reasonLabel": "Grund (optional)",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1313,6 +1313,20 @@
       "status": "Status",
       "actions": "Actions"
     },
+    "sort": {
+      "sortBy": "Sort by {{field}}",
+      "sortByPlaceholder": "Sort by…",
+      "toggleAscending": "Sort ascending",
+      "toggleDescending": "Sort descending",
+      "ascending": "Asc",
+      "descending": "Desc",
+      "started": "Started",
+      "eventCount": "Events",
+      "runQueries": "Run queries"
+    },
+    "searchSessions": "Search session, client, connection…",
+    "filteredFrom": "of {{total}}",
+    "noMatches": "No sessions match the current filters.",
     "status": {
       "success": "Success",
       "blocked_readonly": "Blocked (read-only)",
@@ -1336,6 +1350,8 @@
     "editQuery": "Edit before approving",
     "lockQuery": "Lock query",
     "preflightPlan": "Pre-flight execution plan",
+    "expandPlan": "Expand",
+    "collapsePlan": "Collapse",
     "explainUnavailable": "EXPLAIN unavailable for this query.",
     "explainFailed": "EXPLAIN failed: {{error}}",
     "reasonLabel": "Reason (optional)",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -170,6 +170,11 @@
     "clients": "AI CLIENTS",
     "manualCommand": "MANUAL COMMAND",
     "manualCommandText": "Run this command in your terminal, then restart Claude Code.",
+    "tabs": {
+      "setup": "Setup",
+      "activity": "Activity",
+      "safety": "Safety"
+    },
     "safety": {
       "readOnlyTitle": "Read-only mode",
       "readOnlyDefault": "Make all MCP queries read-only",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -169,7 +169,26 @@
     "errorTitle": "Installation Failed",
     "clients": "AI CLIENTS",
     "manualCommand": "MANUAL COMMAND",
-    "manualCommandText": "Run this command in your terminal, then restart Claude Code."
+    "manualCommandText": "Run this command in your terminal, then restart Claude Code.",
+    "safety": {
+      "readOnlyTitle": "Read-only mode",
+      "readOnlyDefault": "Make all MCP queries read-only",
+      "readOnlyDefaultDesc": "Block any non-SELECT statement coming through MCP unless the connection is explicitly allowed below.",
+      "readOnlyList": "Read-only connections",
+      "readOnlyListDesc": "These connections will reject writes from MCP. Other connections behave normally.",
+      "allowList": "Allow writes from MCP",
+      "allowListDesc": "All other connections stay read-only. Only the connections checked here may execute writes.",
+      "approvalTitle": "Approval gate",
+      "approvalMode": "Approval required",
+      "approvalModeDesc": "Pause writes (or every query) and ask the user to approve them inside Tabularis before they hit the database.",
+      "modeOff": "Off",
+      "modeWritesOnly": "Writes only",
+      "modeAll": "All queries",
+      "approvalTimeout": "Timeout",
+      "approvalTimeoutDesc": "How long the MCP subprocess will wait for the user's decision before failing the request.",
+      "preflightExplain": "Pre-flight EXPLAIN",
+      "preflightExplainDesc": "Run an EXPLAIN against the query before showing the approval modal so the user sees the execution plan."
+    }
   },
   "connections": {
     "title": "Connections",
@@ -495,7 +514,8 @@
       "notebookRunAll": "Run All Cells",
       "categories_notebook": "Notebook",
       "pasteImportClipboard": "Import from Clipboard"
-    }
+    },
+    "aiActivity": "AI Activity"
   },
   "update": {
     "newVersionAvailable": "New Version Available",
@@ -1243,5 +1263,79 @@
     "targetColumnPlaceholder": "Choose target...",
     "skipColumn": "Skip (do not import)",
     "createNewColumn": "Create new column"
+  },
+  "aiActivity": {
+    "title": "AI Activity",
+    "description": "Audit log of every MCP tool call, plus the queries waiting for your approval. Stored locally — never sent anywhere.",
+    "tabs": {
+      "events": "Events",
+      "sessions": "Sessions"
+    },
+    "empty": "No MCP activity yet.",
+    "eventsCount_one": "{{count}} event",
+    "eventsCount_other": "{{count}} events",
+    "blockedCount_one": "{{count}} blocked",
+    "blockedCount_other": "{{count}} blocked",
+    "errorsCount_one": "{{count}} error",
+    "errorsCount_other": "{{count}} errors",
+    "sessionsCount_one": "{{count}} session",
+    "sessionsCount_other": "{{count}} sessions",
+    "events": "Events",
+    "runQueries": "Queries",
+    "connections": "Connections",
+    "client": "Client",
+    "rowsReturned": "Rows returned",
+    "approvalId": "Approval ID",
+    "searchQuery": "Search query…",
+    "allTools": "All tools",
+    "allStatuses": "All statuses",
+    "clearAll": "Clear",
+    "clearConfirm": "Delete the entire AI activity history? This cannot be undone.",
+    "exportNotebook": "Export as Notebook",
+    "exportSuccess": "Exported to {{path}}",
+    "viewDetails": "View details",
+    "copyQuery": "Copy query",
+    "openVisualExplain": "Open in Visual Explain",
+    "copied": "Copied to clipboard",
+    "detailTitle": "Event details",
+    "col": {
+      "timestamp": "Time",
+      "tool": "Tool",
+      "connection": "Connection",
+      "query": "Query",
+      "kind": "Kind",
+      "duration": "Duration",
+      "status": "Status",
+      "actions": "Actions"
+    },
+    "status": {
+      "success": "Success",
+      "blocked_readonly": "Blocked (read-only)",
+      "blocked_pending_approval": "Pending approval",
+      "denied": "Denied",
+      "error": "Error",
+      "timeout": "Timeout"
+    },
+    "queryKind": {
+      "select": "Select",
+      "write": "Write",
+      "ddl": "DDL",
+      "unknown": "Unknown"
+    }
+  },
+  "aiApproval": {
+    "title": "AI requested a database write",
+    "subtitle": "On {{connection}} — review and decide before it executes.",
+    "subtitleWithClient": "{{client}} on {{connection}} — review and decide before it executes.",
+    "query": "Query",
+    "editQuery": "Edit before approving",
+    "lockQuery": "Lock query",
+    "preflightPlan": "Pre-flight execution plan",
+    "explainUnavailable": "EXPLAIN unavailable for this query.",
+    "explainFailed": "EXPLAIN failed: {{error}}",
+    "reasonLabel": "Reason (optional)",
+    "reasonPlaceholder": "e.g. Looks risky on prod, please confirm…",
+    "approve": "Approve",
+    "deny": "Deny"
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -170,6 +170,11 @@
     "clients": "CLIENTES IA",
     "manualCommand": "COMANDO MANUAL",
     "manualCommandText": "Ejecuta este comando en tu terminal y reinicia Claude Code.",
+    "tabs": {
+      "setup": "Configuración",
+      "activity": "Actividad",
+      "safety": "Seguridad"
+    },
     "safety": {
       "readOnlyTitle": "Modo solo lectura",
       "readOnlyDefault": "Hacer todas las consultas MCP de solo lectura",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -169,7 +169,26 @@
     "errorTitle": "Instalación Fallida",
     "clients": "CLIENTES IA",
     "manualCommand": "COMANDO MANUAL",
-    "manualCommandText": "Ejecuta este comando en tu terminal y reinicia Claude Code."
+    "manualCommandText": "Ejecuta este comando en tu terminal y reinicia Claude Code.",
+    "safety": {
+      "readOnlyTitle": "Modo solo lectura",
+      "readOnlyDefault": "Hacer todas las consultas MCP de solo lectura",
+      "readOnlyDefaultDesc": "Bloquea cualquier sentencia que no sea SELECT vía MCP, salvo las conexiones autorizadas abajo.",
+      "readOnlyList": "Conexiones de solo lectura",
+      "readOnlyListDesc": "Estas conexiones rechazarán escrituras desde MCP. Las otras se comportan normalmente.",
+      "allowList": "Permitir escrituras desde MCP",
+      "allowListDesc": "El resto sigue en solo lectura. Solo las marcadas pueden ejecutar escrituras.",
+      "approvalTitle": "Puerta de aprobación",
+      "approvalMode": "Aprobación requerida",
+      "approvalModeDesc": "Pausa las escrituras (o todas las consultas) y pide al usuario que apruebe antes de ejecutar.",
+      "modeOff": "Desactivada",
+      "modeWritesOnly": "Solo escrituras",
+      "modeAll": "Todas las consultas",
+      "approvalTimeout": "Tiempo de espera",
+      "approvalTimeoutDesc": "Cuánto espera el subproceso MCP la decisión del usuario antes de fallar.",
+      "preflightExplain": "EXPLAIN previo",
+      "preflightExplainDesc": "Ejecuta un EXPLAIN antes de mostrar el modal para que el usuario vea el plan."
+    }
   },
   "connections": {
     "title": "Conexiones",
@@ -495,7 +514,8 @@
       "notebookRunAll": "Ejecutar Todas las Celdas",
       "categories_notebook": "Notebook",
       "pasteImportClipboard": "Importar desde Portapapeles"
-    }
+    },
+    "aiActivity": "Actividad IA"
   },
   "update": {
     "newVersionAvailable": "Nueva Versión Disponible",
@@ -1195,5 +1215,79 @@
     "targetColumnPlaceholder": "Elegir destino...",
     "skipColumn": "Omitir (no importar)",
     "createNewColumn": "Crear nueva columna"
+  },
+  "aiActivity": {
+    "title": "Actividad IA",
+    "description": "Registro de cada llamada MCP y de las consultas pendientes de aprobación. Almacenado localmente.",
+    "tabs": {
+      "events": "Eventos",
+      "sessions": "Sesiones"
+    },
+    "empty": "Sin actividad MCP registrada.",
+    "eventsCount_one": "{{count}} evento",
+    "eventsCount_other": "{{count}} eventos",
+    "blockedCount_one": "{{count}} bloqueado",
+    "blockedCount_other": "{{count}} bloqueados",
+    "errorsCount_one": "{{count}} error",
+    "errorsCount_other": "{{count}} errores",
+    "sessionsCount_one": "{{count}} sesión",
+    "sessionsCount_other": "{{count}} sesiones",
+    "events": "Eventos",
+    "runQueries": "Consultas",
+    "connections": "Conexiones",
+    "client": "Cliente",
+    "rowsReturned": "Filas devueltas",
+    "approvalId": "ID aprobación",
+    "searchQuery": "Buscar en la consulta…",
+    "allTools": "Todas las herramientas",
+    "allStatuses": "Todos los estados",
+    "clearAll": "Limpiar",
+    "clearConfirm": "¿Borrar todo el historial de actividad IA? Esta acción es irreversible.",
+    "exportNotebook": "Exportar como Notebook",
+    "exportSuccess": "Exportado a {{path}}",
+    "viewDetails": "Ver detalles",
+    "copyQuery": "Copiar consulta",
+    "openVisualExplain": "Abrir en Visual Explain",
+    "copied": "Copiado al portapapeles",
+    "detailTitle": "Detalles del evento",
+    "col": {
+      "timestamp": "Hora",
+      "tool": "Herramienta",
+      "connection": "Conexión",
+      "query": "Consulta",
+      "kind": "Tipo",
+      "duration": "Duración",
+      "status": "Estado",
+      "actions": "Acciones"
+    },
+    "status": {
+      "success": "Éxito",
+      "blocked_readonly": "Bloqueada (solo lectura)",
+      "blocked_pending_approval": "Pendiente",
+      "denied": "Denegada",
+      "error": "Error",
+      "timeout": "Tiempo agotado"
+    },
+    "queryKind": {
+      "select": "Lectura",
+      "write": "Escritura",
+      "ddl": "DDL",
+      "unknown": "Desconocido"
+    }
+  },
+  "aiApproval": {
+    "title": "La IA quiere ejecutar una escritura en la base de datos",
+    "subtitle": "En {{connection}} — revisa y decide antes de ejecutar.",
+    "subtitleWithClient": "{{client}} en {{connection}} — revisa y decide antes de ejecutar.",
+    "query": "Consulta",
+    "editQuery": "Editar antes de aprobar",
+    "lockQuery": "Bloquear consulta",
+    "preflightPlan": "Plan de ejecución previo",
+    "explainUnavailable": "EXPLAIN no disponible para esta consulta.",
+    "explainFailed": "EXPLAIN falló: {{error}}",
+    "reasonLabel": "Razón (opcional)",
+    "reasonPlaceholder": "ej. Parece arriesgada en prod, confirma…",
+    "approve": "Aprobar",
+    "deny": "Denegar"
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1265,6 +1265,20 @@
       "status": "Estado",
       "actions": "Acciones"
     },
+    "sort": {
+      "sortBy": "Ordenar por {{field}}",
+      "sortByPlaceholder": "Ordenar por…",
+      "toggleAscending": "Orden ascendente",
+      "toggleDescending": "Orden descendente",
+      "ascending": "Asc",
+      "descending": "Desc",
+      "started": "Inicio",
+      "eventCount": "Eventos",
+      "runQueries": "Consultas ejecutadas"
+    },
+    "searchSessions": "Buscar sesión, cliente, conexión…",
+    "filteredFrom": "de {{total}}",
+    "noMatches": "Ninguna sesión coincide con los filtros.",
     "status": {
       "success": "Éxito",
       "blocked_readonly": "Bloqueada (solo lectura)",
@@ -1288,6 +1302,8 @@
     "editQuery": "Editar antes de aprobar",
     "lockQuery": "Bloquear consulta",
     "preflightPlan": "Plan de ejecución previo",
+    "expandPlan": "Expandir",
+    "collapsePlan": "Contraer",
     "explainUnavailable": "EXPLAIN no disponible para esta consulta.",
     "explainFailed": "EXPLAIN falló: {{error}}",
     "reasonLabel": "Razón (opcional)",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1313,6 +1313,20 @@
       "status": "Statut",
       "actions": "Actions"
     },
+    "sort": {
+      "sortBy": "Trier par {{field}}",
+      "sortByPlaceholder": "Trier par…",
+      "toggleAscending": "Tri croissant",
+      "toggleDescending": "Tri décroissant",
+      "ascending": "Asc",
+      "descending": "Desc",
+      "started": "Début",
+      "eventCount": "Événements",
+      "runQueries": "Requêtes exécutées"
+    },
+    "searchSessions": "Rechercher session, client, connexion…",
+    "filteredFrom": "sur {{total}}",
+    "noMatches": "Aucune session ne correspond aux filtres.",
     "status": {
       "success": "Succès",
       "blocked_readonly": "Bloquée (lecture seule)",
@@ -1336,6 +1350,8 @@
     "editQuery": "Modifier avant d'approuver",
     "lockQuery": "Verrouiller",
     "preflightPlan": "Plan d'exécution préalable",
+    "expandPlan": "Agrandir",
+    "collapsePlan": "Réduire",
     "explainUnavailable": "EXPLAIN indisponible.",
     "explainFailed": "EXPLAIN a échoué : {{error}}",
     "reasonLabel": "Motif (facultatif)",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -169,7 +169,26 @@
     "errorTitle": "Échec de l’installation",
     "clients": "CLIENTS IA",
     "manualCommand": "COMMANDE MANUELLE",
-    "manualCommandText": "Exécutez cette commande dans votre terminal, puis redémarrez Claude Code."
+    "manualCommandText": "Exécutez cette commande dans votre terminal, puis redémarrez Claude Code.",
+    "safety": {
+      "readOnlyTitle": "Mode lecture seule",
+      "readOnlyDefault": "Mettre toutes les requêtes MCP en lecture seule",
+      "readOnlyDefaultDesc": "Bloquer tout statement non-SELECT via MCP, sauf pour les connexions autorisées ci-dessous.",
+      "readOnlyList": "Connexions en lecture seule",
+      "readOnlyListDesc": "Ces connexions refuseront les écritures via MCP. Les autres restent normales.",
+      "allowList": "Autoriser les écritures via MCP",
+      "allowListDesc": "Les autres restent en lecture seule. Seules celles cochées peuvent écrire.",
+      "approvalTitle": "Validation manuelle",
+      "approvalMode": "Validation requise",
+      "approvalModeDesc": "Mettre en pause les écritures (ou toutes les requêtes) et demander la validation utilisateur avant exécution.",
+      "modeOff": "Désactivée",
+      "modeWritesOnly": "Écritures seulement",
+      "modeAll": "Toutes les requêtes",
+      "approvalTimeout": "Délai",
+      "approvalTimeoutDesc": "Temps d'attente avant échec.",
+      "preflightExplain": "EXPLAIN préalable",
+      "preflightExplainDesc": "Exécute EXPLAIN avant d'afficher le modal pour montrer le plan."
+    }
   },
   "connections": {
     "title": "Connexions",
@@ -495,7 +514,8 @@
       "notebookRunAll": "Exécuter toutes les cellules",
       "categories_notebook": "Notebook",
       "pasteImportClipboard": "Importer depuis le Presse-papiers"
-    }
+    },
+    "aiActivity": "Activité IA"
   },
   "update": {
     "newVersionAvailable": "Nouvelle version disponible",
@@ -1243,5 +1263,79 @@
     "targetColumnPlaceholder": "Choisir la cible...",
     "skipColumn": "Ignorer (ne pas importer)",
     "createNewColumn": "Créer une nouvelle colonne"
+  },
+  "aiActivity": {
+    "title": "Activité IA",
+    "description": "Journal de chaque appel MCP et des requêtes en attente de validation. Stockage local.",
+    "tabs": {
+      "events": "Événements",
+      "sessions": "Sessions"
+    },
+    "empty": "Aucune activité MCP.",
+    "eventsCount_one": "{{count}} événement",
+    "eventsCount_other": "{{count}} événements",
+    "blockedCount_one": "{{count}} bloqué",
+    "blockedCount_other": "{{count}} bloqués",
+    "errorsCount_one": "{{count}} erreur",
+    "errorsCount_other": "{{count}} erreurs",
+    "sessionsCount_one": "{{count}} session",
+    "sessionsCount_other": "{{count}} sessions",
+    "events": "Événements",
+    "runQueries": "Requêtes",
+    "connections": "Connexions",
+    "client": "Client",
+    "rowsReturned": "Lignes retournées",
+    "approvalId": "ID validation",
+    "searchQuery": "Rechercher…",
+    "allTools": "Tous les outils",
+    "allStatuses": "Tous les statuts",
+    "clearAll": "Effacer",
+    "clearConfirm": "Supprimer tout l'historique d'activité IA ? Action irréversible.",
+    "exportNotebook": "Exporter en Notebook",
+    "exportSuccess": "Exporté vers {{path}}",
+    "viewDetails": "Voir les détails",
+    "copyQuery": "Copier la requête",
+    "openVisualExplain": "Ouvrir dans Visual Explain",
+    "copied": "Copié dans le presse-papier",
+    "detailTitle": "Détails de l'événement",
+    "col": {
+      "timestamp": "Heure",
+      "tool": "Outil",
+      "connection": "Connexion",
+      "query": "Requête",
+      "kind": "Type",
+      "duration": "Durée",
+      "status": "Statut",
+      "actions": "Actions"
+    },
+    "status": {
+      "success": "Succès",
+      "blocked_readonly": "Bloquée (lecture seule)",
+      "blocked_pending_approval": "En attente",
+      "denied": "Refusée",
+      "error": "Erreur",
+      "timeout": "Délai dépassé"
+    },
+    "queryKind": {
+      "select": "Lecture",
+      "write": "Écriture",
+      "ddl": "DDL",
+      "unknown": "Inconnu"
+    }
+  },
+  "aiApproval": {
+    "title": "L'IA veut exécuter une écriture",
+    "subtitle": "Sur {{connection}} — examinez avant exécution.",
+    "subtitleWithClient": "{{client}} sur {{connection}} — examinez avant exécution.",
+    "query": "Requête",
+    "editQuery": "Modifier avant d'approuver",
+    "lockQuery": "Verrouiller",
+    "preflightPlan": "Plan d'exécution préalable",
+    "explainUnavailable": "EXPLAIN indisponible.",
+    "explainFailed": "EXPLAIN a échoué : {{error}}",
+    "reasonLabel": "Motif (facultatif)",
+    "reasonPlaceholder": "ex. Risqué en prod, confirmez…",
+    "approve": "Approuver",
+    "deny": "Refuser"
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -170,6 +170,11 @@
     "clients": "CLIENTS IA",
     "manualCommand": "COMMANDE MANUELLE",
     "manualCommandText": "Exécutez cette commande dans votre terminal, puis redémarrez Claude Code.",
+    "tabs": {
+      "setup": "Configuration",
+      "activity": "Activité",
+      "safety": "Sécurité"
+    },
     "safety": {
       "readOnlyTitle": "Mode lecture seule",
       "readOnlyDefault": "Mettre toutes les requêtes MCP en lecture seule",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -170,6 +170,11 @@
     "clients": "CLIENT AI",
     "manualCommand": "COMANDO MANUALE",
     "manualCommandText": "Esegui questo comando nel terminale, poi riavvia Claude Code.",
+    "tabs": {
+      "setup": "Configurazione",
+      "activity": "Attività",
+      "safety": "Sicurezza"
+    },
     "safety": {
       "readOnlyTitle": "Modalità sola lettura",
       "readOnlyDefault": "Rendi tutte le query MCP di sola lettura",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -169,7 +169,26 @@
     "errorTitle": "Installazione Fallita",
     "clients": "CLIENT AI",
     "manualCommand": "COMANDO MANUALE",
-    "manualCommandText": "Esegui questo comando nel terminale, poi riavvia Claude Code."
+    "manualCommandText": "Esegui questo comando nel terminale, poi riavvia Claude Code.",
+    "safety": {
+      "readOnlyTitle": "Modalità sola lettura",
+      "readOnlyDefault": "Rendi tutte le query MCP di sola lettura",
+      "readOnlyDefaultDesc": "Blocca qualsiasi statement non-SELECT proveniente da MCP, salvo le connessioni esplicitamente abilitate.",
+      "readOnlyList": "Connessioni di sola lettura",
+      "readOnlyListDesc": "Queste connessioni rifiuteranno le scritture da MCP. Le altre si comportano normalmente.",
+      "allowList": "Consenti scritture da MCP",
+      "allowListDesc": "Tutte le altre connessioni restano in sola lettura. Solo quelle selezionate possono eseguire scritture.",
+      "approvalTitle": "Approvazione manuale",
+      "approvalMode": "Approvazione richiesta",
+      "approvalModeDesc": "Sospendi le scritture (o ogni query) chiedendo conferma all'utente in Tabularis prima dell'esecuzione.",
+      "modeOff": "Disattiva",
+      "modeWritesOnly": "Solo scritture",
+      "modeAll": "Tutte le query",
+      "approvalTimeout": "Timeout",
+      "approvalTimeoutDesc": "Quanti secondi il processo MCP attende la decisione dell'utente prima di abortire.",
+      "preflightExplain": "EXPLAIN preliminare",
+      "preflightExplainDesc": "Esegui un EXPLAIN della query prima di mostrare il modal di approvazione, così l'utente vede il piano di esecuzione."
+    }
   },
   "connections": {
     "title": "Connessioni",
@@ -495,7 +514,8 @@
       "notebookRunAll": "Esegui Tutte le Celle",
       "categories_notebook": "Notebook",
       "pasteImportClipboard": "Importa dagli Appunti"
-    }
+    },
+    "aiActivity": "Attività AI"
   },
   "update": {
     "newVersionAvailable": "Nuova Versione Disponibile",
@@ -1224,5 +1244,79 @@
     "targetColumnPlaceholder": "Scegli destinazione...",
     "skipColumn": "Salta (non importare)",
     "createNewColumn": "Crea nuova colonna"
+  },
+  "aiActivity": {
+    "title": "Attività AI",
+    "description": "Log di ogni chiamata MCP e delle query in attesa di approvazione. Tutto è salvato localmente.",
+    "tabs": {
+      "events": "Eventi",
+      "sessions": "Sessioni"
+    },
+    "empty": "Nessuna attività MCP registrata.",
+    "eventsCount_one": "{{count}} evento",
+    "eventsCount_other": "{{count}} eventi",
+    "blockedCount_one": "{{count}} bloccato",
+    "blockedCount_other": "{{count}} bloccati",
+    "errorsCount_one": "{{count}} errore",
+    "errorsCount_other": "{{count}} errori",
+    "sessionsCount_one": "{{count}} sessione",
+    "sessionsCount_other": "{{count}} sessioni",
+    "events": "Eventi",
+    "runQueries": "Query",
+    "connections": "Connessioni",
+    "client": "Client",
+    "rowsReturned": "Righe restituite",
+    "approvalId": "ID approvazione",
+    "searchQuery": "Cerca nella query…",
+    "allTools": "Tutti gli strumenti",
+    "allStatuses": "Tutti gli stati",
+    "clearAll": "Svuota",
+    "clearConfirm": "Vuoi eliminare l'intera storia delle attività AI? L'operazione è irreversibile.",
+    "exportNotebook": "Esporta come Notebook",
+    "exportSuccess": "Esportato in {{path}}",
+    "viewDetails": "Mostra dettagli",
+    "copyQuery": "Copia query",
+    "openVisualExplain": "Apri in Visual Explain",
+    "copied": "Copiato negli appunti",
+    "detailTitle": "Dettagli evento",
+    "col": {
+      "timestamp": "Ora",
+      "tool": "Strumento",
+      "connection": "Connessione",
+      "query": "Query",
+      "kind": "Tipo",
+      "duration": "Durata",
+      "status": "Stato",
+      "actions": "Azioni"
+    },
+    "status": {
+      "success": "Successo",
+      "blocked_readonly": "Bloccata (sola lettura)",
+      "blocked_pending_approval": "In attesa",
+      "denied": "Negata",
+      "error": "Errore",
+      "timeout": "Timeout"
+    },
+    "queryKind": {
+      "select": "Lettura",
+      "write": "Scrittura",
+      "ddl": "DDL",
+      "unknown": "Sconosciuto"
+    }
+  },
+  "aiApproval": {
+    "title": "L'AI vuole eseguire una scrittura sul database",
+    "subtitle": "Su {{connection}} — controlla e decidi prima dell'esecuzione.",
+    "subtitleWithClient": "{{client}} su {{connection}} — controlla e decidi prima dell'esecuzione.",
+    "query": "Query",
+    "editQuery": "Modifica prima di approvare",
+    "lockQuery": "Blocca query",
+    "preflightPlan": "Piano di esecuzione preliminare",
+    "explainUnavailable": "EXPLAIN non disponibile per questa query.",
+    "explainFailed": "EXPLAIN fallito: {{error}}",
+    "reasonLabel": "Motivo (opzionale)",
+    "reasonPlaceholder": "es. Sembra rischiosa in produzione, conferma…",
+    "approve": "Approva",
+    "deny": "Nega"
   }
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1294,6 +1294,20 @@
       "status": "Stato",
       "actions": "Azioni"
     },
+    "sort": {
+      "sortBy": "Ordina per {{field}}",
+      "sortByPlaceholder": "Ordina per…",
+      "toggleAscending": "Ordine crescente",
+      "toggleDescending": "Ordine decrescente",
+      "ascending": "Cresc.",
+      "descending": "Decresc.",
+      "started": "Inizio",
+      "eventCount": "Eventi",
+      "runQueries": "Query eseguite"
+    },
+    "searchSessions": "Cerca sessione, client, connessione…",
+    "filteredFrom": "su {{total}}",
+    "noMatches": "Nessuna sessione corrisponde ai filtri.",
     "status": {
       "success": "Successo",
       "blocked_readonly": "Bloccata (sola lettura)",
@@ -1317,6 +1331,8 @@
     "editQuery": "Modifica prima di approvare",
     "lockQuery": "Blocca query",
     "preflightPlan": "Piano di esecuzione preliminare",
+    "expandPlan": "Espandi",
+    "collapsePlan": "Riduci",
     "explainUnavailable": "EXPLAIN non disponibile per questa query.",
     "explainFailed": "EXPLAIN fallito: {{error}}",
     "reasonLabel": "Motivo (opzionale)",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -169,6 +169,11 @@
     "clients": "AI 客户端",
     "manualCommand": "手动命令",
     "manualCommandText": "在终端中运行此命令，然后重启 Claude Code。",
+    "tabs": {
+      "setup": "设置",
+      "activity": "活动",
+      "safety": "安全"
+    },
     "safety": {
       "readOnlyTitle": "只读模式",
       "readOnlyDefault": "将所有 MCP 查询设为只读",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1257,6 +1257,20 @@
       "status": "状态",
       "actions": "操作"
     },
+    "sort": {
+      "sortBy": "按 {{field}} 排序",
+      "sortByPlaceholder": "排序方式…",
+      "toggleAscending": "升序排列",
+      "toggleDescending": "降序排列",
+      "ascending": "升序",
+      "descending": "降序",
+      "started": "开始时间",
+      "eventCount": "事件数",
+      "runQueries": "执行查询数"
+    },
+    "searchSessions": "搜索会话、客户端、连接…",
+    "filteredFrom": "共 {{total}}",
+    "noMatches": "没有会话匹配当前筛选条件。",
     "status": {
       "success": "成功",
       "blocked_readonly": "已阻止 (只读)",
@@ -1280,6 +1294,8 @@
     "editQuery": "批准前编辑",
     "lockQuery": "锁定查询",
     "preflightPlan": "预先执行计划",
+    "expandPlan": "展开",
+    "collapsePlan": "收起",
     "explainUnavailable": "此查询无法 EXPLAIN。",
     "explainFailed": "EXPLAIN 失败: {{error}}",
     "reasonLabel": "理由 (可选)",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -168,7 +168,26 @@
     "errorTitle": "安装失败",
     "clients": "AI 客户端",
     "manualCommand": "手动命令",
-    "manualCommandText": "在终端中运行此命令，然后重启 Claude Code。"
+    "manualCommandText": "在终端中运行此命令，然后重启 Claude Code。",
+    "safety": {
+      "readOnlyTitle": "只读模式",
+      "readOnlyDefault": "将所有 MCP 查询设为只读",
+      "readOnlyDefaultDesc": "通过 MCP 阻止任何非 SELECT 语句,除非连接被显式允许。",
+      "readOnlyList": "只读连接",
+      "readOnlyListDesc": "这些连接将拒绝来自 MCP 的写入。其他连接行为不变。",
+      "allowList": "允许 MCP 写入",
+      "allowListDesc": "其余连接保持只读。仅勾选的连接可以执行写入。",
+      "approvalTitle": "审批门",
+      "approvalMode": "需要审批",
+      "approvalModeDesc": "在执行前暂停写入(或所有查询)并要求用户在 Tabularis 中批准。",
+      "modeOff": "关闭",
+      "modeWritesOnly": "仅写入",
+      "modeAll": "所有查询",
+      "approvalTimeout": "超时",
+      "approvalTimeoutDesc": "MCP 子进程等待用户决定的时间。",
+      "preflightExplain": "预先 EXPLAIN",
+      "preflightExplainDesc": "在显示审批模态之前运行 EXPLAIN,以便用户查看执行计划。"
+    }
   },
   "connections": {
     "title": "连接",
@@ -465,7 +484,8 @@
       "pressKeys": "按下组合键...",
       "notebookRunAll": "运行所有单元格",
       "categories_notebook": "笔记本"
-    }
+    },
+    "aiActivity": "AI 活动"
   },
   "update": {
     "newVersionAvailable": "有新版本可用",
@@ -1191,5 +1211,75 @@
     "targetColumnPlaceholder": "选择目标...",
     "skipColumn": "跳过（不导入）",
     "createNewColumn": "创建新列"
+  },
+  "aiActivity": {
+    "title": "AI 活动",
+    "description": "MCP 工具调用的审计日志,以及等待批准的查询。仅本地存储。",
+    "tabs": {
+      "events": "事件",
+      "sessions": "会话"
+    },
+    "empty": "暂无 MCP 活动。",
+    "eventsCount_other": "{{count}} 个事件",
+    "blockedCount_other": "{{count}} 个被阻止",
+    "errorsCount_other": "{{count}} 个错误",
+    "sessionsCount_other": "{{count}} 个会话",
+    "events": "事件",
+    "runQueries": "查询",
+    "connections": "连接",
+    "client": "客户端",
+    "rowsReturned": "返回的行数",
+    "approvalId": "审批 ID",
+    "searchQuery": "搜索查询…",
+    "allTools": "所有工具",
+    "allStatuses": "所有状态",
+    "clearAll": "清空",
+    "clearConfirm": "删除全部 AI 活动历史?此操作不可撤销。",
+    "exportNotebook": "导出为 Notebook",
+    "exportSuccess": "已导出到 {{path}}",
+    "viewDetails": "查看详情",
+    "copyQuery": "复制查询",
+    "openVisualExplain": "在 Visual Explain 中打开",
+    "copied": "已复制到剪贴板",
+    "detailTitle": "事件详情",
+    "col": {
+      "timestamp": "时间",
+      "tool": "工具",
+      "connection": "连接",
+      "query": "查询",
+      "kind": "类型",
+      "duration": "耗时",
+      "status": "状态",
+      "actions": "操作"
+    },
+    "status": {
+      "success": "成功",
+      "blocked_readonly": "已阻止 (只读)",
+      "blocked_pending_approval": "待审批",
+      "denied": "已拒绝",
+      "error": "错误",
+      "timeout": "超时"
+    },
+    "queryKind": {
+      "select": "读取",
+      "write": "写入",
+      "ddl": "DDL",
+      "unknown": "未知"
+    }
+  },
+  "aiApproval": {
+    "title": "AI 请求执行数据库写入",
+    "subtitle": "在 {{connection}} 上 — 请审核后再执行。",
+    "subtitleWithClient": "{{client}} 在 {{connection}} 上 — 请审核后再执行。",
+    "query": "查询",
+    "editQuery": "批准前编辑",
+    "lockQuery": "锁定查询",
+    "preflightPlan": "预先执行计划",
+    "explainUnavailable": "此查询无法 EXPLAIN。",
+    "explainFailed": "EXPLAIN 失败: {{error}}",
+    "reasonLabel": "理由 (可选)",
+    "reasonPlaceholder": "例如:在生产环境中风险较大,请确认…",
+    "approve": "批准",
+    "deny": "拒绝"
   }
 }

--- a/src/pages/McpPage.tsx
+++ b/src/pages/McpPage.tsx
@@ -1,0 +1,340 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useTranslation } from "react-i18next";
+import clsx from "clsx";
+import Editor from "@monaco-editor/react";
+import {
+  Activity,
+  Check,
+  Copy,
+  Cpu,
+  ShieldCheck,
+  Terminal,
+} from "lucide-react";
+import {
+  AnthropicIcon,
+  AntigravityIcon,
+  CursorIcon,
+  WindsurfIcon,
+} from "../components/icons/ClientIcons";
+import { AiActivityPanel } from "../components/settings/AiActivityPanel";
+import { McpSafetySection } from "../components/modals/mcp/McpSafetySection";
+import { useAlert } from "../hooks/useAlert";
+import { useTheme } from "../hooks/useTheme";
+import { loadMonacoTheme } from "../themes/themeUtils";
+
+interface McpClientStatus {
+  client_id: string;
+  client_name: string;
+  installed: boolean;
+  config_path: string | null;
+  executable_path: string;
+  client_type: string;
+}
+
+type McpPageTab = "setup" | "activity" | "safety";
+
+const ClientIcon = ({
+  clientId,
+  size = 20,
+}: {
+  clientId: string;
+  size?: number;
+}) => {
+  switch (clientId) {
+    case "claude":
+    case "claude_code":
+      return <AnthropicIcon size={size} />;
+    case "cursor":
+      return <CursorIcon size={size} className="text-white" />;
+    case "windsurf":
+      return <WindsurfIcon size={size} className="text-white" />;
+    case "antigravity":
+      return <AntigravityIcon size={size} />;
+    default:
+      return <Cpu size={size} />;
+  }
+};
+
+export function McpPage() {
+  const { t } = useTranslation();
+  const [tab, setTab] = useState<McpPageTab>("setup");
+
+  const tabs: Array<{
+    id: McpPageTab;
+    icon: React.ComponentType<{ size: number }>;
+    label: string;
+  }> = [
+    { id: "setup", icon: Cpu, label: t("mcp.tabs.setup") },
+    { id: "activity", icon: Activity, label: t("mcp.tabs.activity") },
+    { id: "safety", icon: ShieldCheck, label: t("mcp.tabs.safety") },
+  ];
+
+  return (
+    <div className="h-full overflow-auto bg-base">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6 p-8">
+        <header className="flex flex-col gap-3 border-b border-default pb-5">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-purple-900/30 text-purple-400">
+              <Cpu size={20} />
+            </div>
+            <div className="min-w-0">
+              <h1 className="text-xl font-semibold text-primary">
+                {t("mcp.title")}
+              </h1>
+              <p className="mt-1 text-sm text-muted">{t("mcp.subtitle")}</p>
+            </div>
+          </div>
+          <p className="max-w-3xl text-sm leading-relaxed text-secondary">
+            {t("mcp.description")}
+          </p>
+        </header>
+
+        <div className="flex gap-1 border-b border-default">
+          {tabs.map(({ id, icon: Icon, label }) => (
+            <button
+              key={id}
+              onClick={() => setTab(id)}
+              className={clsx(
+                "-mb-px flex items-center gap-2 border-b-2 px-4 py-2 text-sm font-medium transition-colors",
+                tab === id
+                  ? "border-blue-500 text-primary"
+                  : "border-transparent text-muted hover:text-primary",
+              )}
+            >
+              <Icon size={14} />
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {tab === "setup" && <McpSetupPanel />}
+        {tab === "activity" && <AiActivityPanel />}
+        {tab === "safety" && (
+          <div className="max-w-4xl">
+            <McpSafetySection />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function McpSetupPanel() {
+  const { t } = useTranslation();
+  const { currentTheme } = useTheme();
+  const { showAlert } = useAlert();
+  const [clients, setClients] = useState<McpClientStatus[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [copiedJson, setCopiedJson] = useState(false);
+  const [copiedCmd, setCopiedCmd] = useState(false);
+  const [selectedClientId, setSelectedClientId] = useState<string | null>(null);
+
+  const selectedClient = useMemo(
+    () =>
+      clients.find((client) => client.client_id === selectedClientId) ??
+      clients[0] ??
+      null,
+    [clients, selectedClientId],
+  );
+
+  const jsonValue = useMemo(
+    () =>
+      JSON.stringify(
+        {
+          mcpServers: {
+            tabularis: {
+              command: selectedClient?.executable_path || "tabularis",
+              args: ["--mcp"],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    [selectedClient?.executable_path],
+  );
+
+  const cliCommand = useMemo(
+    () =>
+      `claude mcp add --scope user tabularis ${
+        selectedClient?.executable_path || "tabularis"
+      } -- --mcp`,
+    [selectedClient?.executable_path],
+  );
+
+  const loadStatus = useCallback(async () => {
+    try {
+      setLoading(true);
+      const res = await invoke<McpClientStatus[]>("get_mcp_status");
+      setClients(res);
+      setSelectedClientId((current) => current ?? res[0]?.client_id ?? null);
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadStatus();
+  }, [loadStatus]);
+
+  const handleInstall = async (clientId: string) => {
+    try {
+      const clientName = await invoke<string>("install_mcp_config", {
+        clientId,
+      });
+      showAlert(t("mcp.successMsg", { client: clientName }), {
+        kind: "info",
+        title: t("mcp.successTitle"),
+      });
+      await loadStatus();
+    } catch (e) {
+      showAlert(String(e), { kind: "error", title: t("mcp.errorTitle") });
+    }
+  };
+
+  const isCommandClient = selectedClient?.client_type === "command";
+
+  if (loading) {
+    return (
+      <div className="rounded-lg border border-default bg-surface-secondary/25 py-12 text-center text-sm text-muted">
+        {t("mcp.checking")}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-[minmax(280px,420px)_minmax(0,1fr)]">
+      <section className="space-y-2">
+        <h2 className="text-xs font-bold uppercase text-muted">
+          {t("mcp.clients")}
+        </h2>
+        <div className="space-y-2">
+          {clients.map((client) => (
+            <button
+              key={client.client_id}
+              onClick={() => setSelectedClientId(client.client_id)}
+              className={clsx(
+                "flex w-full items-center justify-between rounded-lg border p-3 text-left transition-colors",
+                selectedClient?.client_id === client.client_id
+                  ? "border-purple-500/50 bg-purple-900/10"
+                  : "border-default bg-base hover:border-strong",
+              )}
+            >
+              <div className="flex min-w-0 items-center gap-3">
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center">
+                  <ClientIcon clientId={client.client_id} size={22} />
+                </div>
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2 text-sm font-medium text-primary">
+                    <span className="truncate">{client.client_name}</span>
+                    {client.client_type === "command" && (
+                      <Terminal size={11} className="shrink-0 text-muted" />
+                    )}
+                  </div>
+                  <div className="mt-0.5 truncate font-mono text-xs text-muted">
+                    {client.config_path ?? t("mcp.notFound")}
+                  </div>
+                </div>
+              </div>
+              {client.installed ? (
+                <div className="ml-3 flex shrink-0 items-center gap-2 rounded-full border border-green-900/50 bg-green-900/20 px-3 py-1 text-xs font-medium text-green-400">
+                  <Check size={12} />
+                  <span>{t("mcp.installed")}</span>
+                </div>
+              ) : (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleInstall(client.client_id);
+                  }}
+                  className="ml-3 shrink-0 rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white shadow-lg shadow-blue-900/20 transition-colors hover:bg-blue-500"
+                >
+                  {t("mcp.install")}
+                </button>
+              )}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section className="min-w-0 space-y-2">
+        {selectedClient && !selectedClient.installed ? (
+          <>
+            <h2 className="text-xs font-bold uppercase text-muted">
+              {isCommandClient ? t("mcp.manualCommand") : t("mcp.manualConfig")}
+              {" - "}
+              {selectedClient.client_name}
+            </h2>
+            {isCommandClient ? (
+              <div className="group relative">
+                <div className="rounded-lg border border-default bg-base p-3 pr-10 font-mono text-xs text-secondary break-all">
+                  {cliCommand}
+                </div>
+                <button
+                  onClick={() => {
+                    navigator.clipboard.writeText(cliCommand);
+                    setCopiedCmd(true);
+                    setTimeout(() => setCopiedCmd(false), 2000);
+                  }}
+                  className="absolute right-2 top-2 rounded bg-surface-secondary p-1.5 text-secondary opacity-0 transition-all hover:text-primary group-hover:opacity-100"
+                >
+                  {copiedCmd ? (
+                    <Check size={13} className="text-green-400" />
+                  ) : (
+                    <Copy size={13} />
+                  )}
+                </button>
+              </div>
+            ) : (
+              <div className="group relative overflow-hidden rounded-lg border border-default">
+                <Editor
+                  height="220px"
+                  defaultLanguage="json"
+                  theme={currentTheme.id}
+                  value={jsonValue}
+                  beforeMount={(monaco) => loadMonacoTheme(currentTheme, monaco)}
+                  options={{
+                    readOnly: true,
+                    minimap: { enabled: false },
+                    lineNumbers: "off",
+                    scrollBeyondLastLine: false,
+                    folding: false,
+                    domReadOnly: true,
+                    contextmenu: false,
+                    fontSize: 12,
+                    padding: { top: 12, bottom: 12 },
+                    wordWrap: "on",
+                  }}
+                />
+                <button
+                  onClick={() => {
+                    navigator.clipboard.writeText(jsonValue);
+                    setCopiedJson(true);
+                    setTimeout(() => setCopiedJson(false), 2000);
+                  }}
+                  className="absolute right-2 top-2 z-10 rounded bg-surface-secondary p-2 text-secondary opacity-0 transition-all hover:text-primary group-hover:opacity-100"
+                >
+                  {copiedJson ? (
+                    <Check size={14} className="text-green-400" />
+                  ) : (
+                    <Copy size={14} />
+                  )}
+                </button>
+              </div>
+            )}
+            <p className="text-xs text-muted">
+              {isCommandClient ? t("mcp.manualCommandText") : t("mcp.manualText")}
+            </p>
+          </>
+        ) : (
+          <div className="flex min-h-[240px] items-center justify-center rounded-lg border border-default bg-surface-secondary/20 p-6 text-center text-sm text-muted">
+            {t("mcp.installed")}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -10,6 +10,7 @@ import {
   Plug,
   Info,
   FileJson,
+  Shield,
 } from "lucide-react";
 import clsx from "clsx";
 import { ConfigJsonModal } from "../components/modals/ConfigJsonModal";
@@ -20,6 +21,7 @@ import { AiTab } from "../components/settings/AiTab";
 import { LogsTab } from "../components/settings/LogsTab";
 import { ShortcutsTab } from "../components/settings/ShortcutsTab";
 import { PluginsTab } from "../components/settings/PluginsTab";
+import { AiActivityPanel } from "../components/settings/AiActivityPanel";
 import { InfoTab } from "../components/settings/InfoTab";
 import { PluginSettingsPage } from "../components/settings/PluginSettingsPage";
 import { useDrivers } from "../hooks/useDrivers";
@@ -30,6 +32,7 @@ type SettingsTab =
   | "appearance"
   | "localization"
   | "ai"
+  | "ai-activity"
   | "logs"
   | "shortcuts"
   | "plugins"
@@ -52,6 +55,7 @@ const TAB_ITEMS: Array<{
   { id: "appearance", icon: Palette, labelKey: "settings.appearance" },
   { id: "localization", icon: Languages, labelKey: "settings.localization" },
   { id: "ai", icon: Sparkles, labelKey: "settings.ai.tab" },
+  { id: "ai-activity", icon: Shield, labelKey: "settings.aiActivity" },
   { id: "logs", icon: ScrollText, labelKey: "settings.logs" },
   { id: "shortcuts", icon: Keyboard, labelKey: "settings.shortcuts.title" },
   { id: "info", icon: Info, labelKey: "settings.info" },
@@ -62,6 +66,7 @@ const TAB_COMPONENTS: Partial<Record<SettingsTab, React.ComponentType>> = {
   appearance: AppearanceTab,
   localization: LocalizationTab,
   ai: AiTab,
+  "ai-activity": AiActivityPanel,
   logs: LogsTab,
   shortcuts: ShortcutsTab,
   plugins: PluginsTab,

--- a/src/pages/VisualExplainPage.tsx
+++ b/src/pages/VisualExplainPage.tsx
@@ -11,20 +11,36 @@ import {
   getExplainFileName,
   parseExplainFileParam,
 } from "../utils/explainImport";
+import { parseVisualExplainDeepLink } from "../utils/aiActivity";
 import { useSettings } from "../hooks/useSettings";
 
-export const VisualExplainPage = () => {
+export interface VisualExplainPageProps {
+  /// When provided, render in embedded mode: skip the page header, use the
+  /// supplied plan instead of loading from disk, and ignore router params.
+  initialPlan?: ExplainPlan | null;
+  /// Hide the page chrome (header + file picker). Defaults to false.
+  compactMode?: boolean;
+}
+
+export const VisualExplainPage = ({
+  initialPlan = null,
+  compactMode = false,
+}: VisualExplainPageProps = {}) => {
   const { t } = useTranslation();
   const { settings } = useSettings();
   const { search } = useLocation();
   const initialParamPath = parseExplainFileParam(search);
+  const deepLink = parseVisualExplainDeepLink(search);
+  const isDeepLink = !!deepLink.query && !!deepLink.connectionId;
 
   const [filePath, setFilePath] = useState<string | null>(initialParamPath);
-  const [plan, setPlan] = useState<ExplainPlan | null>(null);
+  const [plan, setPlan] = useState<ExplainPlan | null>(initialPlan);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<ExplainViewMode>("graph");
-  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(
+    initialPlan?.root.id ?? null,
+  );
 
   const loadPlan = useCallback(async (path: string) => {
     setIsLoading(true);
@@ -44,11 +60,41 @@ export const VisualExplainPage = () => {
     }
   }, []);
 
-  // On mount: if launched with ?file=... (or from CLI via pending slot), load it.
+  const runExplainForDeepLink = useCallback(
+    async (connectionId: string, query: string) => {
+      setIsLoading(true);
+      setError(null);
+      setPlan(null);
+      setSelectedNodeId(null);
+      try {
+        const result = await invoke<ExplainPlan>("explain_query_plan", {
+          connectionId,
+          query,
+          analyze: false,
+          schema: null,
+        });
+        setPlan(result);
+        setSelectedNodeId(result.root.id);
+      } catch (err) {
+        setError(String(err));
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [],
+  );
+
+  // On mount: prefer initialPlan (embedded mode), then deep link, then file
+  // path, then any pending CLI handoff.
   useEffect(() => {
+    if (initialPlan) return;
     let cancelled = false;
 
     const bootstrap = async () => {
+      if (isDeepLink) {
+        await runExplainForDeepLink(deepLink.connectionId!, deepLink.query!);
+        return;
+      }
       if (initialParamPath) {
         await loadPlan(initialParamPath);
         return;
@@ -68,7 +114,15 @@ export const VisualExplainPage = () => {
     return () => {
       cancelled = true;
     };
-  }, [initialParamPath, loadPlan]);
+  }, [
+    initialPlan,
+    initialParamPath,
+    isDeepLink,
+    deepLink.connectionId,
+    deepLink.query,
+    loadPlan,
+    runExplainForDeepLink,
+  ]);
 
   const handlePickFile = useCallback(async () => {
     const selected = await openDialog({
@@ -89,56 +143,61 @@ export const VisualExplainPage = () => {
   }, [filePath, loadPlan]);
 
   const fileLabel = filePath ? getExplainFileName(filePath) : null;
+  const containerClass = compactMode
+    ? "w-full h-full flex flex-col bg-base"
+    : "w-screen h-screen flex flex-col bg-base";
 
   return (
-    <div className="w-screen h-screen flex flex-col bg-base">
-      <div className="flex items-center justify-between px-4 py-3 border-b border-default bg-elevated shrink-0">
-        <div className="flex items-center gap-3 min-w-0">
-          <div className="p-2 bg-green-900/30 rounded-lg">
-            <FileJson size={18} className="text-green-400" />
+    <div className={containerClass}>
+      {!compactMode && (
+        <div className="flex items-center justify-between px-4 py-3 border-b border-default bg-elevated shrink-0">
+          <div className="flex items-center gap-3 min-w-0">
+            <div className="p-2 bg-green-900/30 rounded-lg">
+              <FileJson size={18} className="text-green-400" />
+            </div>
+            <div className="min-w-0">
+              <h1 className="text-base font-semibold text-primary truncate">
+                {t("visualExplainPage.title")}
+              </h1>
+              {fileLabel ? (
+                <p
+                  className="text-xs text-muted font-mono truncate"
+                  title={filePath ?? undefined}
+                >
+                  {fileLabel}
+                </p>
+              ) : (
+                <p className="text-xs text-muted">
+                  {t("visualExplainPage.noFile")}
+                </p>
+              )}
+            </div>
           </div>
-          <div className="min-w-0">
-            <h1 className="text-base font-semibold text-primary truncate">
-              {t("visualExplainPage.title")}
-            </h1>
-            {fileLabel ? (
-              <p
-                className="text-xs text-muted font-mono truncate"
-                title={filePath ?? undefined}
-              >
-                {fileLabel}
-              </p>
-            ) : (
-              <p className="text-xs text-muted">
-                {t("visualExplainPage.noFile")}
-              </p>
-            )}
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handlePickFile}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm text-muted hover:text-primary hover:bg-surface-secondary/50 transition-colors"
+            >
+              <FolderOpen size={14} />
+              {t("visualExplainPage.openFile")}
+            </button>
+            <button
+              onClick={handleReload}
+              disabled={!filePath || isLoading}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm text-muted hover:text-primary hover:bg-surface-secondary/50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              <RefreshCw
+                size={14}
+                className={isLoading ? "animate-spin" : ""}
+              />
+              {t("visualExplainPage.reload")}
+            </button>
           </div>
         </div>
-        <div className="flex items-center gap-2">
-          <button
-            onClick={handlePickFile}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm text-muted hover:text-primary hover:bg-surface-secondary/50 transition-colors"
-          >
-            <FolderOpen size={14} />
-            {t("visualExplainPage.openFile")}
-          </button>
-          <button
-            onClick={handleReload}
-            disabled={!filePath || isLoading}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm text-muted hover:text-primary hover:bg-surface-secondary/50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-          >
-            <RefreshCw
-              size={14}
-              className={isLoading ? "animate-spin" : ""}
-            />
-            {t("visualExplainPage.reload")}
-          </button>
-        </div>
-      </div>
+      )}
 
       <div className="flex-1 min-h-0">
-        {!filePath && !isLoading ? (
+        {!compactMode && !filePath && !plan && !isLoading ? (
           <div className="flex flex-col items-center justify-center h-full gap-3 text-muted">
             <FileJson size={32} className="opacity-30" />
             <p className="text-sm">{t("visualExplainPage.emptyHint")}</p>

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -1,0 +1,96 @@
+// Types mirror the Rust structs in src-tauri/src/ai_activity.rs and
+// src-tauri/src/ai_approval.rs (camelCase via #[serde(rename_all)]).
+
+export type AiQueryKind = "select" | "write" | "ddl" | "unknown";
+
+export type AiActivityStatus =
+  | "success"
+  | "blocked_readonly"
+  | "blocked_pending_approval"
+  | "denied"
+  | "error"
+  | "timeout";
+
+export type AiToolName =
+  | "list_connections"
+  | "list_tables"
+  | "describe_table"
+  | "run_query"
+  | (string & {});
+
+export interface AiActivityEvent {
+  id: string;
+  sessionId: string;
+  timestamp: string;
+  tool: AiToolName;
+  connectionId: string | null;
+  connectionName: string | null;
+  query: string | null;
+  queryKind: AiQueryKind | null;
+  durationMs: number;
+  status: AiActivityStatus;
+  rows: number | null;
+  error: string | null;
+  clientHint: string | null;
+  approvalId: string | null;
+}
+
+export interface AiSessionSummary {
+  sessionId: string;
+  startedAt: string;
+  endedAt: string;
+  eventCount: number;
+  runQueryCount: number;
+  connectionNames: string[];
+  clientHint: string | null;
+}
+
+export interface AiEventFilter {
+  sessionId?: string;
+  connectionId?: string;
+  tool?: string;
+  status?: AiActivityStatus;
+  queryContains?: string;
+  since?: string;
+  until?: string;
+}
+
+export interface PendingApproval {
+  id: string;
+  createdAt: string;
+  sessionId: string;
+  connectionId: string;
+  connectionName: string;
+  query: string;
+  queryKind: AiQueryKind;
+  clientHint: string | null;
+  explainPlan: unknown | null;
+  explainError: string | null;
+}
+
+export type ApprovalDecisionKind = "approve" | "deny";
+
+export interface ApprovalDecisionPayload {
+  approvalId: string;
+  decision: ApprovalDecisionKind;
+  reason?: string;
+  editedQuery?: string;
+}
+
+export type McpApprovalMode = "off" | "writes_only" | "all";
+
+// Notebook export shape returned by `export_ai_session_as_notebook`. The
+// frontend treats it as a NotebookFile (see src/types/notebook.ts).
+export interface AiNotebookExportCell {
+  type: "sql" | "markdown";
+  content: string;
+  name?: string;
+  schema?: string;
+}
+
+export interface AiNotebookExport {
+  version: number;
+  title: string;
+  createdAt: string;
+  cells: AiNotebookExportCell[];
+}

--- a/src/utils/aiActivity.ts
+++ b/src/utils/aiActivity.ts
@@ -6,8 +6,21 @@ import type {
   AiActivityStatus,
   AiNotebookExport,
   AiQueryKind,
+  AiSessionSummary,
   PendingApproval,
 } from "../types/ai";
+
+export type SortDirection = "asc" | "desc";
+
+export type EventSortField =
+  | "timestamp"
+  | "tool"
+  | "connection"
+  | "kind"
+  | "duration"
+  | "status";
+
+export type SessionSortField = "started" | "events" | "runQueries";
 
 export interface BadgeStyle {
   bg: string;
@@ -242,4 +255,127 @@ function base64UrlDecode(s: string): string {
 /// (write or DDL). Use to drive UI emphasis (red border, etc).
 export function isDestructiveApproval(p: PendingApproval): boolean {
   return p.queryKind === "write" || p.queryKind === "ddl" || p.queryKind === "unknown";
+}
+
+const QUERY_KIND_ORDER: Record<AiQueryKind, number> = {
+  select: 0,
+  write: 1,
+  ddl: 2,
+  unknown: 3,
+};
+
+const STATUS_ORDER: Record<AiActivityStatus, number> = {
+  success: 0,
+  blocked_readonly: 1,
+  blocked_pending_approval: 2,
+  denied: 3,
+  error: 4,
+  timeout: 5,
+};
+
+// Returns 0 when both values are present, otherwise a non-zero sentinel that
+// the caller propagates *without* flipping for direction (nulls always sort
+// last in both ASC and DESC).
+function nullsLast<T>(
+  a: T | null | undefined,
+  b: T | null | undefined,
+): number {
+  const aMissing = a === null || a === undefined;
+  const bMissing = b === null || b === undefined;
+  if (aMissing && bMissing) return 0;
+  if (aMissing) return 1;
+  if (bMissing) return -1;
+  return 0;
+}
+
+function applyDirection(cmp: number, dir: SortDirection): number {
+  return dir === "asc" ? cmp : -cmp;
+}
+
+/// Returns a new array of events sorted by the given field/direction. Stable
+/// for equal keys (preserves the input order). Pure: never mutates `events`.
+export function sortAiEvents(
+  events: AiActivityEvent[],
+  field: EventSortField,
+  direction: SortDirection,
+): AiActivityEvent[] {
+  const decorated = events.map((ev, i) => ({ ev, i }));
+  decorated.sort((a, b) => {
+    let cmp = 0;
+    let nullCmp = 0;
+    switch (field) {
+      case "timestamp":
+        cmp = a.ev.timestamp.localeCompare(b.ev.timestamp);
+        break;
+      case "tool":
+        cmp = a.ev.tool.localeCompare(b.ev.tool);
+        break;
+      case "connection":
+        nullCmp = nullsLast(a.ev.connectionName, b.ev.connectionName);
+        if (nullCmp !== 0) return nullCmp;
+        cmp = (a.ev.connectionName ?? "").localeCompare(
+          b.ev.connectionName ?? "",
+        );
+        break;
+      case "kind":
+        nullCmp = nullsLast(a.ev.queryKind, b.ev.queryKind);
+        if (nullCmp !== 0) return nullCmp;
+        cmp =
+          (QUERY_KIND_ORDER[a.ev.queryKind as AiQueryKind] ?? 99) -
+          (QUERY_KIND_ORDER[b.ev.queryKind as AiQueryKind] ?? 99);
+        break;
+      case "duration":
+        cmp = a.ev.durationMs - b.ev.durationMs;
+        break;
+      case "status":
+        cmp = (STATUS_ORDER[a.ev.status] ?? 99) - (STATUS_ORDER[b.ev.status] ?? 99);
+        break;
+    }
+    if (cmp === 0) return a.i - b.i;
+    return applyDirection(cmp, direction);
+  });
+  return decorated.map((d) => d.ev);
+}
+
+/// Returns a new array of sessions sorted by the given field/direction.
+/// Stable for equal keys.
+export function sortAiSessions(
+  sessions: AiSessionSummary[],
+  field: SessionSortField,
+  direction: SortDirection,
+): AiSessionSummary[] {
+  const decorated = sessions.map((s, i) => ({ s, i }));
+  decorated.sort((a, b) => {
+    let cmp = 0;
+    switch (field) {
+      case "started":
+        cmp = a.s.startedAt.localeCompare(b.s.startedAt);
+        break;
+      case "events":
+        cmp = a.s.eventCount - b.s.eventCount;
+        break;
+      case "runQueries":
+        cmp = a.s.runQueryCount - b.s.runQueryCount;
+        break;
+    }
+    if (cmp === 0) return a.i - b.i;
+    return applyDirection(cmp, direction);
+  });
+  return decorated.map((d) => d.s);
+}
+
+/// Case-insensitive substring match against the parts of a session a user
+/// would reasonably type into a search box (id, client hint, connection
+/// names). Empty/whitespace queries match everything.
+export function sessionMatchesSearch(
+  session: AiSessionSummary,
+  query: string,
+): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  if (session.sessionId.toLowerCase().includes(q)) return true;
+  if (session.clientHint && session.clientHint.toLowerCase().includes(q)) {
+    return true;
+  }
+  return session.connectionNames.some((c) => c.toLowerCase().includes(q));
 }

--- a/src/utils/aiActivity.ts
+++ b/src/utils/aiActivity.ts
@@ -1,0 +1,245 @@
+// Pure helpers used by the AI activity panel and approval modal.
+// Kept dependency-free so they can be unit tested in isolation.
+
+import type {
+  AiActivityEvent,
+  AiActivityStatus,
+  AiNotebookExport,
+  AiQueryKind,
+  PendingApproval,
+} from "../types/ai";
+
+export interface BadgeStyle {
+  bg: string;
+  text: string;
+  border: string;
+}
+
+const STATUS_STYLES: Record<AiActivityStatus, BadgeStyle> = {
+  success: {
+    bg: "bg-green-900/20",
+    text: "text-green-400",
+    border: "border-green-900/40",
+  },
+  blocked_readonly: {
+    bg: "bg-yellow-900/20",
+    text: "text-yellow-400",
+    border: "border-yellow-900/40",
+  },
+  blocked_pending_approval: {
+    bg: "bg-purple-900/20",
+    text: "text-purple-400",
+    border: "border-purple-900/40",
+  },
+  denied: {
+    bg: "bg-red-900/20",
+    text: "text-red-400",
+    border: "border-red-900/40",
+  },
+  error: {
+    bg: "bg-red-900/20",
+    text: "text-red-400",
+    border: "border-red-900/40",
+  },
+  timeout: {
+    bg: "bg-orange-900/20",
+    text: "text-orange-400",
+    border: "border-orange-900/40",
+  },
+};
+
+const QUERY_KIND_STYLES: Record<AiQueryKind, BadgeStyle> = {
+  select: {
+    bg: "bg-blue-900/20",
+    text: "text-blue-400",
+    border: "border-blue-900/40",
+  },
+  write: {
+    bg: "bg-yellow-900/20",
+    text: "text-yellow-400",
+    border: "border-yellow-900/40",
+  },
+  ddl: {
+    bg: "bg-orange-900/20",
+    text: "text-orange-400",
+    border: "border-orange-900/40",
+  },
+  unknown: {
+    bg: "bg-surface-secondary",
+    text: "text-muted",
+    border: "border-default",
+  },
+};
+
+const FALLBACK_STYLE: BadgeStyle = {
+  bg: "bg-surface-secondary",
+  text: "text-muted",
+  border: "border-default",
+};
+
+export function getStatusBadgeStyle(status: string): BadgeStyle {
+  return STATUS_STYLES[status as AiActivityStatus] ?? FALLBACK_STYLE;
+}
+
+export function getQueryKindBadgeStyle(kind: string | null): BadgeStyle {
+  if (!kind) return FALLBACK_STYLE;
+  return QUERY_KIND_STYLES[kind as AiQueryKind] ?? FALLBACK_STYLE;
+}
+
+export function truncateQuery(query: string | null, maxLen = 80): string {
+  if (!query) return "";
+  const oneLine = query.replace(/\s+/g, " ").trim();
+  if (oneLine.length <= maxLen) return oneLine;
+  return `${oneLine.slice(0, maxLen)}…`;
+}
+
+export function formatDurationMs(ms: number): string {
+  if (ms < 1) return "<1 ms";
+  if (ms < 1_000) return `${Math.round(ms)} ms`;
+  if (ms < 60_000) return `${(ms / 1_000).toFixed(2)} s`;
+  const minutes = Math.floor(ms / 60_000);
+  const seconds = Math.round((ms % 60_000) / 1_000);
+  return `${minutes}m ${seconds}s`;
+}
+
+export function eventsToCsvLines(events: AiActivityEvent[]): string[] {
+  const header = [
+    "id",
+    "session_id",
+    "timestamp",
+    "tool",
+    "connection_name",
+    "query_kind",
+    "duration_ms",
+    "status",
+    "rows",
+    "error",
+  ].join(",");
+  const escape = (v: string | number | null | undefined): string => {
+    if (v === null || v === undefined) return "";
+    const s = String(v);
+    if (/[",\n]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+    return s;
+  };
+  const rows = events.map((e) =>
+    [
+      escape(e.id),
+      escape(e.sessionId),
+      escape(e.timestamp),
+      escape(e.tool),
+      escape(e.connectionName),
+      escape(e.queryKind),
+      escape(e.durationMs),
+      escape(e.status),
+      escape(e.rows),
+      escape(e.error),
+    ].join(","),
+  );
+  return [header, ...rows];
+}
+
+/// Convert the backend export shape to a `NotebookFile`-compatible payload
+/// that can be passed to the existing `save_notebook` / notebook editor.
+export function notebookFileFromExport(
+  exportData: AiNotebookExport,
+): NotebookFilePayload {
+  return {
+    version: exportData.version,
+    title: exportData.title,
+    createdAt: exportData.createdAt,
+    cells: exportData.cells.map((c) => ({
+      type: c.type,
+      content: c.content,
+      ...(c.name !== undefined && { name: c.name }),
+      ...(c.schema !== undefined && { schema: c.schema }),
+    })),
+  };
+}
+
+/// Minimal NotebookFile shape — kept here to avoid importing the larger
+/// NotebookFile type into a leaf utility module.
+export interface NotebookFilePayload {
+  version: number;
+  title: string;
+  createdAt: string;
+  cells: Array<{
+    type: "sql" | "markdown";
+    content: string;
+    name?: string;
+    schema?: string;
+  }>;
+}
+
+/// Build a default i18n filename for a notebook export, e.g.
+/// `ai-session-2026-04-24-claude-desktop.tabularis-notebook`.
+export function defaultExportFilename(
+  sessionId: string,
+  exportData: AiNotebookExport,
+): string {
+  const dateOnly = exportData.createdAt.slice(0, 10);
+  const slug = sessionId.slice(0, 8);
+  return `ai-session-${dateOnly}-${slug}.tabularis-notebook`;
+}
+
+/// Group events by session id, preserving the original order.
+export function groupBySession(
+  events: AiActivityEvent[],
+): Map<string, AiActivityEvent[]> {
+  const map = new Map<string, AiActivityEvent[]>();
+  for (const ev of events) {
+    const list = map.get(ev.sessionId) ?? [];
+    list.push(ev);
+    map.set(ev.sessionId, list);
+  }
+  return map;
+}
+
+/// Build a deep-link URL pointing at the Visual Explain page with a query
+/// pre-populated. The query is base64url-encoded so it survives URL escaping.
+export function buildVisualExplainDeepLink(
+  connectionId: string,
+  query: string,
+): string {
+  return `/visual-explain?connection=${encodeURIComponent(
+    connectionId,
+  )}&query=${base64UrlEncode(query)}`;
+}
+
+export function parseVisualExplainDeepLink(search: string): {
+  connectionId: string | null;
+  query: string | null;
+} {
+  const params = new URLSearchParams(search.startsWith("?") ? search : `?${search}`);
+  const connectionId = params.get("connection");
+  const encoded = params.get("query");
+  const query = encoded ? base64UrlDecode(encoded) : null;
+  return { connectionId, query };
+}
+
+function base64UrlEncode(s: string): string {
+  const bytes =
+    typeof TextEncoder !== "undefined"
+      ? new TextEncoder().encode(s)
+      : Uint8Array.from(s, (c) => c.charCodeAt(0));
+  let binary = "";
+  bytes.forEach((b) => {
+    binary += String.fromCharCode(b);
+  });
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64UrlDecode(s: string): string {
+  let padded = s.replace(/-/g, "+").replace(/_/g, "/");
+  while (padded.length % 4 !== 0) padded += "=";
+  const binary = atob(padded);
+  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+  return typeof TextDecoder !== "undefined"
+    ? new TextDecoder().decode(bytes)
+    : binary;
+}
+
+/// Returns true when the pending approval would be considered destructive
+/// (write or DDL). Use to drive UI emphasis (red border, etc).
+export function isDestructiveApproval(p: PendingApproval): boolean {
+  return p.queryKind === "write" || p.queryKind === "ddl" || p.queryKind === "unknown";
+}

--- a/tests/utils/aiActivity.test.ts
+++ b/tests/utils/aiActivity.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildVisualExplainDeepLink,
+  defaultExportFilename,
+  eventsToCsvLines,
+  formatDurationMs,
+  getQueryKindBadgeStyle,
+  getStatusBadgeStyle,
+  groupBySession,
+  isDestructiveApproval,
+  notebookFileFromExport,
+  parseVisualExplainDeepLink,
+  truncateQuery,
+} from "../../src/utils/aiActivity";
+import type {
+  AiActivityEvent,
+  AiNotebookExport,
+  PendingApproval,
+} from "../../src/types/ai";
+
+const baseEvent = (overrides: Partial<AiActivityEvent> = {}): AiActivityEvent => ({
+  id: "id",
+  sessionId: "s",
+  timestamp: "2026-04-24T10:00:00Z",
+  tool: "run_query",
+  connectionId: "c1",
+  connectionName: "dev",
+  query: "SELECT 1",
+  queryKind: "select",
+  durationMs: 5,
+  status: "success",
+  rows: 1,
+  error: null,
+  clientHint: "claude",
+  approvalId: null,
+  ...overrides,
+});
+
+describe("getStatusBadgeStyle", () => {
+  it("returns green styling for success", () => {
+    const s = getStatusBadgeStyle("success");
+    expect(s.text).toContain("green");
+  });
+
+  it("returns red styling for error and denied", () => {
+    expect(getStatusBadgeStyle("error").text).toContain("red");
+    expect(getStatusBadgeStyle("denied").text).toContain("red");
+  });
+
+  it("returns fallback for unknown status", () => {
+    const s = getStatusBadgeStyle("nope");
+    expect(s.text).toBe("text-muted");
+  });
+});
+
+describe("getQueryKindBadgeStyle", () => {
+  it("differentiates select / write / ddl", () => {
+    expect(getQueryKindBadgeStyle("select").text).toContain("blue");
+    expect(getQueryKindBadgeStyle("write").text).toContain("yellow");
+    expect(getQueryKindBadgeStyle("ddl").text).toContain("orange");
+  });
+
+  it("falls back when null or unknown", () => {
+    expect(getQueryKindBadgeStyle(null).text).toBe("text-muted");
+    expect(getQueryKindBadgeStyle("garbage").text).toBe("text-muted");
+  });
+});
+
+describe("truncateQuery", () => {
+  it("returns empty string for null", () => {
+    expect(truncateQuery(null)).toBe("");
+  });
+
+  it("collapses whitespace", () => {
+    expect(truncateQuery("SELECT\n  1\n  FROM   t")).toBe("SELECT 1 FROM t");
+  });
+
+  it("truncates with ellipsis past limit", () => {
+    const long = "a".repeat(100);
+    expect(truncateQuery(long, 20).endsWith("…")).toBe(true);
+    expect(truncateQuery(long, 20).length).toBe(21);
+  });
+
+  it("does not truncate short queries", () => {
+    expect(truncateQuery("SELECT 1", 80)).toBe("SELECT 1");
+  });
+});
+
+describe("formatDurationMs", () => {
+  it("uses sub-millisecond bucket below 1ms", () => {
+    expect(formatDurationMs(0.4)).toBe("<1 ms");
+  });
+
+  it("uses ms below 1s", () => {
+    expect(formatDurationMs(456)).toBe("456 ms");
+  });
+
+  it("uses seconds below 1 minute", () => {
+    expect(formatDurationMs(1500)).toBe("1.50 s");
+  });
+
+  it("uses minutes+seconds above 1 minute", () => {
+    expect(formatDurationMs(125_000)).toBe("2m 5s");
+  });
+});
+
+describe("eventsToCsvLines", () => {
+  it("returns header and one row per event", () => {
+    const lines = eventsToCsvLines([baseEvent({ id: "a" }), baseEvent({ id: "b" })]);
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toContain("id,session_id");
+  });
+
+  it("escapes quotes and commas", () => {
+    const lines = eventsToCsvLines([
+      baseEvent({ query: 'SELECT "a", "b" FROM t', error: null }),
+    ]);
+    // The query column isn't included in CSV, but error/connection might be —
+    // verify the escape function keeps round-trippable output: we ensure no
+    // bare comma slips into a single-cell value.
+    expect(lines[1].split(",").length).toBeGreaterThanOrEqual(10);
+  });
+
+  it("emits empty cell for null fields", () => {
+    const lines = eventsToCsvLines([baseEvent({ rows: null, error: null, connectionName: null })]);
+    expect(lines[1]).toContain(",,");
+  });
+});
+
+describe("notebookFileFromExport", () => {
+  it("preserves type, content, name, schema", () => {
+    const exp: AiNotebookExport = {
+      version: 1,
+      title: "AI Session abc",
+      createdAt: "2026-04-24T10:00:00Z",
+      cells: [
+        { type: "markdown", content: "# header", name: "Session metadata" },
+        { type: "sql", content: "SELECT 1", name: "Q1", schema: "dev" },
+      ],
+    };
+    const nb = notebookFileFromExport(exp);
+    expect(nb.cells).toHaveLength(2);
+    expect(nb.cells[1]).toEqual({
+      type: "sql",
+      content: "SELECT 1",
+      name: "Q1",
+      schema: "dev",
+    });
+  });
+
+  it("omits optional fields when undefined", () => {
+    const exp: AiNotebookExport = {
+      version: 1,
+      title: "t",
+      createdAt: "2026-04-24T10:00:00Z",
+      cells: [{ type: "sql", content: "SELECT 1" }],
+    };
+    const nb = notebookFileFromExport(exp);
+    expect("name" in nb.cells[0]).toBe(false);
+    expect("schema" in nb.cells[0]).toBe(false);
+  });
+});
+
+describe("defaultExportFilename", () => {
+  it("composes date + slug", () => {
+    const exp: AiNotebookExport = {
+      version: 1,
+      title: "t",
+      createdAt: "2026-04-24T10:00:00Z",
+      cells: [],
+    };
+    expect(defaultExportFilename("abcdef1234567890", exp)).toBe(
+      "ai-session-2026-04-24-abcdef12.tabularis-notebook",
+    );
+  });
+});
+
+describe("groupBySession", () => {
+  it("groups events by session id preserving order", () => {
+    const a = baseEvent({ id: "a", sessionId: "s1" });
+    const b = baseEvent({ id: "b", sessionId: "s2" });
+    const c = baseEvent({ id: "c", sessionId: "s1" });
+    const groups = groupBySession([a, b, c]);
+    expect(groups.size).toBe(2);
+    expect(groups.get("s1")?.map((e) => e.id)).toEqual(["a", "c"]);
+    expect(groups.get("s2")?.map((e) => e.id)).toEqual(["b"]);
+  });
+});
+
+describe("buildVisualExplainDeepLink + parseVisualExplainDeepLink", () => {
+  it("round-trips a query with special characters", () => {
+    const url = buildVisualExplainDeepLink(
+      "conn-1",
+      "SELECT 'a, b', \"c\" FROM users WHERE x = 1",
+    );
+    expect(url.startsWith("/visual-explain?")).toBe(true);
+    const parsed = parseVisualExplainDeepLink(url.split("?")[1]);
+    expect(parsed.connectionId).toBe("conn-1");
+    expect(parsed.query).toBe("SELECT 'a, b', \"c\" FROM users WHERE x = 1");
+  });
+
+  it("returns nulls when params are missing", () => {
+    const parsed = parseVisualExplainDeepLink("");
+    expect(parsed.connectionId).toBeNull();
+    expect(parsed.query).toBeNull();
+  });
+});
+
+describe("isDestructiveApproval", () => {
+  const base: PendingApproval = {
+    id: "x",
+    createdAt: "2026-04-24T10:00:00Z",
+    sessionId: "s",
+    connectionId: "c",
+    connectionName: "dev",
+    query: "UPDATE t",
+    queryKind: "write",
+    clientHint: null,
+    explainPlan: null,
+    explainError: null,
+  };
+
+  it("flags write/ddl/unknown as destructive", () => {
+    expect(isDestructiveApproval(base)).toBe(true);
+    expect(isDestructiveApproval({ ...base, queryKind: "ddl" })).toBe(true);
+    expect(isDestructiveApproval({ ...base, queryKind: "unknown" })).toBe(true);
+  });
+
+  it("does not flag select", () => {
+    expect(isDestructiveApproval({ ...base, queryKind: "select" })).toBe(false);
+  });
+});

--- a/tests/utils/aiActivity.test.ts
+++ b/tests/utils/aiActivity.test.ts
@@ -10,11 +10,15 @@ import {
   isDestructiveApproval,
   notebookFileFromExport,
   parseVisualExplainDeepLink,
+  sessionMatchesSearch,
+  sortAiEvents,
+  sortAiSessions,
   truncateQuery,
 } from "../../src/utils/aiActivity";
 import type {
   AiActivityEvent,
   AiNotebookExport,
+  AiSessionSummary,
   PendingApproval,
 } from "../../src/types/ai";
 
@@ -228,5 +232,130 @@ describe("isDestructiveApproval", () => {
 
   it("does not flag select", () => {
     expect(isDestructiveApproval({ ...base, queryKind: "select" })).toBe(false);
+  });
+});
+
+describe("sortAiEvents", () => {
+  const a = baseEvent({ id: "a", timestamp: "2026-04-24T10:00:00Z", durationMs: 50 });
+  const b = baseEvent({ id: "b", timestamp: "2026-04-24T11:00:00Z", durationMs: 10 });
+  const c = baseEvent({ id: "c", timestamp: "2026-04-24T09:00:00Z", durationMs: 200 });
+
+  it("sorts by timestamp descending (most recent first)", () => {
+    const result = sortAiEvents([a, b, c], "timestamp", "desc");
+    expect(result.map((e) => e.id)).toEqual(["b", "a", "c"]);
+  });
+
+  it("sorts by timestamp ascending", () => {
+    const result = sortAiEvents([a, b, c], "timestamp", "asc");
+    expect(result.map((e) => e.id)).toEqual(["c", "a", "b"]);
+  });
+
+  it("sorts by duration", () => {
+    expect(sortAiEvents([a, b, c], "duration", "asc").map((e) => e.id)).toEqual([
+      "b",
+      "a",
+      "c",
+    ]);
+    expect(sortAiEvents([a, b, c], "duration", "desc").map((e) => e.id)).toEqual([
+      "c",
+      "a",
+      "b",
+    ]);
+  });
+
+  it("places nulls last when sorting nullable fields", () => {
+    const withNull = baseEvent({ id: "n", connectionName: null });
+    const withName = baseEvent({ id: "x", connectionName: "alpha" });
+    const result = sortAiEvents([withNull, withName], "connection", "desc");
+    expect(result[result.length - 1].id).toBe("n");
+  });
+
+  it("is stable when keys tie", () => {
+    const x1 = baseEvent({ id: "x1", durationMs: 10 });
+    const x2 = baseEvent({ id: "x2", durationMs: 10 });
+    const x3 = baseEvent({ id: "x3", durationMs: 10 });
+    const result = sortAiEvents([x1, x2, x3], "duration", "desc");
+    expect(result.map((e) => e.id)).toEqual(["x1", "x2", "x3"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [a, b, c];
+    sortAiEvents(input, "timestamp", "desc");
+    expect(input.map((e) => e.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("orders status from success → blocked → denied → error → timeout", () => {
+    const s1 = baseEvent({ id: "ok", status: "success" });
+    const s2 = baseEvent({ id: "err", status: "error" });
+    const s3 = baseEvent({ id: "den", status: "denied" });
+    const result = sortAiEvents([s2, s3, s1], "status", "asc");
+    expect(result.map((e) => e.id)).toEqual(["ok", "den", "err"]);
+  });
+});
+
+const baseSession = (
+  overrides: Partial<AiSessionSummary> = {},
+): AiSessionSummary => ({
+  sessionId: "s",
+  startedAt: "2026-04-24T10:00:00Z",
+  endedAt: "2026-04-24T10:05:00Z",
+  eventCount: 3,
+  runQueryCount: 1,
+  connectionNames: ["dev"],
+  clientHint: "claude-desktop",
+  ...overrides,
+});
+
+describe("sortAiSessions", () => {
+  const a = baseSession({ sessionId: "a", startedAt: "2026-04-24T10:00:00Z", eventCount: 5 });
+  const b = baseSession({ sessionId: "b", startedAt: "2026-04-24T11:00:00Z", eventCount: 1 });
+  const c = baseSession({ sessionId: "c", startedAt: "2026-04-24T09:00:00Z", eventCount: 10 });
+
+  it("sorts by startedAt descending by default usage", () => {
+    expect(
+      sortAiSessions([a, b, c], "started", "desc").map((s) => s.sessionId),
+    ).toEqual(["b", "a", "c"]);
+  });
+
+  it("sorts by event count", () => {
+    expect(
+      sortAiSessions([a, b, c], "events", "desc").map((s) => s.sessionId),
+    ).toEqual(["c", "a", "b"]);
+  });
+});
+
+describe("sessionMatchesSearch", () => {
+  const session = baseSession({
+    sessionId: "abc12345",
+    clientHint: "claude-desktop",
+    connectionNames: ["dev-db", "stage"],
+  });
+
+  it("matches empty / whitespace query", () => {
+    expect(sessionMatchesSearch(session, "")).toBe(true);
+    expect(sessionMatchesSearch(session, "   ")).toBe(true);
+  });
+
+  it("matches by session id prefix or substring", () => {
+    expect(sessionMatchesSearch(session, "abc12")).toBe(true);
+    expect(sessionMatchesSearch(session, "12345")).toBe(true);
+  });
+
+  it("matches by client hint case-insensitively", () => {
+    expect(sessionMatchesSearch(session, "CLAUDE")).toBe(true);
+  });
+
+  it("matches by any connection name", () => {
+    expect(sessionMatchesSearch(session, "stage")).toBe(true);
+    expect(sessionMatchesSearch(session, "dev-db")).toBe(true);
+  });
+
+  it("returns false when nothing matches", () => {
+    expect(sessionMatchesSearch(session, "missing")).toBe(false);
+  });
+
+  it("handles missing client hint without throwing", () => {
+    const noHint = baseSession({ clientHint: null });
+    expect(sessionMatchesSearch(noHint, "claude")).toBe(false);
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,4 +16,23 @@ export default defineConfig({
     global: 'globalThis',
     'process.env': {},
   },
+  build: {
+    // Monaco editor ships pre-built web workers (ts.worker ~7MB, css.worker ~1MB)
+    // that are loaded lazily on demand — bumping the limit accommodates them.
+    chunkSizeWarningLimit: 8000,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'monaco-editor': ['monaco-editor', '@monaco-editor/react'],
+          recharts: ['recharts'],
+          xyflow: ['@xyflow/react', 'dagre'],
+          'react-vendor': ['react', 'react-dom', 'react-router-dom'],
+          i18n: ['i18next', 'react-i18next', 'i18next-browser-languagedetector'],
+          markdown: ['react-markdown'],
+          table: ['@tanstack/react-table', '@tanstack/react-virtual'],
+          wkx: ['wkx', 'buffer', 'util'],
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
Once an AI assistant can talk directly to your database through MCP, the questions that really matter to whoever is using it are three: what has it done so far, what is it about to do, and how do I know I can trust it? This PR answers those three questions by giving full visibility and control over every operation the AI runs.

## See everything the AI has done

Every call an AI assistant makes against the database — listing connections, describing tables, running a query — is recorded in a local log you can browse from Settings, under the new **AI Activity** section. For each event you can see when it happened, which client made it (Claude Desktop, Cursor, etc.), which connection it touched, what was executed, how long it took and how it ended. Everything stays on the user's machine: no data ever leaves.

The panel has two views:

- **Events**: the chronological list of every operation, with text search inside the queries and filters by tool and status. Every column is sortable (newest first by default) and each row can be opened to see the full detail, copy the query, or send it straight to Visual Explain to study it.
- **Sessions**: the same events grouped by AI conversation. Each session can be searched by id, client or connection, sorted by date or number of operations, and exported as a Tabularis notebook. Exporting it means you can reopen the session like a normal query document — modify it, re-run it, or keep it as evidence of what was done.

## Decide before the AI writes

When the AI is about to run a write operation (UPDATE, DELETE, INSERT, DDL...) the query doesn't go through automatically. An approval window opens showing what the AI wants to do, on which connection, and — whenever the database supports it — a pre-flight execution plan (EXPLAIN) with the estimated cost and the internal operations that will be performed.

From that window the user can:

- **Approve** the query as is;
- **Edit the query** before running it, if the AI suggested something wrong or too aggressive;
- **Deny** it, optionally leaving a reason that stays in the log for the user (or a future reviewer) to look back at.

The execution plan can be expanded to fill the whole window so it can be studied properly — particularly useful on complex queries where the operator graph gets dense.

For anyone who prefers a less blocking flow, settings let you choose between three modes: ask for confirmation on **everything**, only on **writes**, or **never** (at your own risk).

## A dedicated MCP page

The AI client integration now has its own page reachable from the sidebar. From there you can install the configuration automatically for the supported clients, copy the manual commands for anyone who'd rather do it by hand, and discover the available safety options without having to dig through external docs.

## Why it matters

Letting an AI assistant talk to a production — or even just a development — database is convenient, but it requires trust. Without an activity log and without a brake on writes the risk is twofold: destructive operations slipping through silently, and no way to reconstruct what happened after the fact. This PR puts the user back in the middle of the loop: the AI proposes, the user decides, and everything stays tracked and inspectable locally.