### PR TITLE
feat: add connection export and import functionality

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10,9 +10,10 @@ use uuid::Uuid;
 use crate::credential_cache;
 use crate::keychain_utils;
 use crate::models::{
-    ColumnDefinition, ConnectionGroup, ConnectionParams, ConnectionsFile, ExplainPlan, ForeignKey,
-    Index, QueryResult, RoutineInfo, RoutineParameter, SavedConnection, SshConnection,
-    SshConnectionInput, SshTestParams, TableColumn, TableInfo, TestConnectionRequest,
+    ColumnDefinition, ConnectionGroup, ConnectionParams, ConnectionsFile, ExplainPlan,
+    ExportPayload, ForeignKey, Index, QueryResult, RoutineInfo, RoutineParameter, SavedConnection,
+    SshConnection, SshConnectionInput, SshTestParams, TableColumn, TableInfo,
+    TestConnectionRequest,
 };
 use crate::persistence;
 use crate::ssh_tunnel::{get_tunnels, SshTunnel};
@@ -3092,4 +3093,164 @@ pub async fn get_server_now<R: Runtime>(
             other => other.to_string(),
         })
         .ok_or_else(|| "No timestamp returned from server".to_string())
+}
+
+#[tauri::command]
+pub async fn export_connections_payload<R: Runtime>(
+    app: AppHandle<R>,
+) -> Result<ExportPayload, String> {
+    let conn_path = get_config_path(&app)?;
+    let ssh_path = get_ssh_config_path(&app)?;
+
+    let mut conn_file = persistence::load_connections_file(&conn_path)?;
+    let mut ssh_connections = if ssh_path.exists() {
+        let content = fs::read_to_string(&ssh_path).map_err(|e| e.to_string())?;
+        serde_json::from_str::<Vec<SshConnection>>(&content).unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+
+    let cache = app
+        .state::<std::sync::Arc<crate::credential_cache::CredentialCache>>()
+        .inner()
+        .clone();
+
+    // Resolve passwords for database connections
+    for conn in &mut conn_file.connections {
+        if conn.params.save_in_keychain.unwrap_or(false) {
+            if let Ok(pwd) = credential_cache::get_db_password_cached(&cache, &conn.id) {
+                conn.params.password = Some(pwd);
+            }
+            if conn.params.ssh_enabled.unwrap_or(false) {
+                if let Ok(ssh_pwd) = credential_cache::get_ssh_password_cached(&cache, &conn.id) {
+                    conn.params.ssh_password = Some(ssh_pwd);
+                }
+                if let Ok(ssh_passphrase) =
+                    credential_cache::get_ssh_key_passphrase_cached(&cache, &conn.id)
+                {
+                    conn.params.ssh_key_passphrase = Some(ssh_passphrase);
+                }
+            }
+        }
+    }
+
+    // Resolve passwords for SSH connections
+    for ssh in &mut ssh_connections {
+        if ssh.save_in_keychain.unwrap_or(false) {
+            if let Ok(pwd) = credential_cache::get_ssh_password_cached(&cache, &ssh.id) {
+                ssh.password = Some(pwd);
+            }
+            if let Ok(passphrase) = credential_cache::get_ssh_key_passphrase_cached(&cache, &ssh.id)
+            {
+                ssh.key_passphrase = Some(passphrase);
+            }
+        }
+    }
+
+    Ok(ExportPayload {
+        version: 1,
+        groups: conn_file.groups,
+        connections: conn_file.connections,
+        ssh_connections,
+    })
+}
+
+#[tauri::command]
+pub async fn import_connections_payload<R: Runtime>(
+    app: AppHandle<R>,
+    payload: ExportPayload,
+) -> Result<(), String> {
+    let conn_path = get_config_path(&app)?;
+    let ssh_path = get_ssh_config_path(&app)?;
+
+    let mut current_file = persistence::load_connections_file(&conn_path).unwrap_or_default();
+    let mut current_ssh = if ssh_path.exists() {
+        let content = fs::read_to_string(&ssh_path).map_err(|e| e.to_string())?;
+        serde_json::from_str::<Vec<SshConnection>>(&content).unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+
+    let cache = app
+        .state::<std::sync::Arc<crate::credential_cache::CredentialCache>>()
+        .inner()
+        .clone();
+
+    // Merge groups
+    for new_group in payload.groups {
+        if let Some(existing) = current_file.groups.iter_mut().find(|g| g.id == new_group.id) {
+            *existing = new_group;
+        } else {
+            current_file.groups.push(new_group);
+        }
+    }
+
+    // Merge connections and handle passwords
+    for mut new_conn in payload.connections {
+        // Handle passwords in keychain
+        if new_conn.params.save_in_keychain.unwrap_or(false) {
+            if let Some(pwd) = &new_conn.params.password {
+                keychain_utils::set_db_password(&new_conn.id, pwd)?;
+                credential_cache::set_db_password_cached(&cache, &new_conn.id, pwd);
+            }
+            if new_conn.params.ssh_enabled.unwrap_or(false) {
+                if let Some(ssh_pwd) = &new_conn.params.ssh_password {
+                    keychain_utils::set_ssh_password(&new_conn.id, ssh_pwd)?;
+                    credential_cache::set_ssh_password_cached(&cache, &new_conn.id, ssh_pwd);
+                }
+                if let Some(ssh_passphrase) = &new_conn.params.ssh_key_passphrase {
+                    keychain_utils::set_ssh_key_passphrase(&new_conn.id, ssh_passphrase)?;
+                    credential_cache::set_ssh_key_passphrase_cached(
+                        &cache,
+                        &new_conn.id,
+                        ssh_passphrase,
+                    );
+                }
+            }
+            // Clear passwords from struct before saving to disk
+            new_conn.params.password = None;
+            new_conn.params.ssh_password = None;
+            new_conn.params.ssh_key_passphrase = None;
+        }
+
+        if let Some(existing) = current_file
+            .connections
+            .iter_mut()
+            .find(|c| c.id == new_conn.id)
+        {
+            *existing = new_conn;
+        } else {
+            current_file.connections.push(new_conn);
+        }
+    }
+
+    // Merge SSH connections and handle passwords
+    for mut new_ssh in payload.ssh_connections {
+        if new_ssh.save_in_keychain.unwrap_or(false) {
+            if let Some(pwd) = &new_ssh.password {
+                keychain_utils::set_ssh_password(&new_ssh.id, pwd)?;
+                credential_cache::set_ssh_password_cached(&cache, &new_ssh.id, pwd);
+            }
+            if let Some(passphrase) = &new_ssh.key_passphrase {
+                keychain_utils::set_ssh_key_passphrase(&new_ssh.id, passphrase)?;
+                credential_cache::set_ssh_key_passphrase_cached(&cache, &new_ssh.id, passphrase);
+            }
+            // Clear passwords from struct before saving to disk
+            new_ssh.password = None;
+            new_ssh.key_passphrase = None;
+        }
+
+        if let Some(existing) = current_ssh.iter_mut().find(|s| s.id == new_ssh.id) {
+            *existing = new_ssh;
+        } else {
+            current_ssh.push(new_ssh);
+        }
+    }
+
+    // Save files
+    persistence::save_connections_file(&conn_path, &current_file)?;
+    let ssh_json = serde_json::to_string_pretty(&current_ssh).map_err(|e| e.to_string())?;
+    fs::write(ssh_path, ssh_json).map_err(|e| e.to_string())?;
+
+    Ok(())
 }

--- a/src-tauri/src/export_import_tests.rs
+++ b/src-tauri/src/export_import_tests.rs
@@ -1,0 +1,67 @@
+#[cfg(test)]
+mod tests {
+    use crate::models::{ExportPayload, ConnectionGroup, SavedConnection, SshConnection, ConnectionParams, DatabaseSelection};
+
+    #[test]
+    fn test_export_payload_serialization() {
+        let payload = ExportPayload {
+            version: 1,
+            groups: vec![ConnectionGroup {
+                id: "group1".to_string(),
+                name: "Test Group".to_string(),
+                collapsed: false,
+                sort_order: 0,
+            }],
+            connections: vec![SavedConnection {
+                id: "conn1".to_string(),
+                name: "Test Conn".to_string(),
+                params: ConnectionParams {
+                    driver: "mysql".to_string(),
+                    host: Some("localhost".to_string()),
+                    port: Some(3306),
+                    username: Some("root".to_string()),
+                    password: Some("password".to_string()),
+                    database: DatabaseSelection::Single("test".to_string()),
+                    ssl_mode: None,
+                    ssl_ca: None,
+                    ssl_cert: None,
+                    ssl_key: None,
+                    ssh_enabled: Some(false),
+                    ssh_connection_id: None,
+                    ssh_host: None,
+                    ssh_port: None,
+                    ssh_user: None,
+                    ssh_password: None,
+                    ssh_key_file: None,
+                    ssh_key_passphrase: None,
+                    save_in_keychain: Some(true),
+                    connection_id: None,
+                },
+                group_id: Some("group1".to_string()),
+                sort_order: Some(0),
+            }],
+            ssh_connections: vec![SshConnection {
+                id: "ssh1".to_string(),
+                name: "Test SSH".to_string(),
+                host: "remote".to_string(),
+                port: 22,
+                user: "user".to_string(),
+                auth_type: Some("password".to_string()),
+                password: Some("ssh_password".to_string()),
+                key_file: None,
+                key_passphrase: None,
+                save_in_keychain: Some(true),
+            }],
+        };
+
+        let json = serde_json::to_string(&payload).unwrap();
+        let deserialized: ExportPayload = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.version, 1);
+        assert_eq!(deserialized.groups.len(), 1);
+        assert_eq!(deserialized.connections.len(), 1);
+        assert_eq!(deserialized.ssh_connections.len(), 1);
+        assert_eq!(deserialized.connections[0].params.password, Some("password".to_string()));
+        assert_eq!(deserialized.ssh_connections[0].password, Some("ssh_password".to_string()));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,6 +23,8 @@ pub mod explain_import;
 #[cfg(test)]
 pub mod explain_import_tests;
 pub mod export;
+#[cfg(test)]
+pub mod export_import_tests;
 pub mod health_check;
 pub mod heartbeat;
 #[cfg(test)]
@@ -259,6 +261,8 @@ pub fn run() {
             commands::move_connection_to_group,
             commands::reorder_groups,
             commands::reorder_connections_in_group,
+            commands::export_connections_payload,
+            commands::import_connections_payload,
             commands::get_schemas,
             commands::get_available_databases,
             commands::get_tables,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -171,6 +171,14 @@ pub struct ConnectionsFile {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct ExportPayload {
+    pub version: i32,
+    pub groups: Vec<ConnectionGroup>,
+    pub connections: Vec<SavedConnection>,
+    pub ssh_connections: Vec<SshConnection>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct TestConnectionRequest {
     pub params: ConnectionParams,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/components/modals/ConfirmModal.tsx
+++ b/src/components/modals/ConfirmModal.tsx
@@ -10,6 +10,7 @@ interface ConfirmModalProps {
   confirmLabel?: string;
   confirmClassName?: string;
   onConfirm: () => void;
+  variant?: "danger" | "warning" | "info";
 }
 
 export const ConfirmModal = ({
@@ -18,10 +19,31 @@ export const ConfirmModal = ({
   title,
   message,
   confirmLabel,
-  confirmClassName = "px-4 py-2 bg-red-600 hover:bg-red-500 text-white rounded-lg text-sm font-medium transition-colors",
+  confirmClassName,
   onConfirm,
+  variant = "danger",
 }: ConfirmModalProps) => {
   const { t } = useTranslation();
+
+  const variantStyles = {
+    danger: {
+      icon: <AlertTriangle size={20} className="text-red-400" />,
+      iconBg: "bg-red-900/30",
+      button: "bg-red-600 hover:bg-red-500",
+    },
+    warning: {
+      icon: <AlertTriangle size={20} className="text-amber-400" />,
+      iconBg: "bg-amber-900/30",
+      button: "bg-amber-600 hover:bg-amber-500",
+    },
+    info: {
+      icon: <AlertTriangle size={20} className="text-blue-400" />,
+      iconBg: "bg-blue-900/30",
+      button: "bg-blue-600 hover:bg-blue-500",
+    },
+  };
+
+  const currentVariant = variantStyles[variant];
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
@@ -29,8 +51,8 @@ export const ConfirmModal = ({
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-default bg-base">
           <div className="flex items-center gap-3">
-            <div className="p-2 bg-red-900/30 rounded-lg">
-              <AlertTriangle size={20} className="text-red-400" />
+            <div className={`p-2 ${currentVariant.iconBg} rounded-lg`}>
+              {currentVariant.icon}
             </div>
             <h2 className="text-lg font-semibold text-primary">{title}</h2>
           </div>
@@ -41,7 +63,7 @@ export const ConfirmModal = ({
 
         {/* Content */}
         <div className="p-6">
-          <p className="text-sm text-secondary">{message}</p>
+          <p className="text-sm text-secondary leading-relaxed">{message}</p>
         </div>
 
         {/* Footer */}
@@ -52,8 +74,14 @@ export const ConfirmModal = ({
           >
             {t("common.cancel")}
           </button>
-          <button onClick={onConfirm} className={confirmClassName}>
-            {confirmLabel ?? t("common.delete")}
+          <button
+            onClick={onConfirm}
+            className={
+              confirmClassName ??
+              `px-4 py-2 ${currentVariant.button} text-white rounded-lg text-sm font-medium transition-colors`
+            }
+          >
+            {confirmLabel ?? (variant === "danger" ? t("common.delete") : t("common.ok"))}
           </button>
         </div>
       </div>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -221,7 +221,11 @@
     "searchPlaceholder": "Search connections...",
     "noSearchResults": "No connections match \"{{query}}\"",
     "gridView": "Grid view",
-    "listView": "List view"
+    "listView": "List view",
+    "export": "Export Connections",
+    "import": "Import Connections",
+    "exportTitle": "Export Connections",
+    "exportWarning": "The exported file will contain your database and SSH passwords in plaintext. Please store it securely."
   },
   "settings": {
     "title": "Settings",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -220,7 +220,11 @@
     "searchPlaceholder": "搜索连接...",
     "noSearchResults": "无匹配 \"{{query}}\" 的连接",
     "gridView": "网格视图",
-    "listView": "列表视图"
+    "listView": "列表视图",
+    "export": "导出连接",
+    "import": "导入连接",
+    "exportTitle": "导出连接",
+    "exportWarning": "导出的文件将包含您的数据库和 SSH 明文密码。请妥善保管该文件。"
   },
   "settings": {
     "title": "设置",

--- a/src/pages/Connections.tsx
+++ b/src/pages/Connections.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from "react-i18next";
 import { NewConnectionModal } from "../components/modals/NewConnectionModal";
 import { ConfirmModal } from "../components/modals/ConfirmModal";
 import { invoke } from "@tauri-apps/api/core";
+import { save, open } from "@tauri-apps/plugin-dialog";
+import { writeTextFile, readTextFile } from "@tauri-apps/plugin-fs";
 import {
   Database,
   Plus,
@@ -16,6 +18,8 @@ import {
   List,
   FolderPlus,
   Folder,
+  Download,
+  Upload,
 } from "lucide-react";
 import { useDatabase } from "../hooks/useDatabase";
 import { useDrivers } from "../hooks/useDrivers";
@@ -76,6 +80,9 @@ export const Connections = () => {
   const [confirmModal, setConfirmModal] = useState<{
     title: string;
     message: string;
+    confirmLabel?: string;
+    confirmClassName?: string;
+    variant?: "danger" | "warning" | "info";
     onConfirm: () => void;
   } | null>(null);
   const [draggingGroupId, setDraggingGroupId] = useState<string | null>(null);
@@ -152,6 +159,49 @@ export const Connections = () => {
       return next;
     });
     await toggleGroupCollapsed(groupId);
+  };
+
+  const handleExport = async () => {
+    setConfirmModal({
+      title: t("connections.exportTitle"),
+      message: t("connections.exportWarning"),
+      confirmLabel: t("common.save"),
+      variant: "warning",
+      confirmClassName: "px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg text-sm font-medium transition-colors",
+      onConfirm: async () => {
+        try {
+          const payload = await invoke("export_connections_payload");
+          const path = await save({
+            defaultPath: "tabularis-connections.json",
+            filters: [{ name: "JSON", extensions: ["json"] }],
+          });
+          if (path) {
+            await writeTextFile(path, JSON.stringify(payload, null, 2));
+          }
+        } catch (e) {
+          console.error("Export failed:", e);
+          setError(toErrorMessage(e));
+        }
+      },
+    });
+  };
+
+  const handleImport = async () => {
+    try {
+      const selected = await open({
+        filters: [{ name: "JSON", extensions: ["json"] }],
+        multiple: false,
+      });
+      if (selected && !Array.isArray(selected)) {
+        const content = await readTextFile(selected);
+        const payload = JSON.parse(content);
+        await invoke("import_connections_payload", { payload });
+        await loadConnections();
+      }
+    } catch (e) {
+      console.error("Import failed:", e);
+      setError(toErrorMessage(e));
+    }
   };
 
   const handleRenameGroup = async (groupId: string) => {
@@ -587,6 +637,24 @@ export const Connections = () => {
                 </button>
               )}
 
+              {/* Export/Import buttons */}
+              <div className="flex items-center gap-1.5 px-1 py-1 bg-elevated border border-strong rounded-xl shrink-0">
+                <button
+                  onClick={handleImport}
+                  className="p-1.5 rounded-lg text-muted hover:text-blue-400 hover:bg-blue-500/10 transition-all duration-150"
+                  title={t("connections.import")}
+                >
+                  <Upload size={14} />
+                </button>
+                <button
+                  onClick={handleExport}
+                  className="p-1.5 rounded-lg text-muted hover:text-blue-400 hover:bg-blue-500/10 transition-all duration-150"
+                  title={t("connections.export")}
+                >
+                  <Download size={14} />
+                </button>
+              </div>
+
               {/* View toggle */}
               <div className="flex items-center gap-0.5 bg-elevated border border-strong rounded-xl p-1 shrink-0">
                 <button
@@ -767,7 +835,13 @@ export const Connections = () => {
         onClose={() => setConfirmModal(null)}
         title={confirmModal?.title ?? ""}
         message={confirmModal?.message ?? ""}
-        onConfirm={() => confirmModal?.onConfirm()}
+        confirmLabel={confirmModal?.confirmLabel}
+        confirmClassName={confirmModal?.confirmClassName}
+        variant={confirmModal?.variant}
+        onConfirm={() => {
+          confirmModal?.onConfirm();
+          setConfirmModal(null);
+        }}
       />
 
       {/* Group context menu */}

--- a/src/pages/Connections.tsx
+++ b/src/pages/Connections.tsx
@@ -552,16 +552,25 @@ export const Connections = () => {
             <p className="text-sm text-muted mb-6 max-w-xs leading-relaxed">
               {t("connections.noConnectionsHint")}
             </p>
-            <button
-              onClick={() => {
-                setEditingConnection(null);
-                setIsModalOpen(true);
-              }}
-              className="flex items-center gap-2 bg-blue-600 hover:bg-blue-500 text-white px-4 py-2.5 rounded-xl font-semibold text-sm transition-all shadow-lg shadow-blue-500/20 hover:-translate-y-px"
-            >
-              <Plus size={14} />
-              {t("connections.createFirst")}
-            </button>
+            <div className="flex items-center gap-2.5">
+              <button
+                onClick={() => {
+                  setEditingConnection(null);
+                  setIsModalOpen(true);
+                }}
+                className="flex items-center gap-2 bg-blue-600 hover:bg-blue-500 text-white px-4 py-2.5 rounded-xl font-semibold text-sm transition-all shadow-lg shadow-blue-500/20 hover:-translate-y-px"
+              >
+                <Plus size={14} />
+                {t("connections.createFirst")}
+              </button>
+              <button
+                onClick={handleImport}
+                className="flex items-center gap-2 bg-elevated border border-strong hover:border-blue-500/50 text-secondary hover:text-blue-400 px-4 py-2.5 rounded-xl font-semibold text-sm transition-all hover:-translate-y-px"
+              >
+                <Upload size={14} />
+                {t("connections.import")}
+              </button>
+            </div>
           </div>
         ) : (
           <>


### PR DESCRIPTION
Splits #172 — second of two focused PRs.

Introduces export/import of connection configurations:

- `export_connections_payload` serializes connection groups, saved connections and SSH connections into a JSON payload, resolving keychain-stored passwords for both DB and SSH connections.
- `import_connections_payload` merges an `ExportPayload` with existing configurations and securely stores passwords in the system keychain, then persists the updated configurations to disk.
- New `ExportPayload` model with unit tests for (de)serialization.
- UI updates in `Connections.tsx` adding export/import buttons.
- Localization updates for export/import strings.
- `ConfirmModal` styling adjusted to support variants.

Co-authored-by: cole <imzhpe@qq.com>