### PR TITLE
fix(editor): restore correct SQL string color across all themes

### DIFF
--- a/src/themes/monaco/Dracula.json
+++ b/src/themes/monaco/Dracula.json
@@ -15,6 +15,10 @@
       "token": "string"
     },
     {
+      "foreground": "f1fa8c",
+      "token": "string.sql"
+    },
+    {
       "foreground": "bd93f9",
       "token": "constant.numeric"
     },

--- a/src/themes/monaco/GitHub Dark.json
+++ b/src/themes/monaco/GitHub Dark.json
@@ -80,6 +80,10 @@
     },
     {
       "foreground": "79b8ff",
+      "token": "string.sql"
+    },
+    {
+      "foreground": "79b8ff",
       "token": "punctuation.definition.string"
     },
     {

--- a/src/themes/monaco/GitHub Light.json
+++ b/src/themes/monaco/GitHub Light.json
@@ -80,6 +80,10 @@
     },
     {
       "foreground": "032f62",
+      "token": "string.sql"
+    },
+    {
+      "foreground": "032f62",
       "token": "punctuation.definition.string"
     },
     {

--- a/src/themes/monaco/Monokai.json
+++ b/src/themes/monaco/Monokai.json
@@ -15,6 +15,10 @@
       "token": "string"
     },
     {
+      "foreground": "e6db74",
+      "token": "string.sql"
+    },
+    {
       "foreground": "ae81ff",
       "token": "constant.numeric"
     },

--- a/src/themes/monaco/Night Owl.json
+++ b/src/themes/monaco/Night Owl.json
@@ -15,6 +15,10 @@
       "token": "string"
     },
     {
+      "foreground": "addb67",
+      "token": "string.sql"
+    },
+    {
       "foreground": "ecc48d",
       "token": "vstring.quoted"
     },

--- a/src/themes/monaco/Nord.json
+++ b/src/themes/monaco/Nord.json
@@ -15,6 +15,10 @@
       "token": "string"
     },
     {
+      "foreground": "a3be8c",
+      "token": "string.sql"
+    },
+    {
       "foreground": "b48ead",
       "token": "constant.numeric"
     },

--- a/src/themes/monaco/One Dark Pro.json
+++ b/src/themes/monaco/One Dark Pro.json
@@ -962,6 +962,10 @@
       "token": "string"
     },
     {
+      "foreground": "#98c379",
+      "token": "string.sql"
+    },
+    {
       "foreground": "#56b6c2",
       "token": "constant.other.symbol"
     },

--- a/src/themes/monaco/Solarized-dark.json
+++ b/src/themes/monaco/Solarized-dark.json
@@ -15,6 +15,10 @@
       "token": "string"
     },
     {
+      "foreground": "2aa198",
+      "token": "string.sql"
+    },
+    {
       "foreground": "586e75",
       "token": "string"
     },

--- a/src/themes/monaco/Solarized-light.json
+++ b/src/themes/monaco/Solarized-light.json
@@ -15,6 +15,10 @@
       "token": "string"
     },
     {
+      "foreground": "2aa198",
+      "token": "string.sql"
+    },
+    {
       "foreground": "586e75",
       "token": "string"
     },

--- a/src/themes/monaco/Tomorrow-Night-Eighties.json
+++ b/src/themes/monaco/Tomorrow-Night-Eighties.json
@@ -104,6 +104,10 @@
     },
     {
       "foreground": "99cc99",
+      "token": "string.sql"
+    },
+    {
+      "foreground": "99cc99",
       "token": "constant.other.symbol"
     },
     {

--- a/src/themes/themeUtils.ts
+++ b/src/themes/themeUtils.ts
@@ -142,10 +142,17 @@ export function applyThemeToCSS(theme: Theme): void {
 export function generateMonacoTheme(theme: Theme): MonacoThemeDefinition {
   const baseColors = theme.monacoTheme.colors || {};
 
+  const stringColor = theme.colors.semantic.string.replace('#', '');
+  const baseRules = theme.monacoTheme.rules ?? [];
+  const sqlStringRules = [
+    { token: 'string.sql', foreground: stringColor },
+    { token: 'string.quote.sql', foreground: stringColor },
+  ];
+
   return {
     base: theme.monacoTheme.base,
     inherit: theme.monacoTheme.inherit,
-    rules: theme.monacoTheme.rules,
+    rules: [...baseRules, ...sqlStringRules],
     colors: {
       // Base editor colors
       "editor.background": theme.colors.bg.base,


### PR DESCRIPTION
Problem

  SQL string literals (single-quoted values like 'foo') were rendering in a barely-readable dark
  red in the Monaco editor for all themes (most visible in Dracula).

  Root cause: Monaco's built-in SQL tokenizer sets tokenPostfix: ".sql", which means the token type
   for SQL strings is string.sql, not string. Monaco 0.55 does not reliably fall back from
  string.sql to the generic string rule, so SQL strings received no color override and fell through
   to the base theme's unmatched-token rendering — a dark red on dark backgrounds.

  Fix

  Added an explicit string.sql token rule to every bundled Monaco theme JSON, using the same color
  already defined for the generic string rule. Also updated generateMonacoTheme() in themeUtils.ts
  to inject string.sql / string.quote.sql rules for themes that don't have a JSON file (Tabularis
  Dark, Tabularis Light, High Contrast).

   | Theme | String color |
  | --- | --- |
  | Dracula | `#f1fa8c` |
  | Monokai | `#e6db74` |
  | Nord | `#a3be8c` |
  | GitHub Dark | `#79b8ff` |
  | GitHub Light | `#032f62` |
  | Night Owl | `#addb67` |
  | One Dark Pro | `#98c379` |
  | Solarized Dark/Light | `#2aa198` |
  | Tomorrow Night Eighties | `#99cc99` |

  Testing

  Open the SQL console, select any theme, and type a query with a single-quoted string literal — it
   should render in the theme's string color instead of red.