### PR TITLE
feat(editor)!: accept autocomplete suggestion on Enter by default

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -51,6 +51,11 @@ pub struct AppConfig {
     pub editor_tab_size: Option<u32>,
     pub editor_word_wrap: Option<bool>,
     pub editor_show_line_numbers: Option<bool>,
+    /// Whether the Enter key accepts the active autocomplete suggestion in the
+    /// SQL editor. Maps to Monaco's `acceptSuggestionOnEnter` setting: `true`
+    /// becomes `"smart"` (the safer variant), `false` becomes `"off"`.
+    /// Default: `false` (preserves the historical opt-out behaviour).
+    pub editor_accept_suggestion_on_enter: Option<bool>,
     /// Connection health check interval in seconds. 0 = disabled. Default: 30.
     pub ping_interval: Option<u32>,
     /// Maximum number of query history entries per connection. Default: 500.
@@ -274,6 +279,10 @@ pub fn save_config(app: AppHandle, config: AppConfig) -> Result<(), String> {
         }
         if config.editor_show_line_numbers.is_some() {
             existing_config.editor_show_line_numbers = config.editor_show_line_numbers;
+        }
+        if config.editor_accept_suggestion_on_enter.is_some() {
+            existing_config.editor_accept_suggestion_on_enter =
+                config.editor_accept_suggestion_on_enter;
         }
         if config.ping_interval.is_some() {
             let old_interval = existing_config.ping_interval;
@@ -725,6 +734,7 @@ mod tests {
         assert!(config.editor_tab_size.is_none());
         assert!(config.editor_word_wrap.is_none());
         assert!(config.editor_show_line_numbers.is_none());
+        assert!(config.editor_accept_suggestion_on_enter.is_none());
     }
 
     #[test]
@@ -737,6 +747,7 @@ mod tests {
         config.editor_word_wrap = Some(false);
         config.editor_show_line_numbers = Some(true);
         config.editor_theme = Some("tabularis-light".to_string());
+        config.editor_accept_suggestion_on_enter = Some(true);
 
         let json = serde_json::to_string(&config).unwrap();
         assert!(json.contains("editorFontFamily"));
@@ -746,8 +757,10 @@ mod tests {
         assert!(json.contains("editorWordWrap"));
         assert!(json.contains("editorShowLineNumbers"));
         assert!(json.contains("editorTheme"));
+        assert!(json.contains("editorAcceptSuggestionOnEnter"));
         // snake_case must not appear
         assert!(!json.contains("editor_font_family"));
+        assert!(!json.contains("editor_accept_suggestion_on_enter"));
     }
 
     #[test]
@@ -759,7 +772,8 @@ mod tests {
             "editorTabSize": 2,
             "editorWordWrap": true,
             "editorShowLineNumbers": true,
-            "editorTheme": "tabularis-dark"
+            "editorTheme": "tabularis-dark",
+            "editorAcceptSuggestionOnEnter": true
         }"#;
 
         let config: AppConfig = serde_json::from_str(json).unwrap();
@@ -769,6 +783,7 @@ mod tests {
         assert_eq!(config.editor_word_wrap, Some(true));
         assert_eq!(config.editor_show_line_numbers, Some(true));
         assert_eq!(config.editor_theme.as_deref(), Some("tabularis-dark"));
+        assert_eq!(config.editor_accept_suggestion_on_enter, Some(true));
     }
 
     #[test]

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -54,7 +54,7 @@ pub struct AppConfig {
     /// Whether the Enter key accepts the active autocomplete suggestion in the
     /// SQL editor. Maps to Monaco's `acceptSuggestionOnEnter` setting: `true`
     /// becomes `"smart"` (the safer variant), `false` becomes `"off"`.
-    /// Default: `false` (preserves the historical opt-out behaviour).
+    /// Default: `true` — matches the behaviour users expect from most editors.
     pub editor_accept_suggestion_on_enter: Option<bool>,
     /// Connection health check interval in seconds. 0 = disabled. Default: 30.
     pub ping_interval: Option<u32>,

--- a/src/components/settings/AppearanceTab.tsx
+++ b/src/components/settings/AppearanceTab.tsx
@@ -205,7 +205,7 @@ export function AppearanceTab() {
               )}
             >
               <SettingToggle
-                checked={settings.editorAcceptSuggestionOnEnter ?? false}
+                checked={settings.editorAcceptSuggestionOnEnter ?? true}
                 onChange={(v) =>
                   updateSetting("editorAcceptSuggestionOnEnter", v)
                 }

--- a/src/components/settings/AppearanceTab.tsx
+++ b/src/components/settings/AppearanceTab.tsx
@@ -197,6 +197,20 @@ export function AppearanceTab() {
                 onChange={(v) => updateSetting("editorShowLineNumbers", v)}
               />
             </SettingRow>
+
+            <SettingRow
+              label={t("settings.appearance_editorAcceptSuggestionOnEnter")}
+              description={t(
+                "settings.appearance_editorAcceptSuggestionOnEnterDesc",
+              )}
+            >
+              <SettingToggle
+                checked={settings.editorAcceptSuggestionOnEnter ?? false}
+                onChange={(v) =>
+                  updateSetting("editorAcceptSuggestionOnEnter", v)
+                }
+              />
+            </SettingRow>
           </SettingSection>
         </>
       )}

--- a/src/components/ui/SqlEditorWrapper.tsx
+++ b/src/components/ui/SqlEditorWrapper.tsx
@@ -174,7 +174,7 @@ const SqlEditorInternal = ({
             verticalScrollbarSize: 8,
             horizontalScrollbarSize: 8,
           },
-          acceptSuggestionOnEnter: 'off',
+          acceptSuggestionOnEnter: settings.editorAcceptSuggestionOnEnter ? 'smart' : 'off',
           multiCursorModifier: 'ctrlCmd',
           automaticLayout: true,
           ...options

--- a/src/components/ui/SqlEditorWrapper.tsx
+++ b/src/components/ui/SqlEditorWrapper.tsx
@@ -174,7 +174,7 @@ const SqlEditorInternal = ({
             verticalScrollbarSize: 8,
             horizontalScrollbarSize: 8,
           },
-          acceptSuggestionOnEnter: settings.editorAcceptSuggestionOnEnter ? 'smart' : 'off',
+          acceptSuggestionOnEnter: (settings.editorAcceptSuggestionOnEnter ?? true) ? 'smart' : 'off',
           multiCursorModifier: 'ctrlCmd',
           automaticLayout: true,
           ...options

--- a/src/contexts/SettingsContext.ts
+++ b/src/contexts/SettingsContext.ts
@@ -44,6 +44,7 @@ export interface Settings {
   editorTabSize?: number;
   editorWordWrap?: boolean;
   editorShowLineNumbers?: boolean;
+  editorAcceptSuggestionOnEnter?: boolean;
   pingInterval?: number;
   queryHistoryMaxEntries?: number;
   showWelcome?: boolean;
@@ -94,6 +95,7 @@ export const DEFAULT_SETTINGS: Settings = {
   editorTabSize: 2,
   editorWordWrap: true,
   editorShowLineNumbers: true,
+  editorAcceptSuggestionOnEnter: false,
   pingInterval: 30,
   queryHistoryMaxEntries: 500,
   aiAuditEnabled: true,

--- a/src/contexts/SettingsContext.ts
+++ b/src/contexts/SettingsContext.ts
@@ -95,7 +95,7 @@ export const DEFAULT_SETTINGS: Settings = {
   editorTabSize: 2,
   editorWordWrap: true,
   editorShowLineNumbers: true,
-  editorAcceptSuggestionOnEnter: false,
+  editorAcceptSuggestionOnEnter: true,
   pingInterval: 30,
   queryHistoryMaxEntries: 500,
   aiAuditEnabled: true,

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -268,6 +268,8 @@
     "appearance_editorWordWrapDesc": "Lange Zeilen im Editor umbrechen statt horizontal zu scrollen.",
     "appearance_editorShowLineNumbers": "Zeilennummern anzeigen",
     "appearance_editorShowLineNumbersDesc": "Zeigt Zeilennummern im Rand des Editors an.",
+    "appearance_editorAcceptSuggestionOnEnter": "Vorschlag mit Eingabetaste übernehmen",
+    "appearance_editorAcceptSuggestionOnEnterDesc": "Erlaubt der Eingabetaste (zusätzlich zu Tab), den aktiven Autovervollständigungsvorschlag zu übernehmen. Bei deaktivierter Option fügt Enter immer einen Zeilenumbruch ein.",
     "editConfigJson": "config.json bearbeiten",
     "editConfigJsonDesc": "Bearbeite die rohe Konfigurationsdatei direkt. Ein Neustart ist erforderlich, um Änderungen anzuwenden.",
     "configJsonModal": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -285,6 +285,8 @@
     "appearance_editorWordWrapDesc": "Wrap long lines in the editor instead of scrolling horizontally.",
     "appearance_editorShowLineNumbers": "Show Line Numbers",
     "appearance_editorShowLineNumbersDesc": "Display line numbers in the editor gutter.",
+    "appearance_editorAcceptSuggestionOnEnter": "Accept Suggestion with Enter",
+    "appearance_editorAcceptSuggestionOnEnterDesc": "Allow Enter (in addition to Tab) to accept the active autocomplete suggestion. When off, Enter always inserts a newline.",
     "editConfigJson": "Edit config.json",
     "editConfigJsonDesc": "Directly edit the raw configuration file. A restart is required to apply changes.",
     "configJsonModal": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -268,6 +268,8 @@
     "appearance_editorWordWrapDesc": "Ajusta las líneas largas en el editor en vez de desplazarse horizontalmente.",
     "appearance_editorShowLineNumbers": "Mostrar Números de Línea",
     "appearance_editorShowLineNumbersDesc": "Muestra los números de línea en el margen del editor.",
+    "appearance_editorAcceptSuggestionOnEnter": "Aceptar Sugerencia con Intro",
+    "appearance_editorAcceptSuggestionOnEnterDesc": "Permite que Intro (además de Tab) acepte la sugerencia de autocompletado activa. Cuando está desactivado, Intro siempre inserta una nueva línea.",
     "editConfigJson": "Editar config.json",
     "editConfigJsonDesc": "Edita directamente el archivo de configuración en bruto. Se requiere reinicio para aplicar los cambios.",
     "configJsonModal": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -268,6 +268,8 @@
     "appearance_editorWordWrapDesc": "Retourne les longues lignes dans l’éditeur au lieu d’un défilement horizontal.",
     "appearance_editorShowLineNumbers": "Afficher les numéros de ligne",
     "appearance_editorShowLineNumbersDesc": "Affiche les numéros de ligne dans la marge de l’éditeur.",
+    "appearance_editorAcceptSuggestionOnEnter": "Accepter la suggestion avec Entrée",
+    "appearance_editorAcceptSuggestionOnEnterDesc": "Autorise la touche Entrée (en plus de Tab) à accepter la suggestion d’autocomplétion active. Lorsqu’elle est désactivée, Entrée insère toujours un saut de ligne.",
     "editConfigJson": "Modifier config.json",
     "editConfigJsonDesc": "Modifiez directement le fichier de configuration brut. Un redémarrage est nécessaire pour appliquer les changements.",
     "configJsonModal": {

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -268,6 +268,8 @@
     "appearance_editorWordWrapDesc": "Manda a capo le righe lunghe nell'editor invece di scorrere orizzontalmente.",
     "appearance_editorShowLineNumbers": "Mostra Numeri di Riga",
     "appearance_editorShowLineNumbersDesc": "Visualizza i numeri di riga nel margine dell'editor.",
+    "appearance_editorAcceptSuggestionOnEnter": "Accetta Suggerimento con Invio",
+    "appearance_editorAcceptSuggestionOnEnterDesc": "Permetti al tasto Invio (oltre a Tab) di accettare il suggerimento di autocompletamento attivo. Quando disattivato, Invio inserisce sempre una nuova riga.",
     "editConfigJson": "Modifica config.json",
     "editConfigJsonDesc": "Modifica direttamente il file di configurazione grezzo. È necessario un riavvio per applicare le modifiche.",
     "configJsonModal": {

--- a/tests/components/ui/SqlEditorWrapper.test.tsx
+++ b/tests/components/ui/SqlEditorWrapper.test.tsx
@@ -262,11 +262,11 @@ describe('SqlEditorWrapper', () => {
       );
     });
 
-    it('defaults to "off" when the setting is undefined', () => {
+    it('defaults to "smart" when the setting is undefined', () => {
       renderWith(undefined, 'accept-undefined');
       expect(screen.getByTestId('monaco-editor')).toHaveAttribute(
         'data-accept-suggestion-on-enter',
-        'off'
+        'smart'
       );
     });
   });

--- a/tests/components/ui/SqlEditorWrapper.test.tsx
+++ b/tests/components/ui/SqlEditorWrapper.test.tsx
@@ -8,10 +8,10 @@ import type { ReactNode } from 'react';
 vi.mock('@monaco-editor/react', async () => {
   return {
     default: ({ onChange, onMount, defaultValue, options }: any) => {
-      // Simulate Monaco editor behavior
       return (
         <textarea
           data-testid="monaco-editor"
+          data-accept-suggestion-on-enter={options?.acceptSuggestionOnEnter}
           defaultValue={defaultValue}
           onChange={(e) => onChange?.(e.target.value)}
         />
@@ -223,5 +223,51 @@ describe('SqlEditorWrapper', () => {
     );
 
     expect(container).toBeInTheDocument();
+  });
+
+  describe('acceptSuggestionOnEnter mapping', () => {
+    const renderWith = (editorAcceptSuggestionOnEnter: boolean | undefined, key: string) => {
+      const ctx = {
+        settings: { ...DEFAULT_SETTINGS, editorAcceptSuggestionOnEnter },
+        updateSetting: vi.fn(),
+        isLoading: false,
+      };
+      const localWrapper = ({ children }: { children: ReactNode }) => (
+        <SettingsContext.Provider value={ctx}>{children}</SettingsContext.Provider>
+      );
+      return render(
+        <SqlEditorWrapper
+          initialValue=""
+          onChange={mockOnChange}
+          onRun={mockOnRun}
+          editorKey={key}
+        />,
+        { wrapper: localWrapper }
+      );
+    };
+
+    it('passes "off" to Monaco when the setting is false', () => {
+      renderWith(false, 'accept-off');
+      expect(screen.getByTestId('monaco-editor')).toHaveAttribute(
+        'data-accept-suggestion-on-enter',
+        'off'
+      );
+    });
+
+    it('passes "smart" to Monaco when the setting is true', () => {
+      renderWith(true, 'accept-on');
+      expect(screen.getByTestId('monaco-editor')).toHaveAttribute(
+        'data-accept-suggestion-on-enter',
+        'smart'
+      );
+    });
+
+    it('defaults to "off" when the setting is undefined', () => {
+      renderWith(undefined, 'accept-undefined');
+      expect(screen.getByTestId('monaco-editor')).toHaveAttribute(
+        'data-accept-suggestion-on-enter',
+        'off'
+      );
+    });
   });
 });


### PR DESCRIPTION
Closes #186.

## What changes

The SQL editor had `acceptSuggestionOnEnter: 'off'` hard-coded, so Enter always inserted a newline even when the autocomplete dropdown was open. This makes the behaviour configurable and **flips the default to on**, matching what most code editors do.

- Enter now accepts the active autocomplete suggestion alongside Tab
- Monaco runs in `'smart'` mode rather than pure `'on'` — the suggestion is accepted only when it produces a textual change different from typing the character, which avoids the worst footguns
- New setting **Appearance → Editor → "Accept Suggestion with Enter"** lets anyone who relied on the previous behaviour opt out
- New field `editorAcceptSuggestionOnEnter` plumbed through `AppConfig` (Rust) and `Settings` (TS)
- i18n entries added for en / it / es / fr / de

## ⚠️ Breaking change

This is the headline change of the PR and worth calling out in the release notes:

> Pressing Enter while an autocomplete suggestion is highlighted now accepts it instead of inserting a newline. To restore the old behaviour, turn off **Appearance → Editor → "Accept Suggestion with Enter"**.

The trade-off is conscious: the previous behaviour surprised most users (this is exactly what issue #186 was about), and IDE muscle memory expects Enter to confirm the suggestion. Existing users with custom `config.json` keep whatever they explicitly set; only the implicit default flips.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `cargo test --lib config::` — 16 passed (incl. new assertions on the camelCase field and round-trip)
- [x] `vitest tests/components/ui/SqlEditorWrapper.test.tsx` — 13 passed; 3 cases cover `false → 'off'`, `true → 'smart'`, `undefined → 'smart'` (new default)
- [x] `eslint` on the changed files — clean
- [x] Manual: with the toggle on (default), type `SEL` in the editor, confirm Enter accepts `SELECT`; turn the toggle off, confirm Enter inserts a newline