### PR TITLE
chore(discord-release): add link buttons and @everyone mention

### DIFF
--- a/.claude/skills/tabularis-discord-release/SKILL.md
+++ b/.claude/skills/tabularis-discord-release/SKILL.md
@@ -75,7 +75,7 @@ The raw CHANGELOG lines are commit-message-shaped. Rewrite each one for a human 
 ## What NOT to do
 - Don't bypass `template.json` by writing inline JSON. If the template doesn't exist, stop and tell the user.
 - Don't add an `image` field unless the user provides a screenshot URL — edit `template.json` to add it permanently if they want it on every release.
-- Don't add reactions, components, or polls.
+- Don't add reactions or polls. (Link-button components in the template are fine and must be preserved through substitution — they only need `{{VERSION}}` and `{{BLOG_URL}}` substituted like the rest.)
 - Don't include `:::contributors:::` or other blog-specific markdown — that syntax breaks Discord rendering.
 - Don't translate to Italian unless the user explicitly asks; default is English (Tabularis Discord is international).
 

--- a/.claude/skills/tabularis-discord-release/template.json
+++ b/.claude/skills/tabularis-discord-release/template.json
@@ -1,7 +1,7 @@
 {
   "username": "Tabularis",
   "avatar_url": "https://raw.githubusercontent.com/debba/tabularis/main/src-tauri/icons/128x128.png",
-  "content": "**v{{VERSION}}** is out.",
+  "content": "@everyone **v{{VERSION}}** is out.",
   "embeds": [
     {
       "title": "Tabularis v{{VERSION}}",
@@ -28,11 +28,6 @@
           "value": "{{FIXES_BULLETS}}",
           "inline": false,
           "_omit_if_value_empty": true
-        },
-        {
-          "name": "Links",
-          "value": "[Release post]({{BLOG_URL}}?utm_src=discord) · [GitHub release](https://github.com/debba/tabularis/releases/tag/v{{VERSION}}) · [Changelog](https://github.com/debba/tabularis/blob/main/CHANGELOG.md)",
-          "inline": false
         }
       ],
       "footer": {
@@ -40,6 +35,37 @@
         "icon_url": "https://raw.githubusercontent.com/debba/tabularis/main/src-tauri/icons/128x128.png"
       },
       "timestamp": "{{DATE_ISO}}"
+    }
+  ],
+  "components": [
+    {
+      "type": 1,
+      "components": [
+        {
+          "type": 2,
+          "style": 5,
+          "label": "Release post",
+          "url": "{{BLOG_URL}}?utm_src=discord"
+        },
+        {
+          "type": 2,
+          "style": 5,
+          "label": "GitHub Release",
+          "url": "https://github.com/debba/tabularis/releases/tag/v{{VERSION}}"
+        },
+        {
+          "type": 2,
+          "style": 5,
+          "label": "Changelog",
+          "url": "https://github.com/debba/tabularis/blob/main/CHANGELOG.md"
+        },
+        {
+          "type": 2,
+          "style": 5,
+          "label": "Website",
+          "url": "https://tabularis.dev/?utm_src=discord"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds a top-level components row with four link buttons (Release post, GitHub Release, Changelog, Website) so the Discord announcement no longer relies on the embed's Links field, which has been removed. Prefixes the content line with @everyone so the release announcement pings the server. SKILL.md guard against components is narrowed to only forbid reactions and polls; link buttons must be preserved through substitution.