### PR TITLE
feat(sidebar): add 'New Console' to database and table context menus

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "tabularis"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/src/components/layout/ExplorerSidebar.tsx
+++ b/src/components/layout/ExplorerSidebar.tsx
@@ -72,6 +72,7 @@ import { groupByDate, formatHistoryTime } from "../../utils/dateGroups";
 import { SqlHighlight } from "../ui/SqlHighlight";
 import { isMultiDatabaseCapable } from "../../utils/database";
 import { supportsManageTables } from "../../utils/driverCapabilities";
+import { newConsoleForDatabase, newConsoleForTable } from "../../utils/newConsole";
 
 export type SidebarTab = "structure" | "favorites" | "history";
 
@@ -1437,6 +1438,14 @@ export const ExplorerSidebar = ({ sidebarWidth, startResize, onCollapse, sidebar
                       },
                     },
                     {
+                      label: t("sidebar.newConsole"),
+                      icon: FileCode,
+                      action: () => {
+                        const spec = newConsoleForTable(contextMenu.id, activeDriver, ctxSchema);
+                        runQuery(spec.sql, spec.title, undefined, true, spec.schema);
+                      },
+                    },
+                    {
                       label: t("sidebar.countRows"),
                       icon: Hash,
                       action: () => {
@@ -1714,6 +1723,14 @@ export const ExplorerSidebar = ({ sidebarWidth, startResize, onCollapse, sidebar
                             ]
                           : contextMenu.type === "database"
                             ? [
+                                {
+                                  label: t("sidebar.newConsole"),
+                                  icon: FileCode,
+                                  action: () => {
+                                    const spec = newConsoleForDatabase(contextMenu.id);
+                                    runQuery(spec.sql, spec.title, undefined, true, spec.schema);
+                                  },
+                                },
                                 {
                                   label: t("dump.importDatabase"),
                                   icon: Upload,

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -2029,14 +2029,14 @@ export const Editor = () => {
   useEffect(() => {
     const state = location.state as EditorState;
     if (activeConnectionId) {
-      if (state?.initialQuery) {
+      if (state?.initialQuery !== undefined) {
         if (
           state.targetConnectionId &&
           state.targetConnectionId !== activeConnectionId
         )
           return;
 
-        const queryKey = `${state.initialQuery}-${state.tableName}-${state.queryName}`;
+        const queryKey = `${state.initialQuery}-${state.tableName}-${state.queryName}-${state.schema}-${state.title}`;
 
         if (processingRef.current === queryKey) return;
         processingRef.current = queryKey;

--- a/src/utils/newConsole.ts
+++ b/src/utils/newConsole.ts
@@ -1,0 +1,23 @@
+import { quoteTableRef } from "./identifiers";
+
+export interface NewConsoleSpec {
+  sql: string;
+  title: string;
+  schema?: string;
+}
+
+export function newConsoleForDatabase(databaseName: string): NewConsoleSpec {
+  return { sql: "", title: databaseName, schema: databaseName };
+}
+
+export function newConsoleForTable(
+  tableName: string,
+  driver: string | null | undefined,
+  schema?: string,
+): NewConsoleSpec {
+  return {
+    sql: `SELECT * FROM ${quoteTableRef(tableName, driver, schema)}`,
+    title: tableName,
+    schema,
+  };
+}

--- a/tests/utils/newConsole.test.ts
+++ b/tests/utils/newConsole.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import {
+  newConsoleForDatabase,
+  newConsoleForTable,
+} from "../../src/utils/newConsole";
+
+describe("newConsole", () => {
+  describe("newConsoleForDatabase", () => {
+    it("returns empty SQL with database as title and schema target", () => {
+      expect(newConsoleForDatabase("analytics")).toEqual({
+        sql: "",
+        title: "analytics",
+        schema: "analytics",
+      });
+    });
+
+    it("preserves whitespace and special characters in the database name", () => {
+      expect(newConsoleForDatabase("my db")).toEqual({
+        sql: "",
+        title: "my db",
+        schema: "my db",
+      });
+    });
+  });
+
+  describe("newConsoleForTable", () => {
+    it("builds a postgres SELECT with schema qualifier", () => {
+      expect(newConsoleForTable("users", "postgres", "public")).toEqual({
+        sql: 'SELECT * FROM "public"."users"',
+        title: "users",
+        schema: "public",
+      });
+    });
+
+    it("builds a mysql SELECT with backticks and schema qualifier", () => {
+      expect(newConsoleForTable("users", "mysql", "mydb")).toEqual({
+        sql: "SELECT * FROM `mydb`.`users`",
+        title: "users",
+        schema: "mydb",
+      });
+    });
+
+    it("omits schema qualifier when schema is not provided", () => {
+      expect(newConsoleForTable("users", "postgres")).toEqual({
+        sql: 'SELECT * FROM "users"',
+        title: "users",
+        schema: undefined,
+      });
+    });
+
+    it("omits schema qualifier when schema is empty string", () => {
+      expect(newConsoleForTable("users", "postgres", "")).toEqual({
+        sql: 'SELECT * FROM "users"',
+        title: "users",
+        schema: "",
+      });
+    });
+
+    it("uses default quote char for null driver", () => {
+      const spec = newConsoleForTable("users", null);
+      expect(spec.sql).toBe('SELECT * FROM "users"');
+      expect(spec.title).toBe("users");
+    });
+
+    it("uses default quote char for undefined driver", () => {
+      const spec = newConsoleForTable("users", undefined);
+      expect(spec.sql).toBe('SELECT * FROM "users"');
+    });
+
+    it("escapes double quotes in postgres identifiers", () => {
+      const spec = newConsoleForTable('my"table', "postgres", 'my"schema');
+      expect(spec.sql).toBe('SELECT * FROM "my""schema"."my""table"');
+    });
+
+    it("escapes backticks in mysql identifiers", () => {
+      const spec = newConsoleForTable("my`table", "mysql");
+      expect(spec.sql).toBe("SELECT * FROM `my``table`");
+    });
+  });
+});


### PR DESCRIPTION
Closes #187

## Summary

- Adds a "New Console" entry to the right-click context menu on databases and tables in the explorer sidebar.
  - On a database: opens a fresh, empty console with that database preselected as the target schema.
  - On a table: opens a new console pre-filled with `SELECT * FROM <quoted-table>` (driver-aware quoting via `quoteTableRef`) and `preventAutoRun: true`, so the query can be edited before execution.
- The editor's nav-state effect in `Editor.tsx` previously bailed out on falsy `initialQuery`, so an empty navigation state never created a tab. Loosened the guard to `initialQuery !== undefined` and extended the dedup key with `schema` and `title` so consecutive "New Console" clicks on different databases don't collapse onto the same tab.
- Extracted the two state builders into `src/utils/newConsole.ts` (`newConsoleForDatabase`, `newConsoleForTable`) and covered them with unit tests for postgres/mysql quoting, empty/null schemas, and quote-character escaping in identifiers.
- Reuses the existing `sidebar.newConsole` i18n key — already present in all 6 locales, no translation work needed.

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm test --run` — 2108 passing (10 new)
- [ ] Manual: right-click a database in the sidebar → "New Console" opens an empty console targeting that DB
- [ ] Manual: right-click a table → "New Console" opens a console with the SELECT pre-filled and not executed; running it returns rows
- [ ] Manual: do the above twice for two different databases and confirm two separate tabs (no dedup collapse)