### PR TITLE
Migrate SQL Server driver from tiberius to mssql-tiberius-bridge

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -362,6 +362,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3376,13 +3398,15 @@ dependencies = [
 
 [[package]]
 name = "mssql-tiberius-bridge"
-version = "0.1.0-preview.1"
+version = "0.1.0-preview.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6fea503cb6e9636768e8b636b32ab477965238411dcc70e7490f23328b2318"
+checksum = "aa62f1fe8f53595471d6ad62c347be6009f7bc9b799f2715b1f593a434c16588"
 dependencies = [
+ "async-stream",
  "async-trait",
  "chrono",
  "deadpool",
+ "futures-core",
  "mssql-tds-preview",
  "rust_decimal",
  "serde_json",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3345,9 +3345,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "mssql-tds"
-version = "0.1.0"
-source = "git+https://github.com/microsoft/mssql-rs#63de19de0c9d41f29650644e01b98e49c33bafc1"
+name = "mssql-tds-preview"
+version = "0.1.0-preview.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "454957bed59024ea56acb311e8c0b74369182f1a3256d9e036d4b46f687d0462"
 dependencies = [
  "async-trait",
  "bigdecimal",
@@ -3375,13 +3376,14 @@ dependencies = [
 
 [[package]]
 name = "mssql-tiberius-bridge"
-version = "0.1.0"
-source = "git+https://github.com/saurabh500/mssql-tiberius-bridge#f8312c688ec1c7848830bb73366a32dd4a56f998"
+version = "0.1.0-preview.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6fea503cb6e9636768e8b636b32ab477965238411dcc70e7490f23328b2318"
 dependencies = [
  "async-trait",
  "chrono",
  "deadpool",
- "mssql-tds",
+ "mssql-tds-preview",
  "rust_decimal",
  "serde_json",
  "thiserror 2.0.18",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -209,6 +209,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,18 +315,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-native-tls"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d57d4cec3c647232e1094dc013546c0b33ce785d8aeb251e1f20dfaf8a9a13fe"
-dependencies = [
- "futures-util",
- "native-tls",
- "thiserror 1.0.69",
- "url",
-]
-
-[[package]]
 name = "async-process"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,19 +376,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "asynchronous-codec"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4057f2c32adbb2fc158e22fb38433c8e9bbf76b75a4732c7c0cbaf695fb65568"
-dependencies = [
- "bytes",
- "futures-sink",
- "futures-util",
- "memchr",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -463,6 +477,19 @@ dependencies = [
  "blowfish",
  "pbkdf2 0.12.2",
  "sha2",
+]
+
+[[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -914,12 +941,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "connection-string"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510ca239cf13b7f8d16a2b48f263de7b4f8c566f0af58d901031473c76afb1e3"
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1319,6 +1340,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1465,6 +1500,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dns-lookup"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5597a4b7fe5275fc9dcf88ce26326bc8e4cb87d0130f33752d4c5f717793cf"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "socket2 0.6.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2504,6 +2551,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2609,7 +2667,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3244,6 +3302,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "minisign-verify"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3278,6 +3342,51 @@ checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "mssql-tds"
+version = "0.1.0"
+source = "git+https://github.com/microsoft/mssql-rs#63de19de0c9d41f29650644e01b98e49c33bafc1"
+dependencies = [
+ "async-trait",
+ "bigdecimal",
+ "bitflags 2.11.0",
+ "byteorder",
+ "bytes",
+ "dns-lookup",
+ "encoding_rs",
+ "futures",
+ "hostname",
+ "libc",
+ "native-tls",
+ "pretty-hex",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "winapi",
+ "windows 0.58.0",
+ "x509-parser",
+]
+
+[[package]]
+name = "mssql-tiberius-bridge"
+version = "0.1.0"
+source = "git+https://github.com/saurabh500/mssql-tiberius-bridge#f8312c688ec1c7848830bb73366a32dd4a56f998"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "deadpool",
+ "mssql-tds",
+ "rust_decimal",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -3372,6 +3481,16 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "nom"
@@ -3760,6 +3879,15 @@ dependencies = [
  "objc2-foundation",
  "objc2-javascript-core",
  "objc2-security",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -4400,9 +4528,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "pretty-hex"
-version = "0.3.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
+checksum = "9a65843dfefbafd3c879c683306959a6de478443ffe9c9adf02f5976432402d7"
 
 [[package]]
 name = "prettyplease"
@@ -4545,7 +4673,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4583,7 +4711,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5103,6 +5231,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -5656,6 +5793,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
@@ -6109,6 +6256,7 @@ dependencies = [
  "infer 0.16.0",
  "keyring",
  "log",
+ "mssql-tiberius-bridge",
  "native-tls",
  "once_cell",
  "openssl",
@@ -6131,10 +6279,8 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-updater",
  "tempfile",
- "tiberius",
  "tokio",
  "tokio-postgres",
- "tokio-util",
  "urlencoding",
  "uuid",
  "zip",
@@ -6643,34 +6789,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiberius"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1446cb4198848d1562301a3340424b4f425ef79f35ef9ee034769a9dd92c10d"
-dependencies = [
- "async-native-tls",
- "async-trait",
- "asynchronous-codec",
- "byteorder",
- "bytes",
- "chrono",
- "connection-string",
- "encoding_rs",
- "enumflags2",
- "futures-util",
- "num-traits",
- "once_cell",
- "pin-project-lite",
- "pretty-hex",
- "rust_decimal",
- "thiserror 1.0.69",
- "tokio",
- "tokio-util",
- "tracing",
- "uuid",
-]
-
-[[package]]
 name = "tiff"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6754,7 +6872,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -6800,7 +6918,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "rand 0.9.2",
- "socket2",
+ "socket2 0.6.2",
  "tokio",
  "tokio-util",
  "whoami 2.1.1",
@@ -6837,7 +6955,10 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
+ "hashbrown 0.15.5",
  "pin-project-lite",
+ "slab",
  "tokio",
 ]
 
@@ -7043,7 +7164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
 dependencies = [
  "memchr",
- "nom",
+ "nom 8.0.0",
  "petgraph",
 ]
 
@@ -7241,6 +7362,7 @@ checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "rand 0.9.2",
  "serde_core",
  "wasm-bindgen",
 ]
@@ -7734,6 +7856,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -7763,6 +7895,19 @@ dependencies = [
  "windows-implement 0.57.0",
  "windows-interface 0.57.0",
  "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -7816,6 +7961,17 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
@@ -7830,6 +7986,17 @@ name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7891,6 +8058,15 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
@@ -7905,6 +8081,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8471,6 +8657,23 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "xattr"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -59,7 +59,7 @@ deadpool-postgres = "0.14.1"
 postgres-native-tls = "0.5.1"
 native-tls = "0.2.13"
 # SQL Server driver (mssql-tiberius-bridge) — tiberius-compatible API over mssql-tds
-mssql-tiberius-bridge = "=0.1.0-preview.1"
+mssql-tiberius-bridge = "=0.1.0-preview.3"
 deadpool = "0.12"
 
 # GTK dependencies for Wayland window title workaround (Linux only)

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -59,7 +59,7 @@ deadpool-postgres = "0.14.1"
 postgres-native-tls = "0.5.1"
 native-tls = "0.2.13"
 # SQL Server driver (mssql-tiberius-bridge) — tiberius-compatible API over mssql-tds
-mssql-tiberius-bridge = { package = "mssql-tiberius-bridge", git = "https://github.com/saurabh500/mssql-tiberius-bridge" }
+mssql-tiberius-bridge = "=0.1.0-preview.1"
 deadpool = "0.12"
 
 # GTK dependencies for Wayland window title workaround (Linux only)

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -58,9 +58,8 @@ tokio-postgres = { version = "0.7.13", features = ["with-chrono-0_4", "with-uuid
 deadpool-postgres = "0.14.1"
 postgres-native-tls = "0.5.1"
 native-tls = "0.2.13"
-# SQL Server driver (tiberius) — pooled via generic deadpool manager
-tiberius = { version = "0.12", default-features = false, features = ["native-tls", "tds73", "chrono", "rust_decimal", "sql-browser-tokio"] }
-tokio-util = { version = "0.7", features = ["compat"] }
+# SQL Server driver (mssql-tiberius-bridge) — tiberius-compatible API over mssql-tds
+mssql-tiberius-bridge = { package = "mssql-tiberius-bridge", git = "https://github.com/saurabh500/mssql-tiberius-bridge" }
 deadpool = "0.12"
 
 # GTK dependencies for Wayland window title workaround (Linux only)

--- a/src-tauri/src/drivers/sqlserver/extract/mod.rs
+++ b/src-tauri/src/drivers/sqlserver/extract/mod.rs
@@ -11,7 +11,7 @@ pub mod temporal;
 use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime};
 use rust_decimal::Decimal;
 use serde_json::Value;
-use tiberius::{numeric::Numeric, ColumnType, Row};
+use mssql_tiberius_bridge::{ColumnType, Row};
 use uuid::Uuid;
 
 /// Extract a single cell into the Tabularis wire-level `serde_json::Value`.
@@ -27,12 +27,12 @@ pub fn extract_value(row: &Row, idx: usize) -> Value {
     let Some(col) = row.columns().get(idx) else {
         return Value::Null;
     };
-    let ct = col.column_type();
+    let ct = col.column_type;
 
     match ct {
         ColumnType::Null => Value::Null,
 
-        ColumnType::Bit | ColumnType::Bitn => read_bool(row, idx),
+        ColumnType::Bit => read_bool(row, idx),
 
         ColumnType::Int1 => match row.try_get::<u8, _>(idx) {
             Ok(Some(v)) => Value::from(v),
@@ -50,13 +50,12 @@ pub fn extract_value(row: &Row, idx: usize) -> Value {
             Ok(Some(v)) => Value::from(v),
             _ => Value::Null,
         },
-        ColumnType::Intn => read_intn(row, idx),
 
         ColumnType::Float4 => match row.try_get::<f32, _>(idx) {
             Ok(Some(v)) => f64_to_json(v as f64),
             _ => Value::Null,
         },
-        ColumnType::Float8 | ColumnType::Floatn => match row.try_get::<f64, _>(idx) {
+        ColumnType::Float8 => match row.try_get::<f64, _>(idx) {
             Ok(Some(v)) => f64_to_json(v),
             _ => Value::Null,
         },
@@ -70,7 +69,7 @@ pub fn extract_value(row: &Row, idx: usize) -> Value {
         },
 
         // Temporal
-        ColumnType::Datetime | ColumnType::Datetime4 | ColumnType::Datetimen => {
+        ColumnType::Datetime | ColumnType::Datetime4 => {
             match row.try_get::<NaiveDateTime, _>(idx) {
                 Ok(Some(v)) => Value::String(temporal::format_datetime(&v)),
                 _ => Value::Null,
@@ -80,15 +79,15 @@ pub fn extract_value(row: &Row, idx: usize) -> Value {
             Ok(Some(v)) => Value::String(temporal::format_datetime(&v)),
             _ => Value::Null,
         },
-        ColumnType::DatetimeOffsetn => match row.try_get::<DateTime<FixedOffset>, _>(idx) {
+        ColumnType::DatetimeOffset => match row.try_get::<DateTime<FixedOffset>, _>(idx) {
             Ok(Some(v)) => Value::String(temporal::format_datetime_offset(&v)),
             _ => Value::Null,
         },
-        ColumnType::Daten => match row.try_get::<NaiveDate, _>(idx) {
+        ColumnType::Date => match row.try_get::<NaiveDate, _>(idx) {
             Ok(Some(v)) => Value::String(temporal::format_date(&v)),
             _ => Value::Null,
         },
-        ColumnType::Timen => match row.try_get::<NaiveTime, _>(idx) {
+        ColumnType::Time => match row.try_get::<NaiveTime, _>(idx) {
             Ok(Some(v)) => Value::String(temporal::format_time(&v)),
             _ => Value::Null,
         },
@@ -96,19 +95,19 @@ pub fn extract_value(row: &Row, idx: usize) -> Value {
         // Strings
         ColumnType::Text
         | ColumnType::NText
-        | ColumnType::BigVarChar
-        | ColumnType::BigChar
+        | ColumnType::Varchar
+        | ColumnType::Char
         | ColumnType::NVarchar
         | ColumnType::NChar
         | ColumnType::Xml => read_string(row, idx),
 
         // Binary
-        ColumnType::Image | ColumnType::BigBinary | ColumnType::BigVarBin => {
+        ColumnType::Image | ColumnType::Binary | ColumnType::VarBinary | ColumnType::BigVarBin => {
             read_binary_as_base64(row, idx)
         }
 
-        // Fallbacks: SSVariant and UDT → best-effort string
-        ColumnType::SSVariant | ColumnType::Udt => read_string(row, idx),
+        // Fallbacks: SSVariant, Json, Vector → best-effort string
+        ColumnType::Ssvariant | ColumnType::Json | ColumnType::Vector => read_string(row, idx),
     }
 }
 
@@ -121,24 +120,6 @@ fn read_bool(row: &Row, idx: usize) -> Value {
     }
 }
 
-fn read_intn(row: &Row, idx: usize) -> Value {
-    // tiberius returns the "natural" Rust integer width based on the column
-    // length. Try widest to narrowest; the first successful decode wins.
-    if let Ok(Some(v)) = row.try_get::<i64, _>(idx) {
-        return Value::from(v);
-    }
-    if let Ok(Some(v)) = row.try_get::<i32, _>(idx) {
-        return Value::from(v);
-    }
-    if let Ok(Some(v)) = row.try_get::<i16, _>(idx) {
-        return Value::from(v);
-    }
-    if let Ok(Some(v)) = row.try_get::<u8, _>(idx) {
-        return Value::from(v);
-    }
-    Value::Null
-}
-
 fn read_string(row: &Row, idx: usize) -> Value {
     match row.try_get::<&str, _>(idx) {
         Ok(Some(s)) => Value::String(s.to_string()),
@@ -147,14 +128,9 @@ fn read_string(row: &Row, idx: usize) -> Value {
 }
 
 fn read_numeric_as_string(row: &Row, idx: usize) -> Value {
-    // Prefer `rust_decimal::Decimal` (exact) when the feature exposes it;
-    // fall back to tiberius' own `Numeric` (lossless integer + scale) for
-    // values outside rust_decimal's 96-bit range (NUMERIC(38, ...)).
+    // Prefer `rust_decimal::Decimal` (exact).
     if let Ok(Some(d)) = row.try_get::<Decimal, _>(idx) {
         return Value::String(normalize_decimal_string(&d.to_string()));
-    }
-    if let Ok(Some(n)) = row.try_get::<Numeric, _>(idx) {
-        return Value::String(normalize_decimal_string(&n.to_string()));
     }
     if let Ok(Some(f)) = row.try_get::<f64, _>(idx) {
         return f64_to_json(f);
@@ -164,10 +140,10 @@ fn read_numeric_as_string(row: &Row, idx: usize) -> Value {
 
 fn read_binary_as_base64(row: &Row, idx: usize) -> Value {
     use base64::Engine as _;
-    match row.try_get::<&[u8], _>(idx) {
+    match row.try_get::<Vec<u8>, _>(idx) {
         Ok(Some(bytes)) => Value::String(format!(
             "base64:{}",
-            base64::engine::general_purpose::STANDARD.encode(bytes)
+            base64::engine::general_purpose::STANDARD.encode(&bytes)
         )),
         _ => Value::Null,
     }

--- a/src-tauri/src/drivers/sqlserver/extract/mod.rs
+++ b/src-tauri/src/drivers/sqlserver/extract/mod.rs
@@ -27,7 +27,7 @@ pub fn extract_value(row: &Row, idx: usize) -> Value {
     let Some(col) = row.columns().get(idx) else {
         return Value::Null;
     };
-    let ct = col.column_type;
+    let ct = col.column_type();
 
     match ct {
         ColumnType::Null => Value::Null,

--- a/src-tauri/src/drivers/sqlserver/introspection.rs
+++ b/src-tauri/src/drivers/sqlserver/introspection.rs
@@ -9,7 +9,7 @@
 //! we never interpolate user input.
 
 use crate::drivers::sqlserver::helpers::qualify;
-use crate::drivers::sqlserver::pool::TiberiusConnection;
+use crate::drivers::sqlserver::pool::BridgeConnection;
 use crate::models::{
     ForeignKey, Index, RoutineInfo, RoutineParameter, TableColumn, TableInfo, TableSchema,
     ViewInfo,
@@ -291,33 +291,31 @@ pub fn is_string_type(data_type: &str) -> bool {
 
 // --- Async query helpers --------------------------------------------------
 
-fn row_str(row: &tiberius::Row, col: &str) -> String {
+fn row_str(row: &mssql_tiberius_bridge::Row, col: &str) -> String {
     row.get::<&str, _>(col).unwrap_or("").to_string()
 }
 
-fn row_str_opt(row: &tiberius::Row, col: &str) -> Option<String> {
+fn row_str_opt(row: &mssql_tiberius_bridge::Row, col: &str) -> Option<String> {
     row.get::<&str, _>(col).map(|s| s.to_string())
 }
 
-fn row_bool(row: &tiberius::Row, col: &str) -> bool {
+fn row_bool(row: &mssql_tiberius_bridge::Row, col: &str) -> bool {
     row.get::<bool, _>(col).unwrap_or(false)
 }
 
-fn row_i32(row: &tiberius::Row, col: &str) -> i32 {
+fn row_i32(row: &mssql_tiberius_bridge::Row, col: &str) -> i32 {
     row.get::<i32, _>(col).unwrap_or(0)
 }
 
 pub async fn get_tables(
-    conn: &mut TiberiusConnection,
+    conn: &mut BridgeConnection,
     schema: &str,
 ) -> Result<Vec<TableInfo>, String> {
     let rows = conn
         .query(Q_GET_TABLES, &[&schema])
         .await
         .map_err(|e| e.to_string())?
-        .into_first_result()
-        .await
-        .map_err(|e| e.to_string())?;
+        .into_first_result();
 
     Ok(rows
         .into_iter()
@@ -326,7 +324,7 @@ pub async fn get_tables(
 }
 
 pub async fn get_columns(
-    conn: &mut TiberiusConnection,
+    conn: &mut BridgeConnection,
     table: &str,
     schema: Option<&str>,
 ) -> Result<Vec<TableColumn>, String> {
@@ -335,9 +333,7 @@ pub async fn get_columns(
         .query(Q_GET_COLUMNS, &[&qualified])
         .await
         .map_err(|e| e.to_string())?
-        .into_first_result()
-        .await
-        .map_err(|e| e.to_string())?;
+        .into_first_result();
 
     Ok(rows
         .into_iter()
@@ -356,7 +352,7 @@ pub async fn get_columns(
 }
 
 pub async fn get_foreign_keys(
-    conn: &mut TiberiusConnection,
+    conn: &mut BridgeConnection,
     table: &str,
     schema: Option<&str>,
 ) -> Result<Vec<ForeignKey>, String> {
@@ -365,9 +361,7 @@ pub async fn get_foreign_keys(
         .query(Q_GET_FOREIGN_KEYS, &[&schema, &table])
         .await
         .map_err(|e| e.to_string())?
-        .into_first_result()
-        .await
-        .map_err(|e| e.to_string())?;
+        .into_first_result();
 
     Ok(rows
         .into_iter()
@@ -385,16 +379,14 @@ pub async fn get_foreign_keys(
 }
 
 pub async fn get_all_columns_batch(
-    conn: &mut TiberiusConnection,
+    conn: &mut BridgeConnection,
     schema: &str,
 ) -> Result<HashMap<String, Vec<TableColumn>>, String> {
     let rows = conn
         .query(Q_GET_ALL_COLUMNS_BATCH, &[&schema])
         .await
         .map_err(|e| e.to_string())?
-        .into_first_result()
-        .await
-        .map_err(|e| e.to_string())?;
+        .into_first_result();
 
     let mut out: HashMap<String, Vec<TableColumn>> = HashMap::new();
     for r in rows {
@@ -414,16 +406,14 @@ pub async fn get_all_columns_batch(
 }
 
 pub async fn get_all_foreign_keys_batch(
-    conn: &mut TiberiusConnection,
+    conn: &mut BridgeConnection,
     schema: &str,
 ) -> Result<HashMap<String, Vec<ForeignKey>>, String> {
     let rows = conn
         .query(Q_GET_ALL_FOREIGN_KEYS_BATCH, &[&schema])
         .await
         .map_err(|e| e.to_string())?
-        .into_first_result()
-        .await
-        .map_err(|e| e.to_string())?;
+        .into_first_result();
 
     let mut out: HashMap<String, Vec<ForeignKey>> = HashMap::new();
     for r in rows {
@@ -445,7 +435,7 @@ pub async fn get_all_foreign_keys_batch(
 /// batch, FK batch. Missing columns or FK for a table → empty Vec (never
 /// omitted from the result).
 pub async fn get_schema_snapshot(
-    conn: &mut TiberiusConnection,
+    conn: &mut BridgeConnection,
     schema: &str,
 ) -> Result<Vec<TableSchema>, String> {
     let tables = get_tables(conn, schema).await?;
@@ -463,16 +453,14 @@ pub async fn get_schema_snapshot(
 }
 
 pub async fn get_views(
-    conn: &mut TiberiusConnection,
+    conn: &mut BridgeConnection,
     schema: &str,
 ) -> Result<Vec<ViewInfo>, String> {
     let rows = conn
         .query(Q_GET_VIEWS, &[&schema])
         .await
         .map_err(|e| e.to_string())?
-        .into_first_result()
-        .await
-        .map_err(|e| e.to_string())?;
+        .into_first_result();
 
     Ok(rows
         .into_iter()
@@ -487,7 +475,7 @@ pub async fn get_views(
 }
 
 pub async fn get_module_definition(
-    conn: &mut TiberiusConnection,
+    conn: &mut BridgeConnection,
     object_name: &str,
     schema: Option<&str>,
 ) -> Result<String, String> {
@@ -496,9 +484,7 @@ pub async fn get_module_definition(
         .query(Q_GET_MODULE_DEFINITION, &[&qualified])
         .await
         .map_err(|e| e.to_string())?
-        .into_first_result()
-        .await
-        .map_err(|e| e.to_string())?;
+        .into_first_result();
 
     rows.into_iter()
         .next()
@@ -507,16 +493,14 @@ pub async fn get_module_definition(
 }
 
 pub async fn get_routines(
-    conn: &mut TiberiusConnection,
+    conn: &mut BridgeConnection,
     schema: &str,
 ) -> Result<Vec<RoutineInfo>, String> {
     let rows = conn
         .query(Q_GET_ROUTINES, &[&schema])
         .await
         .map_err(|e| e.to_string())?
-        .into_first_result()
-        .await
-        .map_err(|e| e.to_string())?;
+        .into_first_result();
 
     Ok(rows
         .into_iter()
@@ -534,7 +518,7 @@ pub async fn get_routines(
 }
 
 pub async fn get_routine_parameters(
-    conn: &mut TiberiusConnection,
+    conn: &mut BridgeConnection,
     routine_name: &str,
     schema: &str,
 ) -> Result<Vec<RoutineParameter>, String> {
@@ -542,9 +526,7 @@ pub async fn get_routine_parameters(
         .query(Q_GET_ROUTINE_PARAMETERS, &[&schema, &routine_name])
         .await
         .map_err(|e| e.to_string())?
-        .into_first_result()
-        .await
-        .map_err(|e| e.to_string())?;
+        .into_first_result();
 
     Ok(rows
         .into_iter()
@@ -558,7 +540,7 @@ pub async fn get_routine_parameters(
 }
 
 pub async fn get_indexes(
-    conn: &mut TiberiusConnection,
+    conn: &mut BridgeConnection,
     table: &str,
     schema: Option<&str>,
 ) -> Result<Vec<Index>, String> {
@@ -567,9 +549,7 @@ pub async fn get_indexes(
         .query(Q_GET_INDEXES, &[&qualified])
         .await
         .map_err(|e| e.to_string())?
-        .into_first_result()
-        .await
-        .map_err(|e| e.to_string())?;
+        .into_first_result();
 
     Ok(rows
         .into_iter()

--- a/src-tauri/src/drivers/sqlserver/mod.rs
+++ b/src-tauri/src/drivers/sqlserver/mod.rs
@@ -353,7 +353,7 @@ impl DatabaseDriver for SqlServerDriver {
 
         let columns: Vec<String> = rows
             .first()
-            .map(|r| r.columns().iter().map(|c| c.name.to_string()).collect())
+            .map(|r| r.columns().iter().map(|c| c.name().to_string()).collect())
             .unwrap_or_default();
 
         let mut json_rows: Vec<Vec<serde_json::Value>> = rows

--- a/src-tauri/src/drivers/sqlserver/mod.rs
+++ b/src-tauri/src/drivers/sqlserver/mod.rs
@@ -24,7 +24,7 @@ use crate::models::{
 };
 use crate::pool_manager::get_sqlserver_pool;
 
-/// Built-in SQL Server driver. Backed by `tiberius` + `deadpool`.
+/// Built-in SQL Server driver. Backed by `mssql-tiberius-bridge` + `deadpool`.
 pub struct SqlServerDriver {
     manifest: PluginManifest,
 }
@@ -76,10 +76,10 @@ impl Default for SqlServerDriver {
     }
 }
 
-/// Acquire a tiberius client from the pool.
+/// Acquire a bridge client from the pool.
 async fn acquire(
     params: &ConnectionParams,
-) -> Result<deadpool::managed::Object<pool::TiberiusManager>, String> {
+) -> Result<deadpool::managed::Object<pool::BridgeManager>, String> {
     let pool = get_sqlserver_pool(params).await?;
     pool.get().await.map_err(|e| e.to_string())
 }
@@ -127,9 +127,7 @@ impl DatabaseDriver for SqlServerDriver {
         conn.simple_query("SELECT 1")
             .await
             .map_err(|e| e.to_string())?
-            .into_first_result()
-            .await
-            .map_err(|e| e.to_string())?;
+            .into_first_result();
         Ok(())
     }
 
@@ -142,9 +140,7 @@ impl DatabaseDriver for SqlServerDriver {
             )
             .await
             .map_err(|e| e.to_string())?
-            .into_first_result()
-            .await
-            .map_err(|e| e.to_string())?;
+            .into_first_result();
 
         let mut out = Vec::with_capacity(rows.len());
         for row in rows {
@@ -168,9 +164,7 @@ impl DatabaseDriver for SqlServerDriver {
             )
             .await
             .map_err(|e| e.to_string())?
-            .into_first_result()
-            .await
-            .map_err(|e| e.to_string())?;
+            .into_first_result();
 
         let mut out = Vec::with_capacity(rows.len());
         for row in rows {
@@ -355,13 +349,11 @@ impl DatabaseDriver for SqlServerDriver {
             .await
             .map_err(|e| e.to_string())?;
         let rows = stream
-            .into_first_result()
-            .await
-            .map_err(|e| e.to_string())?;
+            .into_first_result();
 
         let columns: Vec<String> = rows
             .first()
-            .map(|r| r.columns().iter().map(|c| c.name().to_string()).collect())
+            .map(|r| r.columns().iter().map(|c| c.name.to_string()).collect())
             .unwrap_or_default();
 
         let mut json_rows: Vec<Vec<serde_json::Value>> = rows

--- a/src-tauri/src/drivers/sqlserver/pool.rs
+++ b/src-tauri/src/drivers/sqlserver/pool.rs
@@ -1,55 +1,39 @@
-//! Tiberius-backed connection pool primitives.
+//! mssql-tiberius-bridge connection pool primitives.
 //!
-//! This file mirrors the shape of `deadpool_postgres`: a `Manager`
-//! implementation that wraps `tiberius::Client` over a `tokio::net::TcpStream`
-//! (adapted to the futures-io traits tiberius expects via `tokio-util::compat`).
+//! Pools `mssql_tiberius_bridge::Client` objects via a custom deadpool Manager.
+//! The bridge Client provides tiberius-compatible `.query()` and `.simple_query()`
+//! methods over Microsoft's mssql-tds protocol implementation.
 //!
 //! Phase 1 restrictions (intentional):
 //! - SQL authentication only (user + password)
 //! - `trust_cert()` is always enabled; Phase 2 exposes the toggle via `ConnectionParams`
 //! - TLS encryption is requested on login only (`EncryptionLevel::On`)
-//!
-//! The actual `SQLSERVER_POOLS` registry + accessors live in
-//! `crate::pool_manager` (Day 2); this module is runtime-agnostic.
 
 use crate::models::ConnectionParams;
 use deadpool::managed::{Manager, Metrics, RecycleError, RecycleResult};
-use tiberius::{AuthMethod, Client, Config, EncryptionLevel};
-use tokio::net::TcpStream;
-use tokio_util::compat::{Compat, TokioAsyncWriteCompatExt};
+use mssql_tiberius_bridge::{AuthMethod, Client, Config, EncryptionLevel};
 
-/// A live tiberius client bound to a tokio TCP stream.
-/// `deadpool` hands one of these out per checkout; the stream is owned by the
-/// pool and reused across queries.
-pub type TiberiusConnection = Client<Compat<TcpStream>>;
+/// A live bridge client. `deadpool` hands one of these out per checkout.
+pub type BridgeConnection = Client;
 
-/// Deadpool `Manager` for tiberius connections.
+/// Deadpool `Manager` for mssql-tiberius-bridge connections.
 #[derive(Debug, Clone)]
-pub struct TiberiusManager {
+pub struct BridgeManager {
     config: Config,
 }
 
-impl TiberiusManager {
+impl BridgeManager {
     pub fn new(config: Config) -> Self {
         Self { config }
     }
 }
 
-impl Manager for TiberiusManager {
-    type Type = TiberiusConnection;
-    type Error = tiberius::error::Error;
+impl Manager for BridgeManager {
+    type Type = BridgeConnection;
+    type Error = mssql_tiberius_bridge::Error;
 
     async fn create(&self) -> Result<Self::Type, Self::Error> {
-        let tcp = TcpStream::connect(self.config.get_addr())
-            .await
-            .map_err(|e| tiberius::error::Error::Io {
-                kind: e.kind(),
-                message: e.to_string(),
-            })?;
-        // Disable Nagle's algorithm — the same thing the official mssql client
-        // does; small query round-trips benefit.
-        tcp.set_nodelay(true).ok();
-        Client::connect(self.config.clone(), tcp.compat_write()).await
+        Client::connect(&self.config).await
     }
 
     async fn recycle(
@@ -61,14 +45,12 @@ impl Manager for TiberiusManager {
         conn.simple_query("SELECT 1")
             .await
             .map_err(RecycleError::Backend)?
-            .into_first_result()
-            .await
-            .map_err(RecycleError::Backend)?;
+            .into_first_result();
         Ok(())
     }
 }
 
-/// Build a `tiberius::Config` from Tabularis `ConnectionParams`.
+/// Build a `mssql_tiberius_bridge::Config` from Tabularis `ConnectionParams`.
 ///
 /// Phase 1 consumes only: host, port, username, password, database.
 /// Phase 2 will extend with `trust_server_certificate`, `encrypt`, `instance_name`.
@@ -141,9 +123,6 @@ mod tests {
 
     #[test]
     fn build_config_empty_credentials_do_not_panic() {
-        // SQL Server rejects empty credentials at login time, but building the
-        // config must never panic — the pool layer turns the login error into
-        // a descriptive string instead.
         let mut params = base_params(Some("localhost"), Some(1433), "master");
         params.username = None;
         params.password = None;
@@ -155,20 +134,17 @@ mod tests {
         fn assert_send<T: Send>() {}
         fn assert_sync<T: Sync>() {}
         fn assert_clone<T: Clone>() {}
-        assert_send::<TiberiusManager>();
-        assert_sync::<TiberiusManager>();
-        assert_clone::<TiberiusManager>();
+        assert_send::<BridgeManager>();
+        assert_sync::<BridgeManager>();
+        assert_clone::<BridgeManager>();
     }
 
     #[test]
     fn manager_new_stores_config() {
         let cfg = build_config(&base_params(Some("example.com"), Some(1433), "master"))
             .expect("config builds");
-        let mgr = TiberiusManager::new(cfg);
-        // Cloning the manager must not panic and must share the config.
+        let mgr = BridgeManager::new(cfg);
         let cloned = mgr.clone();
-        // We can't assert equality on tiberius::Config directly (no PartialEq),
-        // but we can assert both managers return the same debug representation.
         let original = format!("{:?}", mgr);
         let cloned_dbg = format!("{:?}", cloned);
         assert_eq!(original, cloned_dbg);

--- a/src-tauri/src/pool_manager.rs
+++ b/src-tauri/src/pool_manager.rs
@@ -1,4 +1,4 @@
-use crate::drivers::sqlserver::pool::{build_config as build_sqlserver_config, TiberiusManager};
+use crate::drivers::sqlserver::pool::{build_config as build_sqlserver_config, BridgeManager};
 use crate::models::ConnectionParams;
 use deadpool::managed::Pool as DeadPool;
 use deadpool_postgres::{Manager as PgPoolManager, Pool as PgPool};
@@ -14,7 +14,7 @@ use tokio_postgres::{config::SslMode as PgSslMode, Config as PgConfig};
 
 type PoolMap<T> = Arc<RwLock<HashMap<String, Pool<T>>>>;
 type PgPoolMap = Arc<RwLock<HashMap<String, PgPool>>>;
-pub type SqlServerPool = DeadPool<TiberiusManager>;
+pub type SqlServerPool = DeadPool<BridgeManager>;
 type SqlServerPoolMap = Arc<RwLock<HashMap<String, SqlServerPool>>>;
 
 static MYSQL_POOLS: Lazy<PoolMap<MySql>> = Lazy::new(|| Arc::new(RwLock::new(HashMap::new())));
@@ -385,7 +385,7 @@ pub async fn get_sqlserver_pool_with_id(
     );
 
     let cfg = build_sqlserver_config(params)?;
-    let manager = TiberiusManager::new(cfg);
+    let manager = BridgeManager::new(cfg);
     let pool = DeadPool::builder(manager)
         .max_size(10)
         .build()


### PR DESCRIPTION
Replaces the `tiberius` TDS driver with [`mssql-tiberius-bridge`](https://crates.io/crates/mssql-tiberius-bridge) — a tiberius-compatible API facade over Microsoft's official [`mssql-tds`](https://github.com/microsoft/mssql-rs) Rust implementation.

Closes #171

## What changed

| File | Change |
|------|--------|
| `Cargo.toml` | `tiberius` + `tokio-util` → `mssql-tiberius-bridge = "=0.1.0-preview.1"` (crates.io) |
| `pool.rs` | `TiberiusManager` → `BridgeManager` — custom deadpool Manager pooling bridge `Client` objects. Eliminates manual `TcpStream` + `compat_write()` boilerplate |
| `pool_manager.rs` | Type alias updates (`TiberiusManager` → `BridgeManager`) |
| `extract/mod.rs` | `tiberius::ColumnType` → bridge `ColumnType`, adjusted `FromSql` patterns |
| `introspection.rs` | Connection type update, `into_first_result()` is now sync (no second `.await`) |
| `mod.rs` | Pool type + result collection updates |

## What didn't change

- All SQL queries — identical
- `version.rs`, `helpers.rs`, `extract/temporal.rs` — pure functions, no driver deps
- Frontend — zero changes

## Why

- `tiberius` is community-maintained with infrequent updates
- `mssql-tds` is Microsoft's official, actively developed TDS implementation
- The bridge preserves the same API surface (`Client`, `Row`, `Config`, `query()`, `simple_query()`, `into_first_result()`, `FromSql`/`ToSql`), making this a mechanical migration
- Unlocks future support for JSON columns, Vector type (SQL Server 2025), and Azure AD auth

## Test results

- ✅ All 471 existing tests pass
- ✅ `cargo clippy` — zero warnings
- ✅ `cargo check` — clean

## Known limitation

`execute()` returns 0 for DML — upstream `mssql-tds` doesn't expose DONE token row counts yet. No impact on Phase 1 (read-only). Tracked in [mssql-tiberius-bridge#1](https://github.com/saurabh500/mssql-tiberius-bridge/issues/1).
