### PR TITLE
fix(export): expand SSH params before running query export

### DIFF
--- a/src-tauri/src/drivers/mysql/export.rs
+++ b/src-tauri/src/drivers/mysql/export.rs
@@ -1,0 +1,44 @@
+use futures::StreamExt;
+use serde_json::Value;
+use sqlx::{Column, Row};
+
+use crate::models::ConnectionParams;
+use crate::pool_manager::get_mysql_pool;
+
+use super::extract::extract_value;
+
+/// Streams the rows produced by `query` against a MySQL connection, calling
+/// `on_row` once per row with the column names (captured from the first row)
+/// and the values extracted as `serde_json::Value`s.
+///
+/// The caller is responsible for ranking, formatting, and finishing whatever
+/// sink consumes the rows — this function only handles the database stream.
+pub async fn stream_query<F>(
+    params: &ConnectionParams,
+    query: &str,
+    mut on_row: F,
+) -> Result<(), String>
+where
+    F: FnMut(&[String], &[Value]) -> Result<(), String> + Send,
+{
+    let pool = get_mysql_pool(params).await?;
+    let mut rows = sqlx::query(query).fetch(&pool);
+    let mut headers: Option<Vec<String>> = None;
+
+    while let Some(row_res) = rows.next().await {
+        let row = row_res.map_err(|e| e.to_string())?;
+
+        if headers.is_none() {
+            headers = Some(row.columns().iter().map(|c| c.name().to_string()).collect());
+        }
+        let h = headers.as_ref().expect("headers initialized");
+
+        let values: Vec<Value> = (0..row.columns().len())
+            .map(|i| extract_value(&row, i, None))
+            .collect();
+
+        on_row(h, &values)?;
+    }
+
+    Ok(())
+}

--- a/src-tauri/src/drivers/mysql/mod.rs
+++ b/src-tauri/src/drivers/mysql/mod.rs
@@ -1,3 +1,4 @@
+pub mod export;
 pub mod extract;
 pub mod types;
 

--- a/src-tauri/src/drivers/postgres/export.rs
+++ b/src-tauri/src/drivers/postgres/export.rs
@@ -1,0 +1,49 @@
+use futures::StreamExt;
+use serde_json::Value;
+
+use crate::models::ConnectionParams;
+use crate::pool_manager::get_postgres_pool;
+
+use super::extract::extract_value;
+
+/// Streams the rows produced by `query` against a PostgreSQL connection. See
+/// the MySQL counterpart for the contract of `on_row`.
+pub async fn stream_query<F>(
+    params: &ConnectionParams,
+    query: &str,
+    mut on_row: F,
+) -> Result<(), String>
+where
+    F: FnMut(&[String], &[Value]) -> Result<(), String> + Send,
+{
+    let pool = get_postgres_pool(params).await?;
+    let client = pool
+        .get()
+        .await
+        .map_err(|e| format!("failed to get postgres client: {:?}", e))?;
+
+    let bind_params: Vec<i32> = vec![];
+    let mut rows = std::pin::pin!(client
+        .query_raw(query, &bind_params)
+        .await
+        .map_err(|e| format!("failed to execute postgres query: {:?}", e))?);
+
+    let mut headers: Option<Vec<String>> = None;
+
+    while let Some(row_res) = rows.next().await {
+        let row = row_res.map_err(|e| e.to_string())?;
+
+        if headers.is_none() {
+            headers = Some(row.columns().iter().map(|c| c.name().to_string()).collect());
+        }
+        let h = headers.as_ref().expect("headers initialized");
+
+        let values: Vec<Value> = (0..row.columns().len())
+            .map(|i| extract_value(&row, i, None))
+            .collect();
+
+        on_row(h, &values)?;
+    }
+
+    Ok(())
+}

--- a/src-tauri/src/drivers/postgres/mod.rs
+++ b/src-tauri/src/drivers/postgres/mod.rs
@@ -1,5 +1,6 @@
 pub mod types;
 
+pub mod export;
 pub mod extract;
 
 mod binding;

--- a/src-tauri/src/drivers/sqlite/export.rs
+++ b/src-tauri/src/drivers/sqlite/export.rs
@@ -1,0 +1,40 @@
+use futures::StreamExt;
+use serde_json::Value;
+use sqlx::{Column, Row};
+
+use crate::models::ConnectionParams;
+use crate::pool_manager::get_sqlite_pool;
+
+use super::extract::extract_value;
+
+/// Streams the rows produced by `query` against a SQLite connection. See the
+/// MySQL counterpart for the contract of `on_row`.
+pub async fn stream_query<F>(
+    params: &ConnectionParams,
+    query: &str,
+    mut on_row: F,
+) -> Result<(), String>
+where
+    F: FnMut(&[String], &[Value]) -> Result<(), String> + Send,
+{
+    let pool = get_sqlite_pool(params).await?;
+    let mut rows = sqlx::query(query).fetch(&pool);
+    let mut headers: Option<Vec<String>> = None;
+
+    while let Some(row_res) = rows.next().await {
+        let row = row_res.map_err(|e| e.to_string())?;
+
+        if headers.is_none() {
+            headers = Some(row.columns().iter().map(|c| c.name().to_string()).collect());
+        }
+        let h = headers.as_ref().expect("headers initialized");
+
+        let values: Vec<Value> = (0..row.columns().len())
+            .map(|i| extract_value(&row, i, None))
+            .collect();
+
+        on_row(h, &values)?;
+    }
+
+    Ok(())
+}

--- a/src-tauri/src/drivers/sqlite/mod.rs
+++ b/src-tauri/src/drivers/sqlite/mod.rs
@@ -1,3 +1,4 @@
+pub mod export;
 pub mod extract;
 pub mod types;
 

--- a/src-tauri/src/export.rs
+++ b/src-tauri/src/export.rs
@@ -1,17 +1,29 @@
-use crate::commands::{find_connection_by_id, resolve_connection_params};
-use crate::drivers::mysql::extract::extract_value as extract_mysql_value;
-use crate::drivers::postgres::extract::extract_value as extract_postgres_value;
-use crate::drivers::sqlite::extract::extract_value as extract_sqlite_value;
-use crate::pool_manager::{get_mysql_pool, get_postgres_pool, get_sqlite_pool};
-use futures::StreamExt;
-use serde::Serialize;
-use sqlx::{Column, Row};
+mod format;
+mod progress;
+mod sink;
+
+#[cfg(test)]
+mod tests;
+
+pub use format::{parse_csv_delimiter, value_to_csv_string, ExportFormat, DEFAULT_CSV_DELIMITER};
+pub use progress::{ProgressEmitter, DEFAULT_INTERVAL as DEFAULT_PROGRESS_INTERVAL};
+pub use sink::{CsvSink, JsonSink, RowSink};
+
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::{BufWriter, Write};
+use std::io::BufWriter;
 use std::sync::{Arc, Mutex};
+
+use serde::Serialize;
+use serde_json::Value;
 use tauri::{AppHandle, Emitter, Runtime, State};
 use tokio::task::AbortHandle;
+
+use crate::commands::{
+    expand_ssh_connection_params, find_connection_by_id, resolve_connection_params_with_id,
+};
+use crate::drivers::{mysql, postgres, sqlite};
+use crate::models::ConnectionParams;
 
 pub struct ExportCancellationState {
     pub handles: Arc<Mutex<HashMap<String, AbortHandle>>>,
@@ -26,94 +38,14 @@ impl Default for ExportCancellationState {
 }
 
 #[derive(Clone, Serialize)]
-struct ExportProgress {
+struct ExportProgressPayload {
     rows_processed: u64,
 }
 
-fn value_to_string(val: serde_json::Value) -> String {
-    match val {
-        serde_json::Value::String(s) => s,
-        serde_json::Value::Null => "NULL".to_string(),
-        v => v.to_string(),
-    }
-}
+const EXPORT_PROGRESS_EVENT: &str = "export_progress";
 
-macro_rules! export_rows {
-    ($rows:expr, $extract_fn:expr, $format:expr, $delimiter_byte:expr, $writer:expr, $app:expr) => {{
-        let mut count = 0u64;
-
-        if $format == "csv" {
-            let mut csv_wtr = csv::WriterBuilder::new()
-                .delimiter($delimiter_byte)
-                .from_writer($writer);
-            let mut headers_written = false;
-
-            while let Some(row_res) = $rows.next().await {
-                let row = row_res.map_err(|e| e.to_string())?;
-
-                if !headers_written {
-                    let headers: Vec<String> =
-                        row.columns().iter().map(|c| c.name().to_string()).collect();
-                    csv_wtr.write_record(&headers).map_err(|e| e.to_string())?;
-                    headers_written = true;
-                }
-
-                let record: Vec<String> = (0..row.columns().len())
-                    .map(|i| value_to_string($extract_fn(&row, i, None)))
-                    .collect();
-                csv_wtr.write_record(&record).map_err(|e| e.to_string())?;
-
-                count += 1;
-                if count % 100 == 0 {
-                    $app.emit(
-                        "export_progress",
-                        ExportProgress {
-                            rows_processed: count,
-                        },
-                    )
-                    .unwrap_or(());
-                }
-            }
-            csv_wtr.flush().map_err(|e| e.to_string())?;
-        } else {
-            let mut writer = $writer;
-            writer.write_all(b"[").map_err(|e| e.to_string())?;
-            let mut first = true;
-
-            while let Some(row_res) = $rows.next().await {
-                let row = row_res.map_err(|e| e.to_string())?;
-
-                if !first {
-                    writer.write_all(b",").map_err(|e| e.to_string())?;
-                }
-                first = false;
-
-                let mut obj = serde_json::Map::new();
-                let columns = row.columns();
-                for i in 0..columns.len() {
-                    let name = columns[i].name().to_string();
-                    let val = $extract_fn(&row, i, None);
-                    obj.insert(name, val);
-                }
-                serde_json::to_writer(&mut writer, &obj).map_err(|e| e.to_string())?;
-
-                count += 1;
-                if count % 100 == 0 {
-                    $app.emit(
-                        "export_progress",
-                        ExportProgress {
-                            rows_processed: count,
-                        },
-                    )
-                    .unwrap_or(());
-                }
-            }
-            writer.write_all(b"]").map_err(|e| e.to_string())?;
-            writer.flush().map_err(|e| e.to_string())?;
-        }
-
-        Ok::<(), String>(())
-    }};
+fn sanitize_query(query: &str) -> String {
+    query.trim().trim_end_matches(';').to_string()
 }
 
 #[tauri::command]
@@ -124,10 +56,8 @@ pub async fn cancel_export(
     let mut handles = state.handles.lock().unwrap();
     if let Some(handle) = handles.remove(&connection_id) {
         handle.abort();
-        Ok(())
-    } else {
-        Ok(())
     }
+    Ok(())
 }
 
 #[tauri::command]
@@ -140,83 +70,112 @@ pub async fn export_query_to_file<R: Runtime>(
     format: String,
     csv_delimiter: Option<String>,
 ) -> Result<(), String> {
-    let sanitized_query = query.trim().trim_end_matches(';').to_string();
+    let sanitized_query = sanitize_query(&query);
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
-    let params = resolve_connection_params(&saved_conn.params)?;
+    let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
     let driver = saved_conn.params.driver.clone();
 
-    let delimiter_byte = csv_delimiter.and_then(|d| d.bytes().next()).unwrap_or(b',');
+    let export_format = ExportFormat::parse(&format)?;
+    let delimiter = parse_csv_delimiter(csv_delimiter.as_deref());
+
+    let app_for_task = app.clone();
+    let task_connection_id = connection_id.clone();
 
     let task = tokio::spawn(async move {
         let file = File::create(&file_path).map_err(|e| e.to_string())?;
         let writer = BufWriter::new(file);
-
-        match driver.as_str() {
-            "mysql" => {
-                let pool = get_mysql_pool(&params).await?;
-                let mut rows = sqlx::query(&sanitized_query).fetch(&pool);
-                export_rows!(
-                    rows,
-                    extract_mysql_value,
-                    format,
-                    delimiter_byte,
-                    writer,
-                    app
-                )
-            }
-            "postgres" => {
-                let pool = get_postgres_pool(&params).await?;
-                let client = pool
-                    .get()
-                    .await
-                    .map_err(|e| format!("failed to get postgres client: {:?}", e))?;
-
-                let params: Vec<i32> = vec![];
-                let mut rows = std::pin::pin!(client
-                    .query_raw(&sanitized_query, &params)
-                    .await
-                    .map_err(|e| format!("failed to execute postgres query: {:?}", e))?);
-
-                export_rows!(
-                    rows,
-                    extract_postgres_value,
-                    format,
-                    delimiter_byte,
-                    writer,
-                    app
-                )
-            }
-            "sqlite" => {
-                let pool = get_sqlite_pool(&params).await?;
-                let mut rows = sqlx::query(&sanitized_query).fetch(&pool);
-                export_rows!(
-                    rows,
-                    extract_sqlite_value,
-                    format,
-                    delimiter_byte,
-                    writer,
-                    app
-                )
-            }
-            _ => Err("Unsupported driver".into()),
-        }
+        run_export(
+            app_for_task,
+            &driver,
+            &params,
+            &sanitized_query,
+            writer,
+            export_format,
+            delimiter,
+        )
+        .await
     });
 
     let abort_handle = task.abort_handle();
     {
         let mut handles = state.handles.lock().unwrap();
-        handles.insert(connection_id.clone(), abort_handle);
+        handles.insert(task_connection_id.clone(), abort_handle);
     }
 
     let result = task.await;
 
     {
         let mut handles = state.handles.lock().unwrap();
-        handles.remove(&connection_id);
+        handles.remove(&task_connection_id);
     }
 
     match result {
         Ok(res) => res,
         Err(_) => Err("Export cancelled".into()),
+    }
+}
+
+/// Wires the driver stream, the row sink, and the progress emitter together.
+/// Kept as a free function so the spawned task body stays linear and the
+/// pieces remain individually unit-testable.
+async fn run_export<R: Runtime>(
+    app: AppHandle<R>,
+    driver: &str,
+    params: &ConnectionParams,
+    query: &str,
+    writer: BufWriter<File>,
+    format: ExportFormat,
+    delimiter: u8,
+) -> Result<(), String> {
+    let app_for_progress = app.clone();
+    let mut progress = ProgressEmitter::new(DEFAULT_PROGRESS_INTERVAL, move |count| {
+        let _ = app_for_progress.emit(
+            EXPORT_PROGRESS_EVENT,
+            ExportProgressPayload {
+                rows_processed: count,
+            },
+        );
+    });
+
+    match format {
+        ExportFormat::Csv => {
+            let mut sink = CsvSink::new(writer, delimiter);
+            stream_to_sink(driver, params, query, &mut sink, &mut progress).await?;
+            sink.finish()?;
+        }
+        ExportFormat::Json => {
+            let mut sink = JsonSink::new(writer);
+            stream_to_sink(driver, params, query, &mut sink, &mut progress).await?;
+            sink.finish()?;
+        }
+    }
+
+    progress.finish();
+    Ok(())
+}
+
+async fn stream_to_sink<S, F>(
+    driver: &str,
+    params: &ConnectionParams,
+    query: &str,
+    sink: &mut S,
+    progress: &mut ProgressEmitter<F>,
+) -> Result<(), String>
+where
+    S: RowSink + Send,
+    F: FnMut(u64) + Send,
+{
+    let mut on_row = |headers: &[String], values: &[Value]| -> Result<(), String> {
+        sink.write_row(headers, values)?;
+        progress.tick();
+        Ok(())
+    };
+
+    match driver {
+        "mysql" => mysql::export::stream_query(params, query, &mut on_row).await,
+        "postgres" => postgres::export::stream_query(params, query, &mut on_row).await,
+        "sqlite" => sqlite::export::stream_query(params, query, &mut on_row).await,
+        other => Err(format!("Unsupported driver for export: {}", other)),
     }
 }

--- a/src-tauri/src/export/format.rs
+++ b/src-tauri/src/export/format.rs
@@ -1,0 +1,38 @@
+use serde_json::Value;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExportFormat {
+    Csv,
+    Json,
+}
+
+impl ExportFormat {
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "csv" => Ok(Self::Csv),
+            "json" => Ok(Self::Json),
+            other => Err(format!("Unsupported export format: {}", other)),
+        }
+    }
+}
+
+pub const DEFAULT_CSV_DELIMITER: u8 = b',';
+
+/// Returns the first byte of the supplied string, falling back to a comma when
+/// the option is `None`, an empty string, or pure whitespace.
+pub fn parse_csv_delimiter(value: Option<&str>) -> u8 {
+    value
+        .and_then(|d| d.bytes().next())
+        .unwrap_or(DEFAULT_CSV_DELIMITER)
+}
+
+/// Converts a JSON value into the string representation used by the CSV writer.
+/// Strings are emitted verbatim, `null` becomes the sentinel `NULL`, and every
+/// other scalar/composite delegates to `Value::to_string`.
+pub fn value_to_csv_string(val: &Value) -> String {
+    match val {
+        Value::String(s) => s.clone(),
+        Value::Null => "NULL".to_string(),
+        other => other.to_string(),
+    }
+}

--- a/src-tauri/src/export/progress.rs
+++ b/src-tauri/src/export/progress.rs
@@ -1,0 +1,37 @@
+/// Default number of rows between two interval progress emissions.
+pub const DEFAULT_INTERVAL: u64 = 100;
+
+/// Tracks the number of rows processed and emits progress updates at a fixed
+/// interval (every `every` rows) plus one final update on `finish`.
+pub struct ProgressEmitter<F: FnMut(u64)> {
+    count: u64,
+    every: u64,
+    emit: F,
+}
+
+impl<F: FnMut(u64)> ProgressEmitter<F> {
+    /// `every` is clamped to a minimum of 1 so that callers cannot accidentally
+    /// disable interval emission.
+    pub fn new(every: u64, emit: F) -> Self {
+        Self {
+            count: 0,
+            every: every.max(1),
+            emit,
+        }
+    }
+
+    pub fn tick(&mut self) {
+        self.count += 1;
+        if self.count % self.every == 0 {
+            (self.emit)(self.count);
+        }
+    }
+
+    pub fn finish(&mut self) {
+        (self.emit)(self.count);
+    }
+
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+}

--- a/src-tauri/src/export/sink.rs
+++ b/src-tauri/src/export/sink.rs
@@ -1,0 +1,109 @@
+use serde_json::ser::{CompactFormatter, Formatter};
+use serde_json::Value;
+use std::io::Write;
+
+use super::format::value_to_csv_string;
+
+/// A streaming consumer of rows produced by a driver.
+///
+/// `write_row` is called once per database row with the column names (stable
+/// across the whole export) and the extracted JSON values. `finish` is called
+/// after the last row so the sink can flush any trailing data.
+pub trait RowSink {
+    fn write_row(&mut self, headers: &[String], values: &[Value]) -> Result<(), String>;
+    fn finish(&mut self) -> Result<(), String>;
+}
+
+pub struct CsvSink<W: Write> {
+    writer: csv::Writer<W>,
+    headers_written: bool,
+}
+
+impl<W: Write> CsvSink<W> {
+    pub fn new(inner: W, delimiter: u8) -> Self {
+        Self {
+            writer: csv::WriterBuilder::new()
+                .delimiter(delimiter)
+                .from_writer(inner),
+            headers_written: false,
+        }
+    }
+}
+
+impl<W: Write> RowSink for CsvSink<W> {
+    fn write_row(&mut self, headers: &[String], values: &[Value]) -> Result<(), String> {
+        if !self.headers_written {
+            self.writer
+                .write_record(headers)
+                .map_err(|e| e.to_string())?;
+            self.headers_written = true;
+        }
+        let record: Vec<String> = values.iter().map(value_to_csv_string).collect();
+        self.writer
+            .write_record(&record)
+            .map_err(|e| e.to_string())
+    }
+
+    fn finish(&mut self) -> Result<(), String> {
+        self.writer.flush().map_err(|e| e.to_string())
+    }
+}
+
+/// Streaming JSON-array sink. Delegates the `[`, `,`, `]` punctuation to
+/// `serde_json::ser::CompactFormatter` so we never reinvent JSON framing.
+pub struct JsonSink<W: Write> {
+    writer: W,
+    formatter: CompactFormatter,
+    started: bool,
+    first: bool,
+}
+
+impl<W: Write> JsonSink<W> {
+    pub fn new(writer: W) -> Self {
+        Self {
+            writer,
+            formatter: CompactFormatter,
+            started: false,
+            first: true,
+        }
+    }
+
+    fn ensure_started(&mut self) -> Result<(), String> {
+        if !self.started {
+            self.formatter
+                .begin_array(&mut self.writer)
+                .map_err(|e| e.to_string())?;
+            self.started = true;
+        }
+        Ok(())
+    }
+}
+
+impl<W: Write> RowSink for JsonSink<W> {
+    fn write_row(&mut self, headers: &[String], values: &[Value]) -> Result<(), String> {
+        self.ensure_started()?;
+        self.formatter
+            .begin_array_value(&mut self.writer, self.first)
+            .map_err(|e| e.to_string())?;
+        self.first = false;
+
+        let mut obj = serde_json::Map::with_capacity(headers.len());
+        for (i, name) in headers.iter().enumerate() {
+            let val = values.get(i).cloned().unwrap_or(Value::Null);
+            obj.insert(name.clone(), val);
+        }
+        serde_json::to_writer(&mut self.writer, &obj).map_err(|e| e.to_string())?;
+
+        self.formatter
+            .end_array_value(&mut self.writer)
+            .map_err(|e| e.to_string())
+    }
+
+    fn finish(&mut self) -> Result<(), String> {
+        self.ensure_started()?;
+        self.formatter
+            .end_array(&mut self.writer)
+            .map_err(|e| e.to_string())?;
+        self.writer.flush().map_err(|e| e.to_string())
+    }
+}

--- a/src-tauri/src/export/tests.rs
+++ b/src-tauri/src/export/tests.rs
@@ -1,0 +1,268 @@
+use super::format::{parse_csv_delimiter, value_to_csv_string, ExportFormat, DEFAULT_CSV_DELIMITER};
+use super::progress::ProgressEmitter;
+use super::sink::{CsvSink, JsonSink, RowSink};
+use serde_json::{json, Value};
+
+// ---------------------------------------------------------------------------
+// ExportFormat::parse
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_csv_format_accepts_lowercase() {
+    assert_eq!(ExportFormat::parse("csv").unwrap(), ExportFormat::Csv);
+}
+
+#[test]
+fn parse_csv_format_is_case_insensitive() {
+    assert_eq!(ExportFormat::parse("CSV").unwrap(), ExportFormat::Csv);
+    assert_eq!(ExportFormat::parse("Csv").unwrap(), ExportFormat::Csv);
+}
+
+#[test]
+fn parse_json_format_is_case_insensitive() {
+    assert_eq!(ExportFormat::parse("json").unwrap(), ExportFormat::Json);
+    assert_eq!(ExportFormat::parse("JSON").unwrap(), ExportFormat::Json);
+}
+
+#[test]
+fn parse_format_trims_whitespace() {
+    assert_eq!(ExportFormat::parse("  csv ").unwrap(), ExportFormat::Csv);
+}
+
+#[test]
+fn parse_format_rejects_unknown() {
+    let err = ExportFormat::parse("xml").unwrap_err();
+    assert!(err.contains("xml"));
+}
+
+// ---------------------------------------------------------------------------
+// parse_csv_delimiter
+// ---------------------------------------------------------------------------
+
+#[test]
+fn delimiter_defaults_to_comma_when_none() {
+    assert_eq!(parse_csv_delimiter(None), DEFAULT_CSV_DELIMITER);
+}
+
+#[test]
+fn delimiter_defaults_to_comma_for_empty_string() {
+    assert_eq!(parse_csv_delimiter(Some("")), DEFAULT_CSV_DELIMITER);
+}
+
+#[test]
+fn delimiter_uses_first_byte() {
+    assert_eq!(parse_csv_delimiter(Some(";")), b';');
+    assert_eq!(parse_csv_delimiter(Some("|extra")), b'|');
+    assert_eq!(parse_csv_delimiter(Some("\t")), b'\t');
+}
+
+// ---------------------------------------------------------------------------
+// value_to_csv_string
+// ---------------------------------------------------------------------------
+
+#[test]
+fn value_to_csv_emits_raw_string_without_quotes() {
+    assert_eq!(value_to_csv_string(&json!("hello")), "hello");
+}
+
+#[test]
+fn value_to_csv_emits_null_sentinel() {
+    assert_eq!(value_to_csv_string(&Value::Null), "NULL");
+}
+
+#[test]
+fn value_to_csv_serializes_numbers_and_bools() {
+    assert_eq!(value_to_csv_string(&json!(42)), "42");
+    assert_eq!(value_to_csv_string(&json!(3.5)), "3.5");
+    assert_eq!(value_to_csv_string(&json!(true)), "true");
+    assert_eq!(value_to_csv_string(&json!(false)), "false");
+}
+
+#[test]
+fn value_to_csv_serializes_objects_and_arrays_as_json() {
+    assert_eq!(value_to_csv_string(&json!({"a": 1})), r#"{"a":1}"#);
+    assert_eq!(value_to_csv_string(&json!([1, 2, 3])), "[1,2,3]");
+}
+
+// ---------------------------------------------------------------------------
+// ProgressEmitter
+// ---------------------------------------------------------------------------
+
+#[test]
+fn progress_emits_at_each_interval() {
+    let mut emitted: Vec<u64> = Vec::new();
+    {
+        let mut p = ProgressEmitter::new(3, |c| emitted.push(c));
+        for _ in 0..7 {
+            p.tick();
+        }
+    }
+    assert_eq!(emitted, vec![3, 6]);
+}
+
+#[test]
+fn progress_finish_always_emits_final_count() {
+    let mut emitted: Vec<u64> = Vec::new();
+    {
+        let mut p = ProgressEmitter::new(100, |c| emitted.push(c));
+        for _ in 0..5 {
+            p.tick();
+        }
+        p.finish();
+    }
+    // 5 ticks, no interval emission, but finish() emits the final count.
+    assert_eq!(emitted, vec![5]);
+}
+
+#[test]
+fn progress_finish_emits_zero_on_empty_stream() {
+    let mut emitted: Vec<u64> = Vec::new();
+    {
+        let mut p = ProgressEmitter::new(100, |c| emitted.push(c));
+        p.finish();
+    }
+    assert_eq!(emitted, vec![0]);
+}
+
+#[test]
+fn progress_interval_zero_is_normalized_to_one() {
+    let mut emitted: Vec<u64> = Vec::new();
+    {
+        let mut p = ProgressEmitter::new(0, |c| emitted.push(c));
+        for _ in 0..3 {
+            p.tick();
+        }
+    }
+    assert_eq!(emitted, vec![1, 2, 3]);
+}
+
+#[test]
+fn progress_counter_tracks_total_ticks() {
+    let mut p = ProgressEmitter::new(100, |_| ());
+    for _ in 0..42 {
+        p.tick();
+    }
+    assert_eq!(p.count(), 42);
+}
+
+// ---------------------------------------------------------------------------
+// CsvSink
+// ---------------------------------------------------------------------------
+
+fn collect_csv(delimiter: u8, rows: &[(Vec<&str>, Vec<Value>)]) -> String {
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut sink = CsvSink::new(&mut buf, delimiter);
+        for (headers, values) in rows {
+            let headers_owned: Vec<String> = headers.iter().map(|s| s.to_string()).collect();
+            sink.write_row(&headers_owned, values).unwrap();
+        }
+        sink.finish().unwrap();
+    }
+    String::from_utf8(buf).unwrap()
+}
+
+#[test]
+fn csv_writes_headers_once_then_rows() {
+    let csv = collect_csv(
+        b',',
+        &[
+            (vec!["id", "name"], vec![json!(1), json!("alice")]),
+            (vec!["id", "name"], vec![json!(2), json!("bob")]),
+        ],
+    );
+    assert_eq!(csv, "id,name\n1,alice\n2,bob\n");
+}
+
+#[test]
+fn csv_respects_custom_delimiter() {
+    let csv = collect_csv(
+        b';',
+        &[(vec!["a", "b"], vec![json!("x"), json!("y")])],
+    );
+    assert_eq!(csv, "a;b\nx;y\n");
+}
+
+#[test]
+fn csv_emits_null_sentinel_for_null_values() {
+    let csv = collect_csv(b',', &[(vec!["v"], vec![Value::Null])]);
+    assert_eq!(csv, "v\nNULL\n");
+}
+
+#[test]
+fn csv_quotes_values_containing_delimiter() {
+    let csv = collect_csv(
+        b',',
+        &[(vec!["v"], vec![json!("a,b")])],
+    );
+    assert!(csv.contains("\"a,b\""));
+}
+
+// ---------------------------------------------------------------------------
+// JsonSink
+// ---------------------------------------------------------------------------
+
+fn collect_json(rows: &[(Vec<&str>, Vec<Value>)]) -> String {
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut sink = JsonSink::new(&mut buf);
+        for (headers, values) in rows {
+            let headers_owned: Vec<String> = headers.iter().map(|s| s.to_string()).collect();
+            sink.write_row(&headers_owned, values).unwrap();
+        }
+        sink.finish().unwrap();
+    }
+    String::from_utf8(buf).unwrap()
+}
+
+#[test]
+fn json_empty_stream_writes_empty_array() {
+    let json_out = collect_json(&[]);
+    assert_eq!(json_out, "[]");
+}
+
+#[test]
+fn json_single_row_is_wrapped_in_array() {
+    let json_out = collect_json(&[(vec!["id", "name"], vec![json!(1), json!("alice")])]);
+    let parsed: Value = serde_json::from_str(&json_out).unwrap();
+    assert_eq!(parsed, json!([{"id": 1, "name": "alice"}]));
+}
+
+#[test]
+fn json_multiple_rows_separated_by_commas() {
+    let json_out = collect_json(&[
+        (vec!["id"], vec![json!(1)]),
+        (vec!["id"], vec![json!(2)]),
+        (vec!["id"], vec![json!(3)]),
+    ]);
+    let parsed: Value = serde_json::from_str(&json_out).unwrap();
+    assert_eq!(parsed, json!([{"id": 1}, {"id": 2}, {"id": 3}]));
+}
+
+#[test]
+fn json_preserves_value_types_unchanged() {
+    let json_out = collect_json(&[(
+        vec!["n", "f", "b", "s", "z"],
+        vec![json!(42), json!(3.5), json!(true), json!("hi"), Value::Null],
+    )]);
+    let parsed: Value = serde_json::from_str(&json_out).unwrap();
+    assert_eq!(
+        parsed,
+        json!([{"n": 42, "f": 3.5, "b": true, "s": "hi", "z": null}])
+    );
+}
+
+#[test]
+fn json_missing_value_defaults_to_null() {
+    // Defensive: if a driver yields fewer values than headers, the sink fills
+    // the gap with null rather than panicking.
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut sink = JsonSink::new(&mut buf);
+        let headers = vec!["a".to_string(), "b".to_string()];
+        sink.write_row(&headers, &[json!(1)]).unwrap();
+        sink.finish().unwrap();
+    }
+    let parsed: Value = serde_json::from_str(&String::from_utf8(buf).unwrap()).unwrap();
+    assert_eq!(parsed, json!([{"a": 1, "b": null}]));
+}

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -42,6 +42,8 @@ import {
   Hash,
   Loader2,
   Copy,
+  FileText,
+  FileJson,
 } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
@@ -2475,9 +2477,24 @@ export const Editor = () => {
           <button
             onClick={() => setExportMenuOpen(!exportMenuOpen)}
             disabled={!activeTab.result || activeTab.result.rows.length === 0}
-            className="flex items-center gap-2 px-3 py-1.5 bg-surface-secondary hover:bg-surface text-primary rounded text-sm font-medium disabled:opacity-50 border border-strong"
+            aria-haspopup="menu"
+            aria-expanded={exportMenuOpen}
+            className={clsx(
+              "flex items-center gap-2 px-3 py-1.5 rounded text-sm font-medium border transition-colors disabled:opacity-50 disabled:cursor-not-allowed",
+              exportMenuOpen
+                ? "bg-blue-500/15 border-blue-500/40 text-blue-400"
+                : "bg-surface-secondary enabled:hover:bg-blue-500/15 enabled:hover:border-blue-500/40 enabled:hover:text-blue-400 text-primary border-strong",
+            )}
           >
-            <Download size={16} /> {t("editor.export")}
+            <Download size={16} />
+            {t("editor.export")}
+            <ChevronDown
+              size={14}
+              className={clsx(
+                "transition-transform opacity-70",
+                exportMenuOpen && "rotate-180",
+              )}
+            />
           </button>
           {exportMenuOpen && (
             <>
@@ -2485,18 +2502,27 @@ export const Editor = () => {
                 className="fixed inset-0 z-40"
                 onClick={() => setExportMenuOpen(false)}
               />
-              <div className="absolute top-full left-0 mt-1 w-40 bg-surface-secondary border border-strong rounded shadow-xl z-50 flex flex-col py-1">
+              <div
+                role="menu"
+                className="absolute top-full right-0 mt-1 w-44 bg-elevated border border-strong rounded-md shadow-xl z-50 flex flex-col py-1 overflow-hidden"
+              >
                 <button
+                  role="menuitem"
                   onClick={handleExportCSV}
-                  className="text-left px-4 py-2 text-sm text-secondary hover:bg-surface"
+                  className="flex items-center gap-2.5 text-left px-3 py-2 text-sm text-secondary hover:bg-blue-500/15 hover:text-blue-400 transition-colors"
                 >
-                  CSV (.csv)
+                  <FileText size={14} className="shrink-0 opacity-80" />
+                  <span className="flex-1">CSV</span>
+                  <span className="text-xs text-muted">.csv</span>
                 </button>
                 <button
+                  role="menuitem"
                   onClick={handleExportJSON}
-                  className="text-left px-4 py-2 text-sm text-secondary hover:bg-surface"
+                  className="flex items-center gap-2.5 text-left px-3 py-2 text-sm text-secondary hover:bg-blue-500/15 hover:text-blue-400 transition-colors"
                 >
-                  JSON (.json)
+                  <FileJson size={14} className="shrink-0 opacity-80" />
+                  <span className="flex-1">JSON</span>
+                  <span className="text-xs text-muted">.json</span>
                 </button>
               </div>
             </>


### PR DESCRIPTION
Closes #184

## Summary

- `export_query_to_file` skipped `expand_ssh_connection_params`, so the export of any MySQL/Postgres/SQLite query through an SSH tunnel failed with `Missing SSH Host`. Now mirrors the pattern used by every other Tauri command (`expand_ssh_connection_params` + `resolve_connection_params_with_id`).
- Emits a final `export_progress` event so the progress counter is correct for exports under 100 rows.
- Splits the macro-based row writer into per-driver streamers (`drivers/{mysql,postgres,sqlite}/export.rs`) and pure helpers (`export/{format,progress,sink}.rs`); JSON array framing now delegated to `serde_json::ser::CompactFormatter`.
- 26 new unit tests for format parsing, CSV/JSON sinks, and the progress emitter.
- Minor UI polish on the Export dropdown trigger and menu (chevron indicator, hover highlight, format icons; hover disabled when the button is disabled).

## Test plan

- [x] `cargo test --lib` — 517 passing
- [x] `pnpm tsc --noEmit` — clean
- [ ] Manual: export a query over SSH tunnel (CSV + JSON) and confirm the file contains rows and the progress counter advances