### PR TITLE
feat(data-grid): add SQL INSERT as a copy format option

### DIFF
--- a/src/components/settings/GeneralTab.tsx
+++ b/src/components/settings/GeneralTab.tsx
@@ -53,6 +53,7 @@ export function GeneralTab() {
             options={[
               { value: "csv", label: "CSV" },
               { value: "json", label: "JSON" },
+              { value: "sql-insert", label: "SQL INSERT" },
             ]}
           />
         </SettingRow>

--- a/src/components/ui/DataGrid.tsx
+++ b/src/components/ui/DataGrid.tsx
@@ -59,6 +59,7 @@ import { useDatabase } from "../../hooks/useDatabase";
 import {
   rowsToCSV,
   rowsToJSON,
+  rowsToSqlInsert,
   getSelectedRows,
   copyTextToClipboard,
 } from "../../utils/clipboard";
@@ -94,7 +95,7 @@ interface DataGridProps {
   onDuplicateRow?: (rowData: Record<string, unknown>) => void;
   selectedRows?: Set<number>;
   onSelectionChange?: (indices: Set<number>) => void;
-  copyFormat?: "csv" | "json";
+  copyFormat?: "csv" | "json" | "sql-insert";
   csvDelimiter?: string;
   sortClause?: string;
   onSort?: (colName: string) => void;
@@ -864,11 +865,13 @@ export const DataGrid = React.memo(
     );
 
     const formatRows = useCallback(
-      (rows: unknown[][]) =>
-        copyFormat === "json"
-          ? rowsToJSON(rows, columns)
-          : rowsToCSV(rows, "null", csvDelimiter),
-      [columns, copyFormat, csvDelimiter],
+      (rows: unknown[][]) => {
+        if (copyFormat === "json") return rowsToJSON(rows, columns);
+        if (copyFormat === "sql-insert")
+          return rowsToSqlInsert(rows, columns, tableName ?? "table");
+        return rowsToCSV(rows, "null", csvDelimiter);
+      },
+      [columns, copyFormat, csvDelimiter, tableName],
     );
 
     const copySelectedOrContextRow = useCallback(async () => {

--- a/src/components/ui/MultiResultPanel.tsx
+++ b/src/components/ui/MultiResultPanel.tsx
@@ -45,7 +45,7 @@ interface MultiResultPanelProps {
   tabId: string;
   isAllDone: boolean;
   connectionId: string | null;
-  copyFormat: "csv" | "json";
+  copyFormat: "csv" | "json" | "sql-insert";
   csvDelimiter: string;
   onSelectResult: (entryId: string) => void;
   onRerunEntry: (entryId: string) => void;

--- a/src/components/ui/ResultEntryContent.tsx
+++ b/src/components/ui/ResultEntryContent.tsx
@@ -9,7 +9,7 @@ import type { QueryResultEntry } from "../../types/editor";
 interface ResultEntryContentProps {
   entry: QueryResultEntry;
   connectionId: string | null;
-  copyFormat: "csv" | "json";
+  copyFormat: "csv" | "json" | "sql-insert";
   csvDelimiter: string;
   onPageChange: (page: number) => void;
   compact?: boolean;

--- a/src/components/ui/StackedResultItem.tsx
+++ b/src/components/ui/StackedResultItem.tsx
@@ -23,7 +23,7 @@ import type { QueryResultEntry } from "../../types/editor";
 interface StackedResultItemProps {
   entry: QueryResultEntry;
   connectionId: string | null;
-  copyFormat: "csv" | "json";
+  copyFormat: "csv" | "json" | "sql-insert";
   csvDelimiter: string;
   collapsed: boolean;
   aiEnabled: boolean;

--- a/src/contexts/SettingsContext.ts
+++ b/src/contexts/SettingsContext.ts
@@ -2,7 +2,7 @@ import { createContext } from "react";
 import type { AppLanguage } from "../i18n/config";
 
 export type { AppLanguage };
-export type CopyFormat = "csv" | "json";
+export type CopyFormat = "csv" | "json" | "sql-insert";
 export type AiProvider =
   | "openai"
   | "anthropic"

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -288,7 +288,7 @@ export const Editor = () => {
   const [tempPage, setTempPage] = useState("1");
   const [isCountLoading, setIsCountLoading] = useState(false);
   const [applyToAll, setApplyToAll] = useState(false);
-  const [copyFormat, setCopyFormat] = useState<"csv" | "json">(
+  const [copyFormat, setCopyFormat] = useState<"csv" | "json" | "sql-insert">(
     settings.copyFormat ?? "csv",
   );
   const [csvDelimiter, setCsvDelimiter] = useState(
@@ -2995,7 +2995,7 @@ export const Editor = () => {
                       <select
                         value={copyFormat}
                         onChange={(e) =>
-                          setCopyFormat(e.target.value as "csv" | "json")
+                          setCopyFormat(e.target.value as "csv" | "json" | "sql-insert")
                         }
                         className="bg-transparent border-none text-[11px] text-secondary hover:text-primary focus:outline-none cursor-pointer appearance-none pr-3 font-medium uppercase tracking-wide"
                         title={t("settings.copyFormat")}
@@ -3003,6 +3003,7 @@ export const Editor = () => {
                       >
                         <option value="csv">CSV</option>
                         <option value="json">JSON</option>
+                        <option value="sql-insert">SQL INSERT</option>
                       </select>
                       {copyFormat === "csv" && (
                         <select

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -40,6 +40,32 @@ export function getSelectedRows(
   return sortedIndices.map((idx) => data[idx]);
 }
 
+function sqlValue(cell: unknown): string {
+  if (cell === null || cell === undefined) return "NULL";
+  if (typeof cell === "boolean") return cell ? "TRUE" : "FALSE";
+  if (typeof cell === "number") return String(cell);
+  const str = typeof cell === "object" ? JSON.stringify(cell) : String(cell);
+  return `'${str.replace(/'/g, "''")}'`;
+}
+
+function rowToSqlInsert(
+  row: unknown[],
+  columns: string[],
+  tableName: string,
+): string {
+  const cols = columns.map((c) => `\`${c}\``).join(", ");
+  const vals = row.map(sqlValue).join(", ");
+  return `INSERT INTO \`${tableName}\` (${cols}) VALUES (${vals});`;
+}
+
+export function rowsToSqlInsert(
+  rows: unknown[][],
+  columns: string[],
+  tableName: string,
+): string {
+  return rows.map((row) => rowToSqlInsert(row, columns, tableName)).join("\n");
+}
+
 export async function copyTextToClipboard(
   text: string,
   onError?: (error: unknown) => void


### PR DESCRIPTION
Adds SQL INSERT as a third option in the copy format selector, alongside the existing CSV and JSON options. Once selected,
  Ctrl+C and right-click → "Copy selected row(s)" both produce ready-to-paste INSERT statements.

  Example output:
  INSERT INTO `users` (`id`, `name`, `email`) VALUES (1, 'Alice', 'alice@example.com');
  INSERT INTO `users` (`id`, `name`, `email`) VALUES (2, NULL, 'bob@example.com');

  Value quoting: null → NULL, booleans → TRUE/FALSE, numbers unquoted, strings/objects single-quoted with '' escaping.

  Changes

  - CopyFormat type (SettingsContext.ts) extended to "csv" | "json" | "sql-insert" — all downstream prop types updated
  (DataGrid, MultiResultPanel, StackedResultItem, ResultEntryContent, Editor)
  - clipboard.ts — adds rowsToSqlInsert (and private helper rowToSqlInsert, sqlValue)
  - DataGrid.formatRows — routes "sql-insert" through rowsToSqlInsert; falls back to "table" as the identifier when no
  tableName prop is present (plain query results)
  - Settings panel (GeneralTab.tsx) and editor toolbar (Editor.tsx) both expose the new option