### PR TITLE
feat(query-builder): add mini result grid, schema hook, and layout util

### DIFF
--- a/src/components/ui/MiniResultGrid.tsx
+++ b/src/components/ui/MiniResultGrid.tsx
@@ -1,0 +1,143 @@
+import { useRef, useState, useCallback, useMemo } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { ArrowUpDown, Copy, Loader2 } from 'lucide-react';
+import { copyTextToClipboard } from '../../utils/clipboard';
+
+interface MiniResultGridProps {
+  columns: string[];
+  rows: unknown[][];
+  loading?: boolean;
+  message?: string;
+}
+
+export function MiniResultGrid({ columns, rows, loading, message }: MiniResultGridProps) {
+  const parentRef = useRef<HTMLDivElement>(null);
+  const [sortCol, setSortCol] = useState<string | null>(null);
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+
+  const handleSort = useCallback((col: string) => {
+    if (sortCol === col) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortCol(col);
+      setSortDir('asc');
+    }
+  }, [sortCol]);
+
+  const displayRows = useMemo(() => {
+    if (!sortCol) return rows;
+    const idx = columns.indexOf(sortCol);
+    if (idx === -1) return rows;
+    const sorted = [...rows].sort((a, b) => {
+      const av = a[idx] ?? '';
+      const bv = b[idx] ?? '';
+      if (av < bv) return sortDir === 'asc' ? -1 : 1;
+      if (av > bv) return sortDir === 'asc' ? 1 : -1;
+      return 0;
+    });
+    return sorted;
+  }, [rows, sortCol, sortDir, columns]);
+
+  const virtualizer = useVirtualizer({
+    count: displayRows.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 32,
+    overscan: 10,
+  });
+
+  if (loading) {
+    return (
+      <div className="h-full flex items-center justify-center text-muted gap-2">
+        <Loader2 size={18} className="animate-spin" />
+        <span className="text-sm">Running query...</span>
+      </div>
+    );
+  }
+
+  if (message) {
+    return (
+      <div className="h-full flex items-center justify-center text-muted text-sm">
+        {message}
+      </div>
+    );
+  }
+
+  if (columns.length === 0) {
+    return (
+      <div className="h-full flex items-center justify-center text-muted text-sm">
+        No results
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col overflow-hidden text-sm">
+      <div className="flex-1 overflow-auto" ref={parentRef}>
+        <table className="w-full border-collapse">
+          <thead className="sticky top-0 z-10 bg-elevated">
+            <tr>
+              {columns.map((col) => (
+                <th
+                  key={col}
+                  className="text-left px-3 py-1.5 text-xs font-semibold text-secondary border-b border-strong whitespace-nowrap cursor-pointer select-none hover:text-primary transition-colors"
+                  onClick={() => handleSort(col)}
+                >
+                  <div className="flex items-center gap-1">
+                    {col}
+                    <ArrowUpDown size={12} className={sortCol === col ? 'text-blue-400' : 'text-muted opacity-50'} />
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            <tr style={{ height: virtualizer.getTotalSize() }}>
+              <td colSpan={columns.length} className="p-0">
+                <div style={{ position: 'relative', height: `${virtualizer.getTotalSize()}px` }}>
+                  {virtualizer.getVirtualItems().map((virtualRow) => {
+                    const row = displayRows[virtualRow.index];
+                    return (
+                      <div
+                        key={virtualRow.key}
+                        className="flex absolute left-0 w-full border-b border-strong/30 hover:bg-surface-secondary/50 transition-colors"
+                        style={{
+                          height: `${virtualRow.size}px`,
+                          transform: `translateY(${virtualRow.start}px)`,
+                        }}
+                      >
+                        {columns.map((col, colIdx) => {
+                          const value = row[colIdx];
+                          const display = value === null ? 'NULL' : String(value);
+                          return (
+                            <div
+                              key={col}
+                              className="px-3 py-1.5 text-primary whitespace-nowrap overflow-hidden text-ellipsis flex-1 min-w-[80px]"
+                              title={display}
+                            >
+                              <span className={value === null ? 'text-muted italic' : ''}>{display}</span>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    );
+                  })}
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div className="px-3 py-1.5 text-xs text-muted border-t border-strong bg-elevated flex items-center justify-between shrink-0">
+        <span>{rows.length} rows</span>
+        <button
+          onClick={() => copyTextToClipboard(columns.join('\t') + '\n' + rows.map((r) => r.join('\t')).join('\n'))}
+          className="flex items-center gap-1 hover:text-primary transition-colors"
+          title="Copy all"
+        >
+          <Copy size={12} />
+          Copy
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useSchemaMetadata.ts
+++ b/src/hooks/useSchemaMetadata.ts
@@ -1,0 +1,41 @@
+import { useCallback, useState } from 'react';
+import type { TableSchema, ForeignKey } from '../types/editor';
+
+interface SchemaMetadata {
+  schema: TableSchema[] | null;
+  getForeignKeys: (tableName: string) => ForeignKey[];
+  getTableColumns: (tableName: string) => { name: string; type: string }[];
+  loadSchema: (fetcher: () => Promise<TableSchema[]>) => Promise<void>;
+  isLoaded: boolean;
+}
+
+/**
+ * Hook to cache and query schema metadata for the query builder.
+ */
+export function useSchemaMetadata(): SchemaMetadata {
+  const [schema, setSchema] = useState<TableSchema[] | null>(null);
+
+  const loadSchema = useCallback(async (fetcher: () => Promise<TableSchema[]>) => {
+    if (schema) return;
+    const data = await fetcher();
+    setSchema(data);
+  }, [schema]);
+
+  const getForeignKeys = useCallback((tableName: string): ForeignKey[] => {
+    const table = schema?.find((t) => t.name === tableName);
+    return table?.foreign_keys ?? [];
+  }, [schema]);
+
+  const getTableColumns = useCallback((tableName: string): { name: string; type: string }[] => {
+    const table = schema?.find((t) => t.name === tableName);
+    return table?.columns.map((c) => ({ name: c.name, type: c.data_type })) ?? [];
+  }, [schema]);
+
+  return {
+    schema,
+    getForeignKeys,
+    getTableColumns,
+    loadSchema,
+    isLoaded: schema !== null,
+  };
+}

--- a/src/utils/queryBuilderLayout.ts
+++ b/src/utils/queryBuilderLayout.ts
@@ -1,0 +1,56 @@
+import dagre from 'dagre';
+import type { Node, Edge } from '@xyflow/react';
+import type { TableNodeData } from '../components/ui/TableNode';
+
+const NODE_WIDTH = 220;
+const ROW_HEIGHT = 24;
+const HEADER_HEIGHT = 40;
+const RANK_SEP = 180;
+const NODE_SEP = 60;
+
+export interface LayoutOptions {
+  direction?: 'LR' | 'TB';
+  preserveNodeIds?: Set<string>;
+}
+
+export function layoutQueryBuilderGraph(
+  nodes: Node<TableNodeData>[],
+  edges: Edge[],
+  options: LayoutOptions = {}
+): Node<TableNodeData>[] {
+  const { direction = 'LR', preserveNodeIds } = options;
+
+  const dagreGraph = new dagre.graphlib.Graph();
+  dagreGraph.setDefaultEdgeLabel(() => ({}));
+  dagreGraph.setGraph({
+    rankdir: direction,
+    ranksep: RANK_SEP,
+    nodesep: NODE_SEP,
+  });
+
+  nodes.forEach((node) => {
+    const height = HEADER_HEIGHT + (node.data.columns?.length ?? 0) * ROW_HEIGHT;
+    dagreGraph.setNode(node.id, { width: NODE_WIDTH, height });
+  });
+
+  edges.forEach((edge) => {
+    dagreGraph.setEdge(edge.source, edge.target);
+  });
+
+  dagre.layout(dagreGraph);
+
+  return nodes.map((node) => {
+    if (preserveNodeIds?.has(node.id)) {
+      return node;
+    }
+
+    const nodeWithPosition = dagreGraph.node(node.id);
+    return {
+      ...node,
+      position: {
+        x: nodeWithPosition.x - NODE_WIDTH / 2,
+        y: nodeWithPosition.y - nodeWithPosition.height / 2,
+      },
+    };
+  });
+}

--- a/tests/utils/queryBuilderLayout.test.ts
+++ b/tests/utils/queryBuilderLayout.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { layoutQueryBuilderGraph } from '../../src/utils/queryBuilderLayout';
+import type { Node, Edge } from '@xyflow/react';
+import type { TableNodeData } from '../../src/components/ui/TableNode';
+
+describe('queryBuilderLayout', () => {
+  it('should layout nodes without overlap', () => {
+    const nodes: Node<TableNodeData>[] = [
+      { id: 'a', type: 'table', position: { x: 0, y: 0 }, data: { label: 'users', columns: [{ name: 'id', type: 'INT' }], selectedColumns: {}, columnAggregations: {}, columnAliases: {} } },
+      { id: 'b', type: 'table', position: { x: 0, y: 0 }, data: { label: 'posts', columns: [{ name: 'id', type: 'INT' }, { name: 'title', type: 'VARCHAR' }], selectedColumns: {}, columnAggregations: {}, columnAliases: {} } },
+      { id: 'c', type: 'table', position: { x: 0, y: 0 }, data: { label: 'comments', columns: [{ name: 'id', type: 'INT' }], selectedColumns: {}, columnAggregations: {}, columnAliases: {} } },
+    ];
+    const edges: Edge[] = [
+      { id: 'e1', source: 'a', target: 'b', type: 'join' },
+      { id: 'e2', source: 'b', target: 'c', type: 'join' },
+    ];
+
+    const result = layoutQueryBuilderGraph(nodes, edges, { direction: 'LR' });
+
+    expect(result).toHaveLength(3);
+    const uniqueX = new Set(result.map((n) => Math.round(n.position.x)));
+    const uniqueY = new Set(result.map((n) => Math.round(n.position.y)));
+    // At least some nodes should be separated horizontally or vertically
+    expect(uniqueX.size + uniqueY.size).toBeGreaterThan(2);
+  });
+
+  it('should preserve nodes in preserveNodeIds', () => {
+    const nodes: Node<TableNodeData>[] = [
+      { id: 'a', type: 'table', position: { x: 100, y: 200 }, data: { label: 'users', columns: [], selectedColumns: {}, columnAggregations: {}, columnAliases: {} } },
+      { id: 'b', type: 'table', position: { x: 0, y: 0 }, data: { label: 'posts', columns: [], selectedColumns: {}, columnAggregations: {}, columnAliases: {} } },
+    ];
+    const edges: Edge[] = [];
+
+    const result = layoutQueryBuilderGraph(nodes, edges, { direction: 'LR', preserveNodeIds: new Set(['a']) });
+
+    const preserved = result.find((n) => n.id === 'a');
+    expect(preserved?.position).toEqual({ x: 100, y: 200 });
+  });
+});

--- a/tsconfig.tsbuildinfo
+++ b/tsconfig.tsbuildinfo
@@ -1,0 +1,1 @@
+{"fileNames":[],"fileInfos":[],"root":[],"version":"5.9.3"}


### PR DESCRIPTION
Includes virtualized table, schema metadata cache, and dagre-based graph layout