### PR TITLE
bug: changeed connections configuration so input fiels do not look prefilled if they are not

### DIFF
--- a/src/components/modals/NewConnectionModal.tsx
+++ b/src/components/modals/NewConnectionModal.tsx
@@ -102,7 +102,7 @@ const FieldInput = ({
       autoCapitalize="off"
       autoComplete="off"
       spellCheck={false}
-      className="w-full px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary placeholder:text-muted focus:border-blue-500 focus:outline-none transition-colors"
+      className="w-full px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary placeholder:text-muted placeholder:italic focus:border-blue-500 focus:outline-none transition-colors"
     />
   </div>
 );
@@ -595,7 +595,7 @@ export const NewConnectionModal = ({
               autoCapitalize="off"
               autoComplete="off"
               spellCheck={false}
-              className="flex-1 px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary placeholder:text-muted focus:border-blue-500 focus:outline-none transition-colors"
+              className="flex-1 px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary placeholder:text-muted placeholder:italic focus:border-blue-500 focus:outline-none transition-colors"
               placeholder={
                 activeDriver.capabilities.folder_based
                   ? t("newConnection.folderPathPlaceholder")
@@ -652,7 +652,7 @@ export const NewConnectionModal = ({
                   autoComplete="off"
                   spellCheck={false}
                   className={clsx(
-                    "flex-1 px-3 py-2 bg-base border rounded-md text-sm text-primary placeholder:text-muted focus:border-blue-500 focus:outline-none transition-colors",
+                    "flex-1 px-3 py-2 bg-base border rounded-md text-sm text-primary placeholder:text-muted placeholder:italic focus:border-blue-500 focus:outline-none transition-colors",
                     connectionStringError ? "border-red-500" : "border-strong",
                   )}
                   placeholder={connectionStringPlaceholder}
@@ -700,7 +700,7 @@ export const NewConnectionModal = ({
               label={t("newConnection.username")}
               value={formData.username}
               onChange={(v) => updateField("username", v)}
-              placeholder="root"
+              placeholder={t("newConnection.usernamePlaceholder")}
             />
             <FieldInput
               label={t("newConnection.password")}
@@ -771,7 +771,7 @@ export const NewConnectionModal = ({
                   autoCapitalize="off"
                   autoComplete="off"
                   spellCheck={false}
-                  className="w-full px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary placeholder:text-muted focus:border-blue-500 focus:outline-none transition-colors"
+                  className="w-full px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary placeholder:text-muted placeholder:italic focus:border-blue-500 focus:outline-none transition-colors"
                   placeholder={t("newConnection.dbNamePlaceholder")}
                 />
               )}
@@ -1002,7 +1002,7 @@ export const NewConnectionModal = ({
                 autoCapitalize="off"
                 autoComplete="off"
                 spellCheck={false}
-                className="flex-1 px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary placeholder:text-muted focus:border-blue-500 focus:outline-none transition-colors"
+                className="flex-1 px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary placeholder:text-muted placeholder:italic focus:border-blue-500 focus:outline-none transition-colors"
               />
               <button
                 type="button"
@@ -1040,7 +1040,7 @@ export const NewConnectionModal = ({
                 autoCapitalize="off"
                 autoComplete="off"
                 spellCheck={false}
-                className="flex-1 px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary placeholder:text-muted focus:border-blue-500 focus:outline-none transition-colors"
+                className="flex-1 px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary placeholder:text-muted placeholder:italic focus:border-blue-500 focus:outline-none transition-colors"
               />
               <button
                 type="button"
@@ -1078,7 +1078,7 @@ export const NewConnectionModal = ({
                 autoCapitalize="off"
                 autoComplete="off"
                 spellCheck={false}
-                className="flex-1 px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary placeholder:text-muted focus:border-blue-500 focus:outline-none transition-colors"
+                className="flex-1 px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary placeholder:text-muted placeholder:italic focus:border-blue-500 focus:outline-none transition-colors"
               />
               <button
                 type="button"
@@ -1252,7 +1252,7 @@ export const NewConnectionModal = ({
                     autoCapitalize="off"
                     autoComplete="off"
                     spellCheck={false}
-                    className="w-full px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary placeholder:text-muted focus:border-blue-500 focus:outline-none transition-colors"
+                    className="w-full px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary placeholder:text-muted placeholder:italic focus:border-blue-500 focus:outline-none transition-colors"
                   />
                   {formData.save_in_keychain &&
                     sshPasswordDirty &&

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -574,6 +574,7 @@
     "password": "Passwort",
     "passwordMissing": "Passwort fehlt oder ist nicht gesetzt. Bitte erneut eingeben.",
     "passwordPlaceholder": "Passwort eingeben",
+    "usernamePlaceholder": "Benutzername eingeben",
     "filePath": "Dateipfad",
     "folderPath": "Ordnerpfad",
     "dbName": "Datenbankname",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -574,6 +574,7 @@
     "password": "Password",
     "passwordMissing": "Password missing or not set. Please re-enter.",
     "passwordPlaceholder": "Enter password",
+    "usernamePlaceholder": "Enter username",
     "filePath": "File Path",
     "folderPath": "Folder Path",
     "dbName": "Database Name",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -574,6 +574,7 @@
     "password": "Contraseña",
     "passwordMissing": "Contraseña faltante. Por favor, ingrésala de nuevo.",
     "passwordPlaceholder": "Ingresa la contraseña",
+    "usernamePlaceholder": "Ingresa el nombre de usuario",
     "filePath": "Ruta del Archivo",
     "folderPath": "Ruta de la Carpeta",
     "dbName": "Nombre de la Base de Datos",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -574,6 +574,7 @@
     "password": "Mot de passe",
     "passwordMissing": "Mot de passe manquant ou non défini. Veuillez le ressaisir.",
     "passwordPlaceholder": "Saisir le mot de passe",
+    "usernamePlaceholder": "Saisir le nom d'utilisateur",
     "filePath": "Chemin du fichier",
     "folderPath": "Chemin du dossier",
     "dbName": "Nom de la base de données",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -574,6 +574,7 @@
     "password": "Password",
     "passwordMissing": "Password mancante. Per favore reinseriscila.",
     "passwordPlaceholder": "Inserisci password",
+    "usernamePlaceholder": "Inserisci nome utente",
     "filePath": "Percorso File",
     "folderPath": "Percorso Cartella",
     "dbName": "Nome Database",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -544,6 +544,7 @@
     "password": "密码",
     "passwordMissing": "密码缺失或未设置。请重新输入。",
     "passwordPlaceholder": "输入密码",
+    "usernamePlaceholder": "输入用户名",
     "filePath": "文件路径",
     "folderPath": "文件夹路径",
     "dbName": "数据库名称",


### PR DESCRIPTION
fix: make placeholder text visually distinct in the new connection modal

  Input fields in the new connection modal were indistinguishable between placeholder hints and
  actual configured values. Users reported that hint text like "root" in the username field
  appeared as if it were a saved value, causing confusion about what was actually stored in the
  connection.

  Changes

  - Italic placeholders — added placeholder:italic to all input fields in NewConnectionModal (host,
   port, username, password, database, connection string, SSL paths, SSH fields). Italic styling
  makes it immediately clear that the text is a hint, not a configured value.
  - Translated username placeholder — replaced the hardcoded "root" placeholder in the username
  field with a localized t("newConnection.usernamePlaceholder") key, consistent with how the
  password field already works.
  - i18n — added usernamePlaceholder to all 6 supported locales: en, de, es, fr, it, zh.