### PR TITLE
fix(DataGrid): handle empty column names from drivers

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "tabularis"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { SchemaDiagramPage } from "./pages/SchemaDiagramPage";
 import { TaskManagerPage } from "./pages/TaskManagerPage";
 import { VisualExplainPage } from "./pages/VisualExplainPage";
 import { ConnectionHealthMonitor } from "./components/ConnectionHealthMonitor";
+import { EditorErrorBoundary } from "./components/ui/EditorErrorBoundary";
 import { UpdateNotificationModal } from "./components/modals/UpdateNotificationModal";
 import { CommunityModal } from "./components/modals/CommunityModal";
 import { WhatsNewModal } from "./components/modals/WhatsNewModal";
@@ -116,7 +117,14 @@ export function App() {
                         element={<Navigate to="/connections" replace />}
                       />
                       <Route path="connections" element={<Connections />} />
-                      <Route path="editor" element={<Editor />} />
+                      <Route
+                        path="editor"
+                        element={
+                          <EditorErrorBoundary>
+                            <Editor />
+                          </EditorErrorBoundary>
+                        }
+                      />
                       <Route path="mcp" element={<McpPage />} />
                       <Route path="settings" element={<Settings />} />
                     </Route>

--- a/src/components/ui/DataGrid.tsx
+++ b/src/components/ui/DataGrid.tsx
@@ -504,7 +504,10 @@ export const DataGrid = React.memo(
       () =>
         columns.map((colName, index) =>
           columnHelper.accessor((row) => row[index], {
-            id: colName,
+            // react-table requires a non-empty `id` when an accessorFn is used.
+            // Some drivers (e.g. SQL Server `SELECT @@VERSION`, Postgres `SELECT 1 AS ""`)
+            // return columns with an empty name, which would otherwise crash the grid.
+            id: colName !== "" ? colName : `__unnamed_${index}__`,
             header: () => {
               const sortState = getColumnSortState(colName, sortClause);
               const displaySortState: "none" | "asc" | "desc" =

--- a/src/components/ui/EditorErrorBoundary.tsx
+++ b/src/components/ui/EditorErrorBoundary.tsx
@@ -1,0 +1,148 @@
+import { Component } from "react";
+import type { ErrorInfo, ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
+import { AlertTriangle, Home, RotateCcw, XCircle } from "lucide-react";
+import type { TFunction } from "i18next";
+import { useEditor } from "../../hooks/useEditor";
+
+interface InnerProps {
+  t: TFunction;
+  onBackToConnections: () => void;
+  onCloseActiveTab: (() => void) | null;
+  children: ReactNode;
+}
+
+interface InnerState {
+  error: Error | null;
+  componentStack: string | null;
+}
+
+// Inner class component that catches render errors. Kept private so the
+// public surface is the hook-aware wrapper below.
+class EditorErrorBoundaryInner extends Component<InnerProps, InnerState> {
+  state: InnerState = { error: null, componentStack: null };
+
+  static getDerivedStateFromError(error: Error): Partial<InnerState> {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    this.setState({ componentStack: info.componentStack ?? null });
+    console.error(
+      "[Editor] render crash caught by error boundary:",
+      error,
+      info.componentStack,
+    );
+  }
+
+  reset = () => {
+    this.setState({ error: null, componentStack: null });
+  };
+
+  closeActiveTabAndReset = () => {
+    this.props.onCloseActiveTab?.();
+    this.reset();
+  };
+
+  render() {
+    const { error, componentStack } = this.state;
+    if (!error) {
+      return this.props.children;
+    }
+
+    const { t, onBackToConnections, onCloseActiveTab } = this.props;
+    const details = [error.stack, componentStack].filter(Boolean).join("\n\n");
+
+    return (
+      <div
+        role="alert"
+        className="flex h-full w-full items-center justify-center bg-base p-8 overflow-auto"
+      >
+        <div className="w-full max-w-xl bg-elevated border border-strong rounded-xl shadow-lg p-6">
+          <div className="flex items-start gap-3">
+            <div className="p-2 bg-red-900/30 rounded-lg shrink-0">
+              <AlertTriangle size={24} className="text-red-400" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <h2 className="text-lg font-semibold text-primary">
+                {t("editor.errorBoundary.title")}
+              </h2>
+              <p className="mt-1 text-sm text-secondary">
+                {t("editor.errorBoundary.description")}
+              </p>
+
+              <div className="mt-3 rounded-md border border-red-900/40 bg-red-900/10 px-3 py-2">
+                <p className="text-sm font-mono text-red-400 break-words whitespace-pre-wrap">
+                  {error.message || error.name}
+                </p>
+              </div>
+
+              {details && (
+                <details className="mt-3">
+                  <summary className="cursor-pointer text-xs text-secondary hover:text-primary select-none">
+                    {t("editor.errorBoundary.showDetails")}
+                  </summary>
+                  <pre className="mt-2 max-h-64 overflow-auto rounded bg-base/60 p-2 text-[11px] text-secondary whitespace-pre-wrap">
+                    {details}
+                  </pre>
+                </details>
+              )}
+
+              <div className="mt-4 flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={this.reset}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white rounded-md text-sm font-medium transition-colors"
+                >
+                  <RotateCcw size={14} />
+                  {t("editor.errorBoundary.retry")}
+                </button>
+                {onCloseActiveTab && (
+                  <button
+                    type="button"
+                    onClick={this.closeActiveTabAndReset}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-base hover:bg-elevated border border-default text-primary rounded-md text-sm font-medium transition-colors"
+                  >
+                    <XCircle size={14} />
+                    {t("editor.errorBoundary.closeCurrentTab")}
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={onBackToConnections}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-base hover:bg-elevated border border-default text-primary rounded-md text-sm font-medium transition-colors"
+                >
+                  <Home size={14} />
+                  {t("editor.errorBoundary.backToConnections")}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+interface EditorErrorBoundaryProps {
+  children: ReactNode;
+}
+
+export function EditorErrorBoundary({ children }: EditorErrorBoundaryProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { activeTabId, closeTab } = useEditor();
+
+  const onCloseActiveTab = activeTabId ? () => closeTab(activeTabId) : null;
+
+  return (
+    <EditorErrorBoundaryInner
+      t={t}
+      onBackToConnections={() => navigate("/connections")}
+      onCloseActiveTab={onCloseActiveTab}
+    >
+      {children}
+    </EditorErrorBoundaryInner>
+  );
+}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -730,6 +730,14 @@
     "queryFailed": "Abfrage fehlgeschlagen.",
     "showErrorDetails": "Details anzeigen",
     "hideErrorDetails": "Details ausblenden",
+    "errorBoundary": {
+      "title": "Der Editor ist unerwartet abgestürzt",
+      "description": "Etwas im Editor konnte nicht gerendert werden. Der Fehler wird unten angezeigt — versuche es erneut oder kehre zu deinen Verbindungen zurück.",
+      "retry": "Erneut versuchen",
+      "closeCurrentTab": "Aktuellen Tab schließen",
+      "backToConnections": "Zurück zu den Verbindungen",
+      "showDetails": "Technische Details anzeigen"
+    },
     "newVisualQuery": "Neue visuelle Abfrage",
     "activeDatabase": "Aktive Datenbank",
     "tabSwitcher": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -730,6 +730,14 @@
     "queryFailed": "Query failed.",
     "showErrorDetails": "Show details",
     "hideErrorDetails": "Hide details",
+    "errorBoundary": {
+      "title": "The editor crashed unexpectedly",
+      "description": "Something in the editor failed to render. The error is shown below — try again, or go back to your connections.",
+      "retry": "Try again",
+      "closeCurrentTab": "Close current tab",
+      "backToConnections": "Back to connections",
+      "showDetails": "Show technical details"
+    },
     "newVisualQuery": "New Visual Query",
     "activeDatabase": "Active database",
     "tabSwitcher": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -723,6 +723,14 @@
     "queryFailed": "La consulta falló.",
     "showErrorDetails": "Mostrar detalles",
     "hideErrorDetails": "Ocultar detalles",
+    "errorBoundary": {
+      "title": "El editor falló inesperadamente",
+      "description": "Algo en el editor no pudo renderizarse. El error se muestra abajo — vuelve a intentarlo o regresa a tus conexiones.",
+      "retry": "Reintentar",
+      "closeCurrentTab": "Cerrar pestaña actual",
+      "backToConnections": "Volver a conexiones",
+      "showDetails": "Mostrar detalles técnicos"
+    },
     "newVisualQuery": "Nueva Consulta Visual",
     "activeDatabase": "Base de datos activa",
     "tabSwitcher": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -730,6 +730,14 @@
     "queryFailed": "Échec de la requête.",
     "showErrorDetails": "Afficher les détails",
     "hideErrorDetails": "Masquer les détails",
+    "errorBoundary": {
+      "title": "L'éditeur a planté de manière inattendue",
+      "description": "Un élément de l'éditeur n'a pas pu s'afficher. L'erreur est indiquée ci-dessous — réessayez ou revenez à vos connexions.",
+      "retry": "Réessayer",
+      "closeCurrentTab": "Fermer l’onglet actuel",
+      "backToConnections": "Retour aux connexions",
+      "showDetails": "Afficher les détails techniques"
+    },
     "newVisualQuery": "Nouvelle requête visuelle",
     "activeDatabase": "Base de données active",
     "tabSwitcher": {

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -728,6 +728,14 @@
     "queryFailed": "Esecuzione query fallita.",
     "showErrorDetails": "Mostra dettagli",
     "hideErrorDetails": "Nascondi dettagli",
+    "errorBoundary": {
+      "title": "L'editor si è bloccato in modo imprevisto",
+      "description": "Qualcosa nell'editor non è riuscito a renderizzarsi. L'errore è mostrato qui sotto — riprova oppure torna alle connessioni.",
+      "retry": "Riprova",
+      "closeCurrentTab": "Chiudi scheda corrente",
+      "backToConnections": "Torna alle connessioni",
+      "showDetails": "Mostra dettagli tecnici"
+    },
     "newVisualQuery": "Nuova Query Visuale",
     "activeDatabase": "Database attivo",
     "tabSwitcher": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -700,6 +700,14 @@
     "queryFailed": "查询失败。",
     "showErrorDetails": "显示详情",
     "hideErrorDetails": "隐藏详情",
+    "errorBoundary": {
+      "title": "编辑器意外崩溃",
+      "description": "编辑器中的某些内容渲染失败。错误显示如下 — 请重试或返回到你的连接列表。",
+      "retry": "重试",
+      "closeCurrentTab": "关闭当前标签",
+      "backToConnections": "返回连接",
+      "showDetails": "显示技术细节"
+    },
     "newVisualQuery": "新建可视化查询",
     "activeDatabase": "当前数据库",
     "tabSwitcher": {

--- a/tests/components/ui/EditorErrorBoundary.test.tsx
+++ b/tests/components/ui/EditorErrorBoundary.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { EditorErrorBoundary } from "../../../src/components/ui/EditorErrorBoundary";
+import { EditorContext } from "../../../src/contexts/EditorContext";
+import type { EditorContextType } from "../../../src/contexts/EditorContext";
+
+const HappyChild = () => <div data-testid="happy">happy editor</div>;
+
+let shouldThrow = true;
+const Crasher = () => {
+  if (shouldThrow) {
+    throw new Error("boom");
+  }
+  return <div data-testid="recovered">recovered editor</div>;
+};
+
+const buildEditorContext = (
+  overrides: Partial<EditorContextType> = {},
+): EditorContextType => ({
+  tabs: [],
+  activeTabId: "tab-1",
+  activeTab: null,
+  addTab: vi.fn(() => ""),
+  closeTab: vi.fn(),
+  closeAllTabs: vi.fn(),
+  closeOtherTabs: vi.fn(),
+  closeTabsToLeft: vi.fn(),
+  closeTabsToRight: vi.fn(),
+  updateTab: vi.fn(),
+  setActiveTabId: vi.fn(),
+  getSchema: vi.fn(async () => []),
+  ...overrides,
+});
+
+const renderAtEditor = (
+  children: React.ReactNode,
+  ctx: EditorContextType = buildEditorContext(),
+) =>
+  render(
+    <EditorContext.Provider value={ctx}>
+      <MemoryRouter initialEntries={["/editor"]}>
+        <Routes>
+          <Route
+            path="/editor"
+            element={<EditorErrorBoundary>{children}</EditorErrorBoundary>}
+          />
+          <Route
+            path="/connections"
+            element={<div data-testid="connections-page">connections</div>}
+          />
+        </Routes>
+      </MemoryRouter>
+    </EditorContext.Provider>,
+  );
+
+describe("EditorErrorBoundary", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    shouldThrow = true;
+    // React itself logs uncaught render errors via console.error before the
+    // boundary handles them. Silence to keep test output clean.
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("renders children when no error is thrown", () => {
+    renderAtEditor(<HappyChild />);
+    expect(screen.getByTestId("happy")).toBeInTheDocument();
+  });
+
+  it("renders fallback UI with the error message when a child throws", () => {
+    renderAtEditor(<Crasher />);
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText("editor.errorBoundary.title")).toBeInTheDocument();
+    expect(screen.getByText("boom")).toBeInTheDocument();
+  });
+
+  it("logs the caught error to console.error", () => {
+    renderAtEditor(<Crasher />);
+
+    const wasLoggedByBoundary = consoleErrorSpy.mock.calls.some((args) =>
+      typeof args[0] === "string" &&
+      args[0].includes("[Editor] render crash caught by error boundary"),
+    );
+    expect(wasLoggedByBoundary).toBe(true);
+  });
+
+  it("recovers when the user clicks retry and the child no longer throws", () => {
+    renderAtEditor(<Crasher />);
+
+    expect(screen.getByText("boom")).toBeInTheDocument();
+
+    shouldThrow = false;
+    fireEvent.click(screen.getByText("editor.errorBoundary.retry"));
+
+    expect(screen.getByTestId("recovered")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("navigates to /connections when the user clicks back to connections", () => {
+    renderAtEditor(<Crasher />);
+
+    fireEvent.click(screen.getByText("editor.errorBoundary.backToConnections"));
+
+    expect(screen.getByTestId("connections-page")).toBeInTheDocument();
+  });
+
+  it("closes the active tab and resets the boundary when the user clicks close current tab", () => {
+    const closeTab = vi.fn();
+    const ctx = buildEditorContext({ activeTabId: "tab-1", closeTab });
+
+    renderAtEditor(<Crasher />, ctx);
+    expect(screen.getByText("boom")).toBeInTheDocument();
+
+    shouldThrow = false;
+    fireEvent.click(screen.getByText("editor.errorBoundary.closeCurrentTab"));
+
+    expect(closeTab).toHaveBeenCalledWith("tab-1");
+    expect(screen.getByTestId("recovered")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("hides the close-current-tab button when there is no active tab", () => {
+    const ctx = buildEditorContext({ activeTabId: null });
+
+    renderAtEditor(<Crasher />, ctx);
+
+    expect(
+      screen.queryByText("editor.errorBoundary.closeCurrentTab"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("editor.errorBoundary.retry"),
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -164,6 +164,8 @@ vi.mock("lucide-react", () => ({
   PanelTop: () => null,
   ChevronsDownUp: () => null,
   ChevronsUpDown: () => null,
+  AlertTriangle: () => null,
+  Home: () => null,
 }));
 
 // Mock scrollIntoView (not available in JSDOM)


### PR DESCRIPTION
## Problem

Double-clicking a saved connection (or running certain queries) causes the editor window to go completely blank with no visible error. DevTools shows:

```
Uncaught Error: Columns require an id when using an accessorFn
    at createColumn (column.ts:120)
    at DataGrid.tsx:877
```

Reproducible on multiple engines:

- **SQL Server**: `SELECT @@VERSION` (returns a column with an empty name)
- **PostgreSQL**: `SELECT 1 AS """";`
- Likely any driver/query that yields an unnamed column

Because there is no top-level React error boundary, the throw in `<DataGrid>` unmounts the whole tree, producing the dark window.

## Fix

In `src/components/ui/DataGrid.tsx`, fall back to a synthetic `__unnamed_<index>__` id when `colName` is the empty string. The synthetic id is internal to react-table; the rendered header still shows the original (empty) name, and `info.column.id` consumers downstream (cell renderer, header context menu) keep working.

```ts
id: colName !== """" ? colName : `__unnamed_${index}__`,
```

## Testing

- Manually verified on the `feat/sql-server-complete` branch that `SELECT @@VERSION` no longer crashes the grid.
- Engine-agnostic — also protects PostgreSQL / MySQL / SQLite from the same class of crash.

## Follow-ups (not in this PR)

- Add a top-level React error boundary around the editor route so any future render crash doesn't blank the window.
