### PR TITLE
Add multi-row deletion via context menu

### DIFF
--- a/src/components/ui/DataGrid.tsx
+++ b/src/components/ui/DataGrid.tsx
@@ -84,6 +84,7 @@ interface DataGridProps {
   onDiscardInsertion?: (tempId: string) => void;
   onRevertDeletion?: (pkVal: unknown) => void;
   onMarkForDeletion?: (pkVal: unknown) => void;
+  onMarkMultipleForDeletion?: (pkVals: unknown[]) => void;
   selectedRows?: Set<number>;
   onSelectionChange?: (indices: Set<number>) => void;
   copyFormat?: "csv" | "json";
@@ -113,6 +114,7 @@ export const DataGrid = React.memo(
     onDiscardInsertion,
     onRevertDeletion,
     onMarkForDeletion,
+    onMarkMultipleForDeletion,
     selectedRows: externalSelectedRows,
     onSelectionChange,
     copyFormat,
@@ -679,26 +681,43 @@ export const DataGrid = React.memo(
     const deleteSelectedRow = useCallback(() => {
       if (!contextMenu) return;
 
-      const isInsertion = contextMenu.mergedRow?.type === "insertion";
-      const tempId = contextMenu.mergedRow?.tempId;
+      // If the right-clicked row is part of a multi-selection, delete all selected rows.
+      // Otherwise fall back to deleting just the right-clicked row.
+      const rightClickedIsSelected = selectedRowIndices.has(contextMenu.rowIndex);
+      const indicesToDelete =
+        rightClickedIsSelected && selectedRowIndices.size > 1
+          ? Array.from(selectedRowIndices)
+          : [contextMenu.rowIndex];
 
-      // Handle insertion row deletion (discard)
-      if (isInsertion && tempId && onDiscardInsertion) {
-        onDiscardInsertion(tempId);
-        setContextMenu(null);
-        return;
+      const pkVals: unknown[] = [];
+      for (const idx of indicesToDelete) {
+        const mergedRow = mergedRows[idx];
+        if (!mergedRow) continue;
+
+        if (mergedRow.type === "insertion" && mergedRow.tempId && onDiscardInsertion) {
+          onDiscardInsertion(mergedRow.tempId);
+        } else if (mergedRow.type === "existing" && pkColumn && pkIndexMap !== null) {
+          pkVals.push(mergedRow.rowData[pkIndexMap]);
+        }
       }
 
-      // For existing rows, mark for deletion
-      if (pkColumn && pkIndexMap !== null && onMarkForDeletion) {
-        const pkVal = contextMenu.row[pkIndexMap];
-        onMarkForDeletion(pkVal);
-        setContextMenu(null);
+      // Use batch handler to avoid stale-closure overwrites when called per-row.
+      if (pkVals.length > 0) {
+        if (onMarkMultipleForDeletion) {
+          onMarkMultipleForDeletion(pkVals);
+        } else if (onMarkForDeletion) {
+          pkVals.forEach((v) => onMarkForDeletion(v));
+        }
       }
+
+      setContextMenu(null);
     }, [
       contextMenu,
+      selectedRowIndices,
+      mergedRows,
       onDiscardInsertion,
       onMarkForDeletion,
+      onMarkMultipleForDeletion,
       pkColumn,
       pkIndexMap,
     ]);
@@ -1240,6 +1259,10 @@ export const DataGrid = React.memo(
               const canRevert =
                 isInsertion || hasPendingChanges || hasPendingDeletion;
 
+              const deleteRowCount = selectedRowIndices.has(contextMenu.rowIndex)
+                ? selectedRowIndices.size
+                : 1;
+
               // Determine which cell value options to show based on column properties
               const { colName } = contextMenu;
               const isAutoIncrement = autoIncrementColumns?.includes(colName);
@@ -1303,7 +1326,9 @@ export const DataGrid = React.memo(
                     action: openSidebarEditor,
                   },
                   {
-                    label: t("dataGrid.deleteRow"),
+                    label: deleteRowCount > 1
+                      ? t("dataGrid.deleteRows", { count: deleteRowCount })
+                      : t("dataGrid.deleteRow"),
                     icon: Trash2,
                     danger: true,
                     action: deleteSelectedRow,

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -645,6 +645,7 @@
     "noData": "Keine Daten zum Anzeigen",
     "editRow": "Zeile bearbeiten",
     "deleteRow": "Zeile löschen",
+    "deleteRows": "{{count}} Zeilen löschen",
     "confirmDelete": "Möchtest du diese Zeile wirklich löschen?",
     "deleteTitle": "Zeile löschen",
     "updateFailed": "Aktualisierung fehlgeschlagen: ",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -645,6 +645,7 @@
     "noData": "No data to display",
     "editRow": "Edit Row",
     "deleteRow": "Delete Row",
+    "deleteRows": "Delete {{count}} rows",
     "confirmDelete": "Are you sure you want to delete this row?",
     "deleteTitle": "Delete Row",
     "updateFailed": "Update failed: ",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -645,6 +645,7 @@
     "noData": "No hay datos para mostrar",
     "editRow": "Editar Fila",
     "deleteRow": "Eliminar Fila",
+    "deleteRows": "Eliminar {{count}} filas",
     "confirmDelete": "¿Estás seguro de que deseas eliminar esta fila?",
     "deleteTitle": "Eliminar Fila",
     "updateFailed": "Error en la actualización: ",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -645,6 +645,7 @@
     "noData": "Aucune donnée à afficher",
     "editRow": "Modifier la ligne",
     "deleteRow": "Supprimer la ligne",
+    "deleteRows": "Supprimer {{count}} lignes",
     "confirmDelete": "Voulez-vous vraiment supprimer cette ligne ?",
     "deleteTitle": "Supprimer la ligne",
     "updateFailed": "Échec de la mise à jour : ",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -645,6 +645,7 @@
     "noData": "Nessun dato da visualizzare",
     "editRow": "Modifica riga",
     "deleteRow": "Elimina riga",
+    "deleteRows": "Elimina {{count}} righe",
     "confirmDelete": "Sei sicuro di voler eliminare questa riga?",
     "deleteTitle": "Elimina riga",
     "updateFailed": "Aggiornamento fallito: ",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -615,6 +615,7 @@
     "noData": "无数据显示",
     "editRow": "编辑行",
     "deleteRow": "删除行",
+    "deleteRows": "删除 {{count}} 行",
     "confirmDelete": "确定要删除此行吗？",
     "deleteTitle": "删除行",
     "updateFailed": "更新失败：",

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -1411,6 +1411,23 @@ export const Editor = () => {
     [updateTab],
   );
 
+  const handleMarkMultipleForDeletion = useCallback(
+    (pkVals: unknown[]) => {
+      if (!activeTabIdRef.current) return;
+      const tabId = activeTabIdRef.current;
+      const currentTab = tabsRef.current.find((t) => t.id === tabId);
+      if (!currentTab) return;
+
+      const newPendingDeletions = { ...(currentTab.pendingDeletions || {}) };
+      for (const pkVal of pkVals) {
+        newPendingDeletions[String(pkVal)] = pkVal;
+      }
+
+      updateTab(tabId, { pendingDeletions: newPendingDeletions });
+    },
+    [updateTab],
+  );
+
   const handleNewRow = useCallback(async () => {
     if (
       !activeTabIdRef.current ||
@@ -3053,6 +3070,7 @@ export const Editor = () => {
                     onDiscardInsertion={handleDiscardInsertion}
                     onRevertDeletion={handleRevertDeletion}
                     onMarkForDeletion={handleMarkForDeletion}
+                    onMarkMultipleForDeletion={handleMarkMultipleForDeletion}
                     selectedRows={new Set(activeTab.selectedRows || [])}
                     onSelectionChange={handleSelectionChange}
                     copyFormat={copyFormat}


### PR DESCRIPTION
feat(data-grid): multi-row deletion via context menu

  Users could previously only delete one row at a time from the context menu, even when multiple
  rows were selected. This change makes the context menu deletion respect the current selection.

  What changed

  Multi-row delete via context menu
  - Right-click on any row that is part of a multi-selection → context menu now shows "Delete X
  rows" and marks all selected rows for deletion at once
  - Right-clicking a row that is not part of the current selection still deletes only that single
  row — no change to existing behaviour
  - Works for both regular rows and unsaved insertion rows (new rows are discarded, existing rows
  are marked for deletion as before and still require an explicit save)

  Bug fix: stale state overwrites
  - The previous per-row callback (onMarkForDeletion) read pendingDeletions from a ref snapshot on
  every call. In a loop this meant each call saw the same stale object and only the last pk value
  survived. Fixed by collecting all pk values first and applying them in a single updateTab call
  via the new onMarkMultipleForDeletion prop.

  i18n
  - Added deleteRows key with {{count}} interpolation to all 6 supported locales: en, de, es, fr,
  it, zh