### PR TITLE
feat(editor): foreign key click-to-navigate in result grid

### DIFF
--- a/src/components/ui/DataGrid.tsx
+++ b/src/components/ui/DataGrid.tsx
@@ -48,6 +48,10 @@ import { isGeometricType, formatGeometricValue } from "../../utils/geometry";
 import { isBlobColumn, isBlobWireFormat } from "../../utils/blob";
 import { isJsonColumn } from "../../utils/json";
 import {
+  pickPrimaryForeignKeyByColumn,
+  isForeignKeyValueNavigable,
+} from "../../utils/foreignKeys";
+import {
   getDateInputMode,
   parseDateTime,
   formatDateTime,
@@ -63,7 +67,11 @@ import {
   getSelectedRows,
   copyTextToClipboard,
 } from "../../utils/clipboard";
-import type { PendingInsertion, TableColumn } from "../../types/editor";
+import type {
+  PendingInsertion,
+  TableColumn,
+  ForeignKey,
+} from "../../types/editor";
 
 interface DataGridProps {
   columns: string[];
@@ -74,6 +82,8 @@ interface DataGridProps {
   defaultValueColumns?: string[];
   nullableColumns?: string[];
   columnMetadata?: TableColumn[];
+  foreignKeys?: ForeignKey[];
+  onForeignKeyNavigate?: (fk: ForeignKey, value: unknown) => void;
   connectionId?: string | null;
   onRefresh?: () => void;
   pendingChanges?: Record<
@@ -112,6 +122,8 @@ export const DataGrid = React.memo(
     defaultValueColumns,
     nullableColumns,
     columnMetadata,
+    foreignKeys,
+    onForeignKeyNavigate,
     connectionId,
     onRefresh,
     pendingChanges,
@@ -213,6 +225,12 @@ export const DataGrid = React.memo(
         columnMetadata.map((col) => [col.name, col.character_maximum_length]),
       );
     }, [columnMetadata]);
+
+    // Map of column name → primary single-column FK, for click-to-navigate
+    const fksByColumn = useMemo(
+      () => pickPrimaryForeignKeyByColumn(foreignKeys),
+      [foreignKeys],
+    );
 
     // Merge existing rows with pending insertions
     const mergedRows = useMemo(() => {
@@ -1330,6 +1348,44 @@ export const DataGrid = React.memo(
                                         </span>
                                       );
                                     }
+
+                                    const fkForCol = fksByColumn.get(colName);
+                                    const rawCellValue = cell.getValue();
+                                    if (
+                                      fkForCol &&
+                                      onForeignKeyNavigate &&
+                                      !isPendingDelete &&
+                                      !isInsertion &&
+                                      isForeignKeyValueNavigable(rawCellValue)
+                                    ) {
+                                      return (
+                                        <span className="flex items-center gap-1 group/fkcell w-full">
+                                          <span className="truncate flex-1">
+                                            {flexRender(
+                                              cell.column.columnDef.cell,
+                                              cell.getContext(),
+                                            )}
+                                          </span>
+                                          <button
+                                            type="button"
+                                            onClick={(e) => {
+                                              e.stopPropagation();
+                                              onForeignKeyNavigate(
+                                                fkForCol,
+                                                rawCellValue,
+                                              );
+                                            }}
+                                            className="opacity-0 group-hover/fkcell:opacity-100 transition-opacity p-0.5 rounded text-muted hover:text-blue-400 hover:bg-surface-tertiary flex-shrink-0"
+                                            title={t("dataGrid.openReferenced", {
+                                              table: fkForCol.ref_table,
+                                            })}
+                                          >
+                                            <ExternalLink size={11} />
+                                          </button>
+                                        </span>
+                                      );
+                                    }
+
                                     return flexRender(
                                       cell.column.columnDef.cell,
                                       cell.getContext(),
@@ -1422,6 +1478,28 @@ export const DataGrid = React.memo(
                 if (menuItems.length > 0) {
                   menuItems.push({ separator: true });
                 }
+              }
+
+              const fkForContextCol = fksByColumn.get(contextMenu.colName);
+              const fkContextValue =
+                contextMenu.row[contextMenu.colIndex];
+              if (
+                fkForContextCol &&
+                onForeignKeyNavigate &&
+                !isInsertion &&
+                isForeignKeyValueNavigable(fkContextValue)
+              ) {
+                menuItems.push({
+                  label: t("dataGrid.openReferenced", {
+                    table: fkForContextCol.ref_table,
+                  }),
+                  icon: ExternalLink,
+                  action: () => {
+                    onForeignKeyNavigate(fkForContextCol, fkContextValue);
+                    setContextMenu(null);
+                  },
+                });
+                menuItems.push({ separator: true });
               }
 
               menuItems.push({

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -671,7 +671,8 @@
     "setNull": "NULL setzen",
     "setDefault": "DEFAULT setzen",
     "setEmpty": "EMPTY setzen",
-    "setServerNow": "Aktuellen Zeitstempel einfügen"
+    "setServerNow": "Aktuellen Zeitstempel einfügen",
+    "openReferenced": "Referenzierte Zeile in {{table}} öffnen"
   },
   "editRow": {
     "title": "Zeile bearbeiten",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -688,7 +688,8 @@
     "setNull": "Set NULL",
     "setDefault": "Set DEFAULT",
     "setEmpty": "Set EMPTY",
-    "setServerNow": "Insert Current Timestamp"
+    "setServerNow": "Insert Current Timestamp",
+    "openReferenced": "Open referenced row in {{table}}"
   },
   "editRow": {
     "title": "Edit Row",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -665,7 +665,8 @@
     "copyRows": "Copiar {{count}} Filas",
     "copied": "Copiado al portapapeles",
     "duplicateRow": "Duplicar Fila",
-    "setServerNow": "Insertar marca de tiempo actual"
+    "setServerNow": "Insertar marca de tiempo actual",
+    "openReferenced": "Abrir fila referenciada en {{table}}"
   },
   "editRow": {
     "title": "Editar Fila",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -671,7 +671,8 @@
     "setNull": "Définir NULL",
     "setDefault": "Définir DEFAULT",
     "setEmpty": "Définir EMPTY",
-    "setServerNow": "Insérer l'horodatage actuel"
+    "setServerNow": "Insérer l'horodatage actuel",
+    "openReferenced": "Ouvrir la ligne référencée dans {{table}}"
   },
   "editRow": {
     "title": "Modifier la ligne",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -669,7 +669,8 @@
     "setGenerate": "Imposta GENERATED",
     "setNull": "Imposta NULL",
     "setDefault": "Imposta DEFAULT",
-    "setEmpty": "Imposta VUOTO"
+    "setEmpty": "Imposta VUOTO",
+    "openReferenced": "Apri la riga referenziata in {{table}}"
   },
   "editRow": {
     "title": "Modifica riga",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -645,7 +645,8 @@
     "setNull": "设为 NULL",
     "setDefault": "设为 DEFAULT",
     "setEmpty": "设为空",
-    "setServerNow": "插入当前时间戳"
+    "setServerNow": "插入当前时间戳",
+    "openReferenced": "在 {{table}} 中打开引用的行"
   },
   "editRow": {
     "title": "编辑行",

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -98,7 +98,9 @@ import type {
   Tab,
   PendingInsertion,
   TableColumn,
+  ForeignKey,
 } from "../types/editor";
+import { buildForeignKeyFilterClause } from "../utils/foreignKeys";
 import {
   getTabScrollState,
   getAdjacentTabIndex,
@@ -500,11 +502,21 @@ export const Editor = () => {
       if (!activeConnectionId) return;
       const effectiveSchema = tabSchema ?? activeSchema;
       try {
-        const cols = await invoke<TableColumn[]>("get_columns", {
-          connectionId: activeConnectionId,
-          tableName: table,
-          ...(effectiveSchema ? { schema: effectiveSchema } : {}),
-        });
+        const [cols, fks] = await Promise.all([
+          invoke<TableColumn[]>("get_columns", {
+            connectionId: activeConnectionId,
+            tableName: table,
+            ...(effectiveSchema ? { schema: effectiveSchema } : {}),
+          }),
+          invoke<ForeignKey[]>("get_foreign_keys", {
+            connectionId: activeConnectionId,
+            tableName: table,
+            ...(effectiveSchema ? { schema: effectiveSchema } : {}),
+          }).catch((e) => {
+            console.warn("Failed to fetch foreign keys:", e);
+            return [] as ForeignKey[];
+          }),
+        ]);
         const pk = cols.find((c) => c.is_pk);
         const autoInc = cols
           .filter((c) => c.is_auto_increment)
@@ -523,6 +535,7 @@ export const Editor = () => {
             defaultValueColumns: defaultVal,
             nullableColumns: nullable,
             columnMetadata: cols,
+            foreignKeys: fks,
           });
       } catch (e) {
         console.error("Failed to fetch PK:", e);
@@ -535,6 +548,7 @@ export const Editor = () => {
             defaultValueColumns: [],
             nullableColumns: [],
             columnMetadata: [],
+            foreignKeys: [],
           });
       }
     },
@@ -1188,6 +1202,64 @@ export const Editor = () => {
       runQuery(undefined, 1, undefined, undefined, filter, sort, limit);
     },
     [updateTab, runQuery],
+  );
+
+  const handleForeignKeyNavigate = useCallback(
+    (fk: ForeignKey, value: unknown) => {
+      const currentTab = tabsRef.current.find(
+        (tb) => tb.id === activeTabIdRef.current,
+      );
+      if (!currentTab || !activeConnectionId) return;
+
+      const sourceType = currentTab.columnMetadata?.find(
+        (c) => c.name === fk.column_name,
+      )?.data_type;
+      const filterClause = buildForeignKeyFilterClause(
+        fk,
+        value,
+        activeDriver ?? null,
+        sourceType,
+      );
+
+      const targetSchema = activeCapabilities?.schemas
+        ? currentTab.schema
+        : undefined;
+
+      const newTabId = addTab({
+        type: "table",
+        activeTable: fk.ref_table,
+        schema: targetSchema,
+        filterClause,
+        // Reset clauses that may linger on an existing dedup'd tab
+        sortClause: "",
+        limitClause: undefined,
+        // Drop any stale results so the new query renders fresh
+        result: null,
+      });
+      if (!newTabId) return;
+
+      updateTab(newTabId, {
+        filterClause,
+        sortClause: "",
+        limitClause: undefined,
+      });
+
+      // Defer to next tick: addTab uses setTabs (async), and runQuery resolves
+      // the target tab via tabsRef which is only refreshed by the
+      // tabs-tracking effect after React commits. Running synchronously here
+      // misses the freshly created tab and bails out early.
+      setTimeout(() => {
+        runQuery(undefined, 1, newTabId, undefined, filterClause, "", undefined);
+      }, 0);
+    },
+    [
+      activeConnectionId,
+      activeDriver,
+      activeCapabilities?.schemas,
+      addTab,
+      updateTab,
+      runQuery,
+    ],
   );
 
   const handleSort = useCallback(
@@ -3133,6 +3205,8 @@ export const Editor = () => {
                     defaultValueColumns={activeTab.defaultValueColumns}
                     nullableColumns={activeTab.nullableColumns}
                     columnMetadata={activeTab.columnMetadata}
+                    foreignKeys={activeTab.foreignKeys}
+                    onForeignKeyNavigate={handleForeignKeyNavigate}
                     connectionId={activeConnectionId}
                     onRefresh={handleRefresh}
                     pendingChanges={activeTab.pendingChanges}

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -82,6 +82,7 @@ export interface Tab {
   defaultValueColumns?: string[]; // Names of columns with default values
   nullableColumns?: string[]; // Names of nullable columns
   columnMetadata?: TableColumn[]; // Full column metadata (includes data_type for geometric types, etc.)
+  foreignKeys?: ForeignKey[]; // FK definitions for the active table (used for click-to-navigate)
   isLoading?: boolean;
   connectionId: string;
   flowState?: FlowState;

--- a/src/utils/foreignKeys.ts
+++ b/src/utils/foreignKeys.ts
@@ -1,0 +1,93 @@
+import type { ForeignKey } from "../types/schema";
+import { quoteIdentifier } from "./identifiers";
+
+const NUMERIC_TYPE_KEYWORDS = [
+  "int",
+  "decimal",
+  "numeric",
+  "real",
+  "double",
+  "float",
+  "serial",
+  "number",
+  "money",
+  "bit",
+];
+
+/**
+ * Returns a map of column name → primary foreign key.
+ *
+ * V1 limitation: only single-column FKs are included. FKs that share a
+ * `name` (constraint name) with one or more other entries are treated as
+ * composite and skipped. When the same source column is referenced by
+ * multiple distinct single-column FKs, the first occurrence wins so the
+ * mapping stays deterministic across renders.
+ */
+export function pickPrimaryForeignKeyByColumn(
+  fks: ForeignKey[] | undefined | null,
+): Map<string, ForeignKey> {
+  const result = new Map<string, ForeignKey>();
+  if (!fks || fks.length === 0) return result;
+
+  const byConstraint = new Map<string, ForeignKey[]>();
+  for (const fk of fks) {
+    const list = byConstraint.get(fk.name) ?? [];
+    list.push(fk);
+    byConstraint.set(fk.name, list);
+  }
+
+  for (const [, group] of byConstraint) {
+    if (group.length !== 1) continue;
+    const fk = group[0];
+    if (!result.has(fk.column_name)) {
+      result.set(fk.column_name, fk);
+    }
+  }
+  return result;
+}
+
+/**
+ * Returns true when the cell value can be used to navigate to a referenced row.
+ * Null, undefined, and empty strings are not navigable.
+ */
+export function isForeignKeyValueNavigable(value: unknown): boolean {
+  return value !== null && value !== undefined && value !== "";
+}
+
+/**
+ * Build a WHERE-clause fragment that filters the referenced table by the FK value.
+ * Output: `"ref_col" = 42` or `"ref_col" = 'escaped''value'`.
+ *
+ * `sourceColumnType` is the data type of the *source* column the user clicked on.
+ * In well-formed schemas it matches the referenced column type, so we use it to
+ * decide whether to emit the value unquoted (numeric) or quoted (string).
+ */
+export function buildForeignKeyFilterClause(
+  fk: ForeignKey,
+  value: unknown,
+  driver: string | null | undefined,
+  sourceColumnType?: string,
+): string {
+  const col = quoteIdentifier(fk.ref_column, driver);
+  return `${col} = ${formatSqlValueForFilter(value, sourceColumnType)}`;
+}
+
+export function isNumericColumnType(type: string | undefined): boolean {
+  if (!type) return false;
+  const lower = type.toLowerCase();
+  return NUMERIC_TYPE_KEYWORDS.some((kw) => lower.includes(kw));
+}
+
+function formatSqlValueForFilter(value: unknown, columnType?: string): string {
+  if (typeof value === "number" || typeof value === "bigint") {
+    return String(value);
+  }
+  if (typeof value === "boolean") {
+    return value ? "TRUE" : "FALSE";
+  }
+  const str = String(value);
+  if (isNumericColumnType(columnType) && /^-?\d+(\.\d+)?$/.test(str)) {
+    return str;
+  }
+  return `'${str.replace(/'/g, "''")}'`;
+}

--- a/tests/utils/foreignKeys.test.ts
+++ b/tests/utils/foreignKeys.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import type { ForeignKey } from "../../src/types/schema";
+import {
+  pickPrimaryForeignKeyByColumn,
+  isForeignKeyValueNavigable,
+  isNumericColumnType,
+  buildForeignKeyFilterClause,
+} from "../../src/utils/foreignKeys";
+
+const fk = (
+  name: string,
+  column_name: string,
+  ref_table: string,
+  ref_column: string,
+): ForeignKey => ({ name, column_name, ref_table, ref_column });
+
+describe("foreignKeys", () => {
+  describe("pickPrimaryForeignKeyByColumn", () => {
+    it("returns an empty map for undefined/null/empty input", () => {
+      expect(pickPrimaryForeignKeyByColumn(undefined).size).toBe(0);
+      expect(pickPrimaryForeignKeyByColumn(null).size).toBe(0);
+      expect(pickPrimaryForeignKeyByColumn([]).size).toBe(0);
+    });
+
+    it("indexes single-column FKs by their source column", () => {
+      const fks = [
+        fk("fk_org", "org_id", "organizations", "id"),
+        fk("fk_role", "role_id", "roles", "id"),
+      ];
+      const map = pickPrimaryForeignKeyByColumn(fks);
+      expect(map.size).toBe(2);
+      expect(map.get("org_id")?.ref_table).toBe("organizations");
+      expect(map.get("role_id")?.ref_table).toBe("roles");
+    });
+
+    it("skips composite FKs (entries that share a constraint name)", () => {
+      const fks = [
+        fk("fk_composite", "tenant_id", "memberships", "tenant_id"),
+        fk("fk_composite", "user_id", "memberships", "user_id"),
+        fk("fk_country", "country_code", "countries", "code"),
+      ];
+      const map = pickPrimaryForeignKeyByColumn(fks);
+      expect(map.size).toBe(1);
+      expect(map.has("tenant_id")).toBe(false);
+      expect(map.has("user_id")).toBe(false);
+      expect(map.get("country_code")?.ref_table).toBe("countries");
+    });
+
+    it("keeps the first occurrence when multiple single-column FKs hit the same column", () => {
+      const fks = [
+        fk("fk_first", "owner_id", "users", "id"),
+        fk("fk_second", "owner_id", "service_accounts", "id"),
+      ];
+      const map = pickPrimaryForeignKeyByColumn(fks);
+      expect(map.size).toBe(1);
+      expect(map.get("owner_id")?.name).toBe("fk_first");
+    });
+  });
+
+  describe("isForeignKeyValueNavigable", () => {
+    it("rejects null, undefined, and empty string", () => {
+      expect(isForeignKeyValueNavigable(null)).toBe(false);
+      expect(isForeignKeyValueNavigable(undefined)).toBe(false);
+      expect(isForeignKeyValueNavigable("")).toBe(false);
+    });
+
+    it("accepts numbers, non-empty strings, and zero", () => {
+      expect(isForeignKeyValueNavigable(0)).toBe(true);
+      expect(isForeignKeyValueNavigable(42)).toBe(true);
+      expect(isForeignKeyValueNavigable("abc")).toBe(true);
+      expect(isForeignKeyValueNavigable(false)).toBe(true);
+    });
+  });
+
+  describe("isNumericColumnType", () => {
+    it("recognises common numeric types across drivers", () => {
+      for (const t of [
+        "INT",
+        "int(11)",
+        "bigint unsigned",
+        "DECIMAL(10,2)",
+        "numeric",
+        "double precision",
+        "real",
+        "float",
+        "serial",
+        "bigserial",
+        "money",
+      ]) {
+        expect(isNumericColumnType(t)).toBe(true);
+      }
+    });
+
+    it("returns false for non-numeric or missing types", () => {
+      expect(isNumericColumnType(undefined)).toBe(false);
+      expect(isNumericColumnType("")).toBe(false);
+      expect(isNumericColumnType("varchar(255)")).toBe(false);
+      expect(isNumericColumnType("text")).toBe(false);
+      expect(isNumericColumnType("uuid")).toBe(false);
+      expect(isNumericColumnType("timestamp")).toBe(false);
+    });
+  });
+
+  describe("buildForeignKeyFilterClause", () => {
+    const orgFk = fk("fk_org", "org_id", "organizations", "id");
+
+    it("emits numbers unquoted and quotes the identifier per driver", () => {
+      expect(buildForeignKeyFilterClause(orgFk, 42, "mysql")).toBe(
+        "`id` = 42",
+      );
+      expect(buildForeignKeyFilterClause(orgFk, 42, "postgres")).toBe(
+        '"id" = 42',
+      );
+      expect(buildForeignKeyFilterClause(orgFk, 42, "sqlite")).toBe(
+        '"id" = 42',
+      );
+    });
+
+    it("treats bigint values as numeric", () => {
+      expect(
+        buildForeignKeyFilterClause(orgFk, BigInt("9007199254740993"), "postgres"),
+      ).toBe('"id" = 9007199254740993');
+    });
+
+    it("quotes string values and escapes embedded single quotes", () => {
+      const slugFk = fk("fk_slug", "slug", "pages", "slug");
+      expect(
+        buildForeignKeyFilterClause(slugFk, "o'brien", "postgres"),
+      ).toBe(`"slug" = 'o''brien'`);
+    });
+
+    it("emits numeric strings unquoted when the source column is numeric", () => {
+      expect(
+        buildForeignKeyFilterClause(orgFk, "42", "postgres", "BIGINT"),
+      ).toBe('"id" = 42');
+    });
+
+    it("keeps numeric strings quoted when the source column type is unknown", () => {
+      expect(buildForeignKeyFilterClause(orgFk, "42", "postgres")).toBe(
+        `"id" = '42'`,
+      );
+    });
+
+    it("emits booleans as TRUE/FALSE", () => {
+      const flagFk = fk("fk_flag", "active", "settings", "active");
+      expect(buildForeignKeyFilterClause(flagFk, true, "postgres")).toBe(
+        '"active" = TRUE',
+      );
+      expect(buildForeignKeyFilterClause(flagFk, false, "postgres")).toBe(
+        '"active" = FALSE',
+      );
+    });
+
+    it("escapes identifiers that contain the quote character", () => {
+      const weirdFk = fk("fk_weird", '"id', "weird", '"id');
+      expect(buildForeignKeyFilterClause(weirdFk, 1, "postgres")).toBe(
+        `"""id" = 1`,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Result-grid cells in a column that's a foreign key get a "go to referenced row" affordance — same pattern TablePlus and Postico use. Given `users.org_id = 42`, you click and land in `organizations` already filtered to `id = 42`, instead of writing the query yourself.

## Behaviour

- **Hover** an FK cell → small ↗ icon appears on the right of the cell (mirrors the BLOB cell pattern already in `DataGrid.tsx`). Clicking it opens or reuses the referenced-table tab with `WHERE "ref_col" = value` pre-applied and runs the query.
- **Right-click** an FK cell → new "Open referenced row in `<table>`" entry at the top of the context menu, separated from the existing row/cell actions.
- Both paths share the same `handleForeignKeyNavigate` handler in `Editor.tsx`.
- Icon and menu entry only appear when the cell value is non-null, the row is not a pending insertion, and the row is not pending deletion.

## Where the FKs come from

`fetchPkColumn` in `Editor.tsx` now fetches `get_columns` and `get_foreign_keys` in parallel and stores the result on the tab as `foreignKeys`. If the FK fetch errors the array stays empty and the feature simply doesn't surface — no UI breakage. `foreignKeys` is intentionally not persisted via `tabCleaner` so it's always re-fetched fresh on tab open.

## SQL value formatting

The WHERE fragment is built in `src/utils/foreignKeys.ts`:

- Identifier quoted via the existing `quoteIdentifier(driver)` (backticks for MySQL/MariaDB, double-quotes elsewhere) — no driver-specific branches in the frontend.
- Numbers and bigints → unquoted.
- Booleans → `TRUE` / `FALSE`.
- Strings → single-quoted with `'` escaped to `''`.
- Numeric-looking strings emitted unquoted only when the source column metadata reports a numeric type — guards against accidentally quoting bigints that some drivers return as JS strings.

## Out of scope (V1)

- **Composite FKs** (multi-column constraints): skipped. `pickPrimaryForeignKeyByColumn` groups by constraint name and only emits single-column FKs.
- **Cross-schema FKs**: the `ForeignKey` model has no `ref_schema` field today, so navigation stays within the current tab's schema. Same limitation that already affects the FK browser elsewhere in the app.
- **Reverse navigation** (parent → rows that reference it): not in V1.

## One subtlety worth flagging

When the referenced table is already open as a tab, `addTab` returns the existing tab id rather than creating a new one. The filter is then applied via a follow-up `updateTab`, but `runQuery` reads the tab from `tabsRef.current` which is only refreshed after React commits — so for *newly created* tabs the query was firing before the tab existed in the ref and bailing out. The handler defers the `runQuery` call to the next macrotask via `setTimeout(0)` so React has a chance to flush. Microtasks (`queueMicrotask`, `Promise.then`) are not enough because they can run before the commit.

## Tests

- `tests/utils/foreignKeys.test.ts` — 15 cases:
  - `pickPrimaryForeignKeyByColumn`: empty/null input, single FKs indexed by source column, composite skip, deterministic pick when multiple single FKs target the same column.
  - `isForeignKeyValueNavigable`: rejects null/undefined/empty string, accepts 0 / false / non-empty strings.
  - `isNumericColumnType`: standard numeric types across MySQL / Postgres / SQLite spellings, negative cases (text, uuid, timestamp).
  - `buildForeignKeyFilterClause`: number unquoted, bigint, single-quote escape in strings, numeric strings with/without source column type, boolean, identifier quoting per driver, identifier containing the quote character.
- `pnpm test --run` — 2123 passing.
- `pnpm tsc --noEmit` — clean.
- `pnpm lint` — clean.

## Test plan

- [ ] Open a table with at least one single-column FK, hover an FK cell, click the ↗ → referenced table opens filtered to that row and results render.
- [ ] Right-click the same cell → "Open referenced row in …" appears at the top of the menu; clicking it does the same as the icon.
- [ ] Click an FK in a table whose `ref_table` is already open as a tab → the existing tab is reused, filter is overwritten, query re-runs.
- [ ] Cell with NULL FK value → icon and menu entry are not rendered.
- [ ] String FK (e.g. `pages.slug`) with a `'` in the value → no SQL syntax error.
- [ ] Repeat against MySQL, Postgres and SQLite to verify identifier quoting.