### PR TITLE
feat: Make database selector dropdowns scrollable after 10 entries

### DIFF
--- a/src/components/notebook/NotebookCellHeader.tsx
+++ b/src/components/notebook/NotebookCellHeader.tsx
@@ -203,7 +203,7 @@ export function NotebookCellHeader({
                   className="fixed inset-0 z-40"
                   onClick={() => setIsDbOpen(false)}
                 />
-                <div className="absolute top-full left-0 mt-1 min-w-[120px] bg-surface-secondary border border-strong rounded shadow-xl z-50 flex flex-col py-1">
+                <div className="absolute top-full left-0 mt-1 min-w-[120px] max-h-[230px] overflow-y-auto bg-surface-secondary border border-strong rounded shadow-xl z-50 flex flex-col py-1">
                   {selectedDatabases.map((db) => (
                     <button
                       key={db}

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -2475,7 +2475,7 @@ export const Editor = () => {
                   className="fixed inset-0 z-40"
                   onClick={() => setIsDbDropdownOpen(false)}
                 />
-                <div className="absolute top-full right-0 mt-1 min-w-[140px] bg-surface-secondary border border-strong rounded shadow-xl z-50 flex flex-col py-1">
+                <div className="absolute top-full right-0 mt-1 min-w-[140px] max-h-[280px] overflow-y-auto bg-surface-secondary border border-strong rounded shadow-xl z-50 flex flex-col py-1">
                   {selectedDatabases.map((db) => (
                     <button
                       key={db}


### PR DESCRIPTION
Make database selector dropdowns scrollable after 10 entries

  When connecting to a server with many databases/schemas, the database selector dropdown in the
  editor toolbar and in notebook cell headers would grow unbounded and overflow the application
  window.

  Cap both dropdowns at a fixed height sized for ~10 entries (280px in the editor, 230px in the
  notebook cell header to match the smaller item size) and add overflow-y-auto so the list scrolls
  when it exceeds that limit.

  Files changed
  - src/pages/Editor.tsx — editor toolbar db selector
  - src/components/notebook/NotebookCellHeader.tsx — notebook cell db selector