### PR TITLE
fix(postgres): switch deadpool TLS to rustls + honor ssl_ca (closes #166)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1283,8 +1283,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "der_derive",
+ "flagset",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1781,6 +1794,12 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flate2"
@@ -4366,18 +4385,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "postgres-native-tls"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac73153d92e4bde922bd6f1dfba7f1ab8132266c031153b55e20a1521cd36d49"
-dependencies = [
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tokio-postgres",
-]
-
-[[package]]
 name = "postgres-protocol"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5168,6 +5175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5186,6 +5194,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.7.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -6152,15 +6169,16 @@ dependencies = [
  "infer 0.16.0",
  "keyring",
  "log",
- "native-tls",
  "notify",
  "once_cell",
  "openssl",
- "postgres-native-tls",
  "reqwest",
  "russh",
  "russh-keys",
  "rust_decimal",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -6177,6 +6195,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-postgres",
+ "tokio-postgres-rustls",
  "urlencoding",
  "uuid",
  "zip",
@@ -6757,6 +6776,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6785,16 +6825,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-postgres"
 version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6818,6 +6848,21 @@ dependencies = [
  "tokio",
  "tokio-util",
  "whoami 2.1.1",
+]
+
+[[package]]
+name = "tokio-postgres-rustls"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d684bad428a0f2481f42241f821db42c54e2dc81d8c00db8536c506b0a0144"
+dependencies = [
+ "const-oid",
+ "ring",
+ "rustls",
+ "tokio",
+ "tokio-postgres",
+ "tokio-rustls",
+ "x509-cert",
 ]
 
 [[package]]
@@ -8484,6 +8529,18 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+ "tls_codec",
+]
 
 [[package]]
 name = "xattr"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -56,8 +56,14 @@ zip = "4.2.0"
 tauri-plugin-clipboard-manager = "2"
 tokio-postgres = { version = "0.7.13", features = ["with-chrono-0_4", "with-uuid-1", "with-serde_json-1", "array-impls"] }
 deadpool-postgres = "0.14.1"
-postgres-native-tls = "0.5.1"
-native-tls = "0.2.13"
+# rustls is used for the PostgreSQL deadpool TLS path. native-tls (used by
+# sqlx and the MySQL pool) trips macOS Secure Transport's strict EKU checks
+# on user-supplied root anchors (e.g. the AWS RDS bundle), so the Postgres
+# pool routes through rustls + the platform verifier instead.
+tokio-postgres-rustls = "0.13"
+rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
+rustls-pemfile = "2"
+rustls-platform-verifier = "0.6"
 notify = "6"
 
 # GTK dependencies for Wayland window title workaround (Linux only)

--- a/src-tauri/src/drivers/postgres/mod.rs
+++ b/src-tauri/src/drivers/postgres/mod.rs
@@ -1215,11 +1215,14 @@ impl DatabaseDriver for PostgresDriver {
             return Err("No active connection pool".into());
         }
         let pool = crate::pool_manager::get_postgres_pool_with_id(params, conn_id).await?;
-        let client = pool.get().await.map_err(|e| e.to_string())?;
+        let client = pool
+            .get()
+            .await
+            .map_err(|e| crate::pool_manager::format_error_chain(&e))?;
         client
             .simple_query("SELECT 1")
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| crate::pool_manager::format_error_chain(&e))?;
         Ok(())
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -39,6 +39,8 @@ pub mod paths; // Added
 pub mod persistence;
 pub mod plugins;
 pub mod pool_manager;
+#[cfg(test)]
+pub mod pool_manager_tests;
 pub mod preferences;
 pub mod query_history;
 #[cfg(test)]

--- a/src-tauri/src/pool_manager.rs
+++ b/src-tauri/src/pool_manager.rs
@@ -1,14 +1,37 @@
 use crate::models::ConnectionParams;
 use deadpool_postgres::{Manager as PgPoolManager, Pool as PgPool};
-use native_tls::TlsConnector;
 use once_cell::sync::Lazy;
-use postgres_native_tls::MakeTlsConnector;
+use rustls::{ClientConfig, RootCertStore};
+use rustls_platform_verifier::BuilderVerifierExt;
 use sqlx::{sqlite::SqliteConnectOptions, MySql, Pool, Sqlite};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
 use tokio_postgres::{config::SslMode as PgSslMode, Config as PgConfig};
+use tokio_postgres_rustls::MakeRustlsConnect;
+
+/// `tokio_postgres` renders only the top-level error kind ("error performing
+/// TLS handshake"); the concrete cause lives in the `source()` chain.
+pub(crate) fn format_error_chain<E: std::error::Error + ?Sized>(err: &E) -> String {
+    let mut out = err.to_string();
+    let mut source = err.source();
+    while let Some(cause) = source {
+        out.push_str(" -> ");
+        out.push_str(&cause.to_string());
+        source = cause.source();
+    }
+    out
+}
+
+/// rustls 0.23 needs a process-level `CryptoProvider`; install once.
+fn ensure_rustls_crypto_provider() {
+    use std::sync::Once;
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
 
 type PoolMap<T> = Arc<RwLock<HashMap<String, Pool<T>>>>;
 type PgPoolMap = Arc<RwLock<HashMap<String, PgPool>>>;
@@ -134,6 +157,57 @@ fn build_postgres_configurations(params: &ConnectionParams) -> PgConfig {
     }
 
     cfg
+}
+
+/// Build the rustls connector for the PostgreSQL pool.
+///
+/// `rustls` (not `native-tls`) because macOS Secure Transport applies a
+/// strict `id-kp-serverAuth` EKU check to user-supplied root anchors, which
+/// rejects valid CA certs with "The extended key usage is not valid".
+///
+/// `ssl_ca` (PEM file or bundle) overrides the platform trust store. This
+/// is the path RDS users take: the macOS keychain does not trust the
+/// regional Amazon RDS root CAs, so they must supply
+/// `https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem`
+/// (or a region-specific bundle) via the connection's CA Certificate field.
+///
+/// We deliberately do NOT vendor the RDS bundle in the repo: AWS rotates
+/// these CAs every 1-3 years, and shipping a stale bundle in a release
+/// silently breaks RDS users until they upgrade. Distributors who want
+/// out-of-the-box RDS support can pull a fresh bundle at packaging time
+/// (e.g. via a Dockerfile `RUN curl ...` or a build script that drops it
+/// into `src-tauri/assets/`) and point users at the resulting path.
+fn build_postgres_tls_connector(params: &ConnectionParams) -> Result<MakeRustlsConnect, String> {
+    ensure_rustls_crypto_provider();
+    let builder = ClientConfig::builder();
+    let user_ca = params.ssl_ca.as_deref().filter(|s| !s.trim().is_empty());
+    let config = match user_ca {
+        Some(ca_path) => {
+            let pem = std::fs::read(ca_path)
+                .map_err(|e| format!("Failed to read ssl_ca file '{}': {}", ca_path, e))?;
+            let mut roots = RootCertStore::empty();
+            let mut cursor = std::io::Cursor::new(&pem[..]);
+            for cert in rustls_pemfile::certs(&mut cursor) {
+                let cert = cert
+                    .map_err(|e| format!("Failed to parse ssl_ca '{}': {}", ca_path, e))?;
+                roots.add(cert).map_err(|e| {
+                    format!("Failed to add ssl_ca cert from '{}': {}", ca_path, e)
+                })?;
+            }
+            if roots.is_empty() {
+                return Err(format!(
+                    "ssl_ca '{}' contained no PEM CERTIFICATE blocks",
+                    ca_path
+                ));
+            }
+            builder.with_root_certificates(roots).with_no_client_auth()
+        }
+        None => builder
+            .with_platform_verifier()
+            .map_err(|e| format!("Failed to build platform TLS verifier: {}", e))?
+            .with_no_client_auth(),
+    };
+    Ok(MakeRustlsConnect::new(config))
 }
 
 fn build_sqlite_connectoptions(params: &ConnectionParams) -> SqliteConnectOptions {
@@ -263,17 +337,18 @@ pub async fn get_postgres_pool_with_id(
 
     let cfg = build_postgres_configurations(params);
 
-    let tls_connector = MakeTlsConnector::new(TlsConnector::new().map_err(|e| {
-        log::error!("Failed to create Tls Connector for PostgreSQL pool: {}", e);
-        e.to_string()
-    })?);
+    let tls_connector = build_postgres_tls_connector(params).map_err(|e| {
+        log::error!("Failed to create TLS connector for PostgreSQL pool: {}", e);
+        e
+    })?;
 
     let pool = PgPool::builder(PgPoolManager::new(cfg, tls_connector))
         .max_size(10)
         .build()
         .map_err(|e| {
-            log::error!("Failed to create PostgreSQL connection pool: {}", e);
-            e.to_string()
+            let detail = format_error_chain(&e);
+            log::error!("Failed to create PostgreSQL connection pool: {}", detail);
+            detail
         })?;
 
     log::info!(

--- a/src-tauri/src/pool_manager_tests.rs
+++ b/src-tauri/src/pool_manager_tests.rs
@@ -1,0 +1,37 @@
+#[cfg(test)]
+mod tests {
+    use crate::pool_manager::format_error_chain;
+
+    #[test]
+    fn format_error_chain_walks_sources() {
+        use std::error::Error as StdError;
+        use std::fmt;
+
+        #[derive(Debug)]
+        struct Inner;
+        impl fmt::Display for Inner {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("inner cause")
+            }
+        }
+        impl StdError for Inner {}
+
+        #[derive(Debug)]
+        struct Outer(Inner);
+        impl fmt::Display for Outer {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("outer message")
+            }
+        }
+        impl StdError for Outer {
+            fn source(&self) -> Option<&(dyn StdError + 'static)> {
+                Some(&self.0)
+            }
+        }
+
+        assert_eq!(
+            format_error_chain(&Outer(Inner)),
+            "outer message -> inner cause"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #166. The Postgres deadpool path used `postgres-native-tls`. On macOS this triggered two stacked failures against AWS RDS endpoints — first conn ok, every reconnect/health-check ping fails:

1. Secure Transport applies a strict `id-kp-serverAuth` EKU check to user-supplied root anchors → "The extended key usage is not valid" when the user pastes the AWS RDS bundle.
2. The macOS keychain does not trust the regional Amazon RDS root CAs out of the box → platform verification fails with `errSecNotTrusted` (-67843) even without a custom CA.

`tokio_postgres::Error::Display` only prints "error performing TLS handshake", which hid the real cause. Walking `source()` made both surface.

## Change

- Replace `postgres-native-tls` with `tokio-postgres-rustls` for the **Postgres deadpool pool only**. MySQL pool and sqlx keep `native-tls`.
- `rustls-platform-verifier` provides default trust without the Secure Transport EKU quirk.
- Honor `params.ssl_ca` (PEM file/bundle) so users pin RDS or any custom CA from the connection's "CA Certificate" field.
- Surface the full `source()` chain on ping/pool failures.

## Why no bundled RDS CA

We deliberately do **not** vendor `global-bundle.pem`:
- AWS rotates these CAs every 1-3 years; a vendored bundle silently breaks RDS users on released app versions until a new build ships.
- Repo bloat (~165 KB binary, 108 PEM blocks).

Distributors who want out-of-the-box RDS support can pull the bundle at packaging time:

```dockerfile
# Dockerfile
RUN curl -fsSLo /app/src-tauri/assets/rds-global-bundle.pem \\
    https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
```

```bash
# build script
mkdir -p src-tauri/assets
curl -fsSLo src-tauri/assets/rds-global-bundle.pem \\
    https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
```

## End-user workflow for RDS

1. Download \`https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem\`.
2. Connection edit → SSL → CA Certificate = path to that file.
3. Save.

## Test plan

- [x] \`cargo test --lib\` — all relevant tests pass; 2 pre-existing flakes in \`updater::tests\` (\`test_detect_installation_source_{flatpak,snap}\`) verified on \`main\` too.
- [x] Reporter (myself, macOS, eu-central-1 RDS, regional cert): with \`global-bundle.pem\` set as CA Certificate the connection opens, schemas load, and health-check ping survives multiple cycles. Without the bundle the platform verifier path returns the real \`errSecNotTrusted\` error rather than a masked one.
- [ ] Maintainer to confirm on a non-RDS Postgres (system-trusted cert) that platform verifier path still works.