### PR TITLE
fix(drivers): share a single connection across multi-statement scripts

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10,9 +10,9 @@ use uuid::Uuid;
 use crate::credential_cache;
 use crate::keychain_utils;
 use crate::models::{
-    ColumnDefinition, ConnectionGroup, ConnectionParams, ConnectionsFile, ExplainPlan,
-    ExportPayload, ForeignKey, Index, QueryResult, RoutineInfo, RoutineParameter, SavedConnection,
-    SshConnection, SshConnectionInput, SshTestParams, TableColumn, TableInfo,
+    BatchStatementResult, ColumnDefinition, ConnectionGroup, ConnectionParams, ConnectionsFile,
+    ExplainPlan, ExportPayload, ForeignKey, Index, QueryResult, RoutineInfo, RoutineParameter,
+    SavedConnection, SshConnection, SshConnectionInput, SshTestParams, TableColumn, TableInfo,
     TestConnectionRequest, TriggerInfo,
 };
 use crate::persistence;
@@ -41,6 +41,19 @@ impl Default for QueryCancellationState {
             handles: Arc::new(Mutex::new(HashMap::new())),
         }
     }
+}
+
+/// Trims trailing semicolons and normalises Unicode smart quotes that some
+/// editors insert when the user pastes a query. Called on every query the
+/// UI hands off to a driver.
+fn sanitize_user_query(query: &str) -> String {
+    query
+        .trim()
+        .trim_end_matches(';')
+        .replace('\u{2018}', "'")
+        .replace('\u{2019}', "'")
+        .replace('\u{201C}', "\"")
+        .replace('\u{201D}', "\"")
 }
 
 // --- Persistence Helpers ---
@@ -2131,21 +2144,12 @@ pub async fn execute_query<R: Runtime>(
         query
     );
 
-    // 1. Sanitize Query (Ignore trailing semicolon + normalize smart quotes)
-    let sanitized_query = query
-        .trim()
-        .trim_end_matches(';')
-        .replace('\u{2018}', "'") // Left single quotation mark
-        .replace('\u{2019}', "'") // Right single quotation mark
-        .replace('\u{201C}', "\"") // Left double quotation mark
-        .replace('\u{201D}', "\"") // Right double quotation mark
-        .to_string();
+    let sanitized_query = sanitize_user_query(&query);
 
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
-    // 2. Spawn Cancellable Task
     let drv = driver_for(&saved_conn.params.driver).await?;
     let task = tokio::spawn(async move {
         drv.execute_query(
@@ -2158,22 +2162,19 @@ pub async fn execute_query<R: Runtime>(
         .await
     });
 
-    // 3. Register Abort Handle
     let abort_handle = task.abort_handle();
     {
         let mut handles = state.handles.lock().unwrap();
-        // If a query is already running for this connection, we overwrite the handle.
-        // Ideally we should cancel the previous one, but the UI should prevent double run.
+        // Overwrite any in-flight handle for this connection. The UI is
+        // responsible for preventing double-run; a leaked previous query
+        // is preferable to a missing abort handle for the new one.
         handles.insert(connection_id.clone(), abort_handle);
     }
 
-    // 4. Await & Handle Cancellation
     let result = task.await;
 
-    // 5. Cleanup
     {
         let mut handles = state.handles.lock().unwrap();
-        // Only remove if it matches (edge case: multiple queries, but connection_id is unique per tab usually)
         handles.remove(&connection_id);
     }
 
@@ -2191,6 +2192,83 @@ pub async fn execute_query<R: Runtime>(
         }
         Err(_) => {
             log::warn!("Query was cancelled");
+            Err("Query cancelled".into())
+        }
+    }
+}
+
+/// Runs a sequence of statements that share a single physical database
+/// connection. Use this — not multiple parallel `execute_query` calls —
+/// whenever statements depend on connection-local session state
+/// (`SET @var`, `LAST_INSERT_ID()` / `LASTVAL()`, `BEGIN`/`COMMIT`,
+/// `TEMPORARY TABLE`, `PREPARE`/`EXECUTE`, `SET FOREIGN_KEY_CHECKS = 0`).
+///
+/// The whole batch shares one cancellation handle so `cancel_query`
+/// aborts the entire batch atomically.
+#[tauri::command]
+pub async fn execute_query_batch<R: Runtime>(
+    app: AppHandle<R>,
+    state: State<'_, QueryCancellationState>,
+    connection_id: String,
+    queries: Vec<String>,
+    limit: Option<u32>,
+    page: Option<u32>,
+    schema: Option<String>,
+) -> Result<Vec<BatchStatementResult>, String> {
+    log::info!(
+        "Executing query batch on connection: {} | {} statement(s)",
+        connection_id,
+        queries.len()
+    );
+
+    let sanitized_queries: Vec<String> = queries.iter().map(|q| sanitize_user_query(q)).collect();
+
+    let saved_conn = find_connection_by_id(&app, &connection_id)?;
+    let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
+
+    let drv = driver_for(&saved_conn.params.driver).await?;
+    let task = tokio::spawn(async move {
+        drv.execute_batch(
+            &params,
+            &sanitized_queries,
+            limit,
+            page.unwrap_or(1),
+            schema.as_deref(),
+        )
+        .await
+    });
+
+    let abort_handle = task.abort_handle();
+    {
+        let mut handles = state.handles.lock().unwrap();
+        handles.insert(connection_id.clone(), abort_handle);
+    }
+
+    let result = task.await;
+
+    {
+        let mut handles = state.handles.lock().unwrap();
+        handles.remove(&connection_id);
+    }
+
+    match result {
+        Ok(Ok(batch_results)) => {
+            let success_count = batch_results.iter().filter(|r| r.result.is_some()).count();
+            log::info!(
+                "Batch executed: {} succeeded, {} failed (of {} total)",
+                success_count,
+                batch_results.len() - success_count,
+                batch_results.len()
+            );
+            Ok(batch_results)
+        }
+        Ok(Err(e)) => {
+            log::error!("Batch execution failed at setup: {}", e);
+            Err(e)
+        }
+        Err(_) => {
+            log::warn!("Batch was cancelled");
             Err("Query cancelled".into())
         }
     }
@@ -2214,14 +2292,7 @@ pub async fn explain_query_plan<R: Runtime>(
         query
     );
 
-    let sanitized_query = query
-        .trim()
-        .trim_end_matches(';')
-        .replace('\u{2018}', "'")
-        .replace('\u{2019}', "'")
-        .replace('\u{201C}', "\"")
-        .replace('\u{201D}', "\"")
-        .to_string();
+    let sanitized_query = sanitize_user_query(&query);
 
     if !crate::drivers::common::is_explainable_query(&sanitized_query) {
         return Err(

--- a/src-tauri/src/drivers/common.rs
+++ b/src-tauri/src/drivers/common.rs
@@ -10,5 +10,5 @@ pub use blob::{
 };
 pub use query::{
     build_paginated_query, calculate_offset, extract_user_limit, is_explainable_query,
-    is_select_query, strip_leading_sql_comments, strip_limit_offset,
+    is_select_query, returns_result_set, strip_leading_sql_comments, strip_limit_offset,
 };

--- a/src-tauri/src/drivers/common/query.rs
+++ b/src-tauri/src/drivers/common/query.rs
@@ -26,6 +26,38 @@ pub fn strip_leading_sql_comments(query: &str) -> &str {
     s
 }
 
+/// Returns true if a statement's leading keyword produces a row stream.
+/// Used by drivers to pick between the fetch-rows path and the
+/// execute-and-collect-affected-rows path so INSERT/UPDATE/DELETE no
+/// longer hardcode `affected_rows: 0`.
+///
+/// `CALL` is intentionally treated as result-set-bearing: a MySQL stored
+/// procedure may or may not return one, and the fetch path degrades to
+/// `(rows: [], affected_rows: 0)` for the no-result case without
+/// erroring — losing accurate affected_rows for procs that mutate is the
+/// lesser evil compared to misclassifying procedures that do return
+/// rows.
+pub fn returns_result_set(query: &str) -> bool {
+    let head = strip_leading_sql_comments(query)
+        .split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+        .next()
+        .unwrap_or("")
+        .to_uppercase();
+    matches!(
+        head.as_str(),
+        "SELECT"
+            | "WITH"
+            | "SHOW"
+            | "EXPLAIN"
+            | "DESCRIBE"
+            | "DESC"
+            | "VALUES"
+            | "TABLE"
+            | "PRAGMA"
+            | "CALL"
+    )
+}
+
 /// Check if a query type supports EXPLAIN.
 ///
 /// MySQL/MariaDB support EXPLAIN for DML statements only:

--- a/src-tauri/src/drivers/driver_trait.rs
+++ b/src-tauri/src/drivers/driver_trait.rs
@@ -7,8 +7,9 @@ use sqlx::{AnyConnection, Connection};
 use std::str::FromStr;
 
 use crate::models::{
-    ColumnDefinition, ConnectionParams, DataTypeInfo, ExplainPlan, ForeignKey, Index, QueryResult,
-    RoutineInfo, RoutineParameter, TableColumn, TableInfo, TableSchema, TriggerInfo, ViewInfo,
+    BatchStatementResult, ColumnDefinition, ConnectionParams, DataTypeInfo, ExplainPlan,
+    ForeignKey, Index, QueryResult, RoutineInfo, RoutineParameter, TableColumn, TableInfo,
+    TableSchema, TriggerInfo, ViewInfo,
 };
 
 /// Capabilities advertised by a driver.
@@ -322,6 +323,38 @@ pub trait DatabaseDriver: Send + Sync {
         page: u32,
         schema: Option<&str>,
     ) -> Result<QueryResult, String>;
+
+    /// Runs a sequence of statements that may depend on connection-local
+    /// session state (`SET @var`, `LAST_INSERT_ID()`, `BEGIN`/`COMMIT`,
+    /// `TEMPORARY TABLE`, `PREPARE`/`EXECUTE`). Built-in drivers override
+    /// this to acquire a single physical connection from the pool and run
+    /// every statement on it, in order, so session-local state survives.
+    ///
+    /// The default implementation falls back to calling `execute_query`
+    /// sequentially: statements run in order but each acquires its own
+    /// pooled connection, so session state is NOT preserved. Plugin drivers
+    /// that need that continuity must override this method.
+    ///
+    /// The outer `Result` represents a batch-level setup failure (e.g.
+    /// acquiring a connection). Per-statement failures are reported inside
+    /// `BatchStatementResult` so earlier successful statements still reach
+    /// the UI.
+    async fn execute_batch(
+        &self,
+        params: &ConnectionParams,
+        queries: &[String],
+        limit: Option<u32>,
+        page: u32,
+        schema: Option<&str>,
+    ) -> Result<Vec<BatchStatementResult>, String> {
+        let mut results = Vec::with_capacity(queries.len());
+        for q in queries {
+            let start = std::time::Instant::now();
+            let outcome = self.execute_query(params, q, limit, page, schema).await;
+            results.push(BatchStatementResult::from_outcome(start, outcome));
+        }
+        Ok(results)
+    }
 
     /// Runs EXPLAIN (or EXPLAIN ANALYZE) on the given query and returns a
     /// parsed execution plan tree. Drivers that do not support EXPLAIN can

--- a/src-tauri/src/drivers/mysql/mod.rs
+++ b/src-tauri/src/drivers/mysql/mod.rs
@@ -845,30 +845,89 @@ pub async fn get_routine_definition(
     Ok(definition)
 }
 
-pub async fn execute_query(
+/// Acquires a single MySQL connection from the pool, honouring the optional
+/// schema override (which routes to a per-database pool to avoid invalidating
+/// the prepared-statement cache via `USE`).
+async fn acquire_mysql_conn(
     params: &ConnectionParams,
-    query: &str,
-    limit: Option<u32>,
-    page: u32,
     schema: Option<&str>,
-) -> Result<QueryResult, String> {
-    // Use a per-database pool when a schema override is requested to avoid
-    // polluting the shared pool's prepared-statement cache (MySQL invalidates
-    // all cached handles on a `USE <db>` command).
-    let effective_params;
+) -> Result<sqlx::pool::PoolConnection<sqlx::MySql>, String> {
     let pool = if let Some(db) = schema {
-        effective_params = {
-            let mut p = params.clone();
-            p.database = crate::models::DatabaseSelection::Single(db.to_string());
-            p
-        };
-        get_mysql_pool(&effective_params).await?
+        let mut p = params.clone();
+        p.database = crate::models::DatabaseSelection::Single(db.to_string());
+        get_mysql_pool(&p).await?
     } else {
         get_mysql_pool(params).await?
     };
-    let mut conn = pool.acquire().await.map_err(|e| e.to_string())?;
+    pool.acquire().await.map_err(|e| e.to_string())
+}
 
-    let is_select = query.trim_start().to_uppercase().starts_with("SELECT");
+/// Statements that MySQL refuses on the prepared-statement protocol
+/// (server error 1295: "This command is not supported in the prepared
+/// statement protocol yet"). `sqlx::query()` always goes through
+/// `COM_STMT_PREPARE` + `COM_STMT_EXECUTE`, so these have to be routed
+/// through `sqlx::raw_sql()` which uses `COM_QUERY` (text protocol)
+/// instead. Without this, explicit transactions inside a multi-statement
+/// script (`BEGIN; … COMMIT;`) silently fail — which would defeat the
+/// point of `execute_batch` even after sharing a single connection.
+fn is_text_protocol_stmt(query: &str) -> bool {
+    let head = crate::drivers::common::strip_leading_sql_comments(query).to_uppercase();
+    head.starts_with("BEGIN")
+        || head.starts_with("START TRANSACTION")
+        || head.starts_with("COMMIT")
+        || head.starts_with("ROLLBACK")
+        || head.starts_with("SAVEPOINT")
+        || head.starts_with("RELEASE SAVEPOINT")
+        || head.starts_with("LOCK TABLES")
+        || head.starts_with("UNLOCK TABLES")
+}
+
+/// Executes one statement on an already-acquired connection. Used by both
+/// `execute_query` (one statement, one connection) and `execute_batch`
+/// (many statements, one shared connection — required for session-local
+/// state like `SET @var`, `LAST_INSERT_ID()`, transactions, temp tables).
+async fn exec_on_mysql_conn(
+    conn: &mut sqlx::MySqlConnection,
+    query: &str,
+    limit: Option<u32>,
+    page: u32,
+) -> Result<QueryResult, String> {
+    // Transaction-control statements have to bypass the prepared-statement
+    // protocol — see `is_text_protocol_stmt`. They never return a result
+    // set, so we can short-circuit with an empty `QueryResult`.
+    if is_text_protocol_stmt(query) {
+        use sqlx::Executor;
+        let exec_result = conn
+            .execute(sqlx::raw_sql(query))
+            .await
+            .map_err(|e| e.to_string())?;
+        return Ok(QueryResult {
+            columns: vec![],
+            rows: vec![],
+            affected_rows: exec_result.rows_affected(),
+            truncated: false,
+            pagination: None,
+        });
+    }
+
+    // Non-result-set statements (INSERT / UPDATE / DELETE / DDL) go through
+    // `execute()` so we can return the actual `rows_affected`.
+    if !crate::drivers::common::returns_result_set(query) {
+        use sqlx::Executor;
+        let exec_result = conn
+            .execute(sqlx::query(query))
+            .await
+            .map_err(|e| e.to_string())?;
+        return Ok(QueryResult {
+            columns: vec![],
+            rows: vec![],
+            affected_rows: exec_result.rows_affected(),
+            truncated: false,
+            pagination: None,
+        });
+    }
+
+    let is_select = crate::drivers::common::is_select_query(query);
     let mut pagination: Option<Pagination> = None;
     let final_query: String;
     let mut manual_limit = limit;
@@ -894,7 +953,7 @@ pub async fn execute_query(
     let mut columns: Vec<String> = Vec::new();
     let mut json_rows = Vec::new();
 
-    // Scope the stream so `conn` borrow is released before the restore step
+    // Scope the stream so `conn` borrow is released before returning
     {
         use futures::stream::StreamExt;
         let mut rows_stream = sqlx::query(&final_query).fetch(&mut *conn);
@@ -945,6 +1004,45 @@ pub async fn execute_query(
         truncated,
         pagination,
     })
+}
+
+pub async fn execute_query(
+    params: &ConnectionParams,
+    query: &str,
+    limit: Option<u32>,
+    page: u32,
+    schema: Option<&str>,
+) -> Result<QueryResult, String> {
+    let mut conn = acquire_mysql_conn(params, schema).await?;
+    exec_on_mysql_conn(&mut *conn, query, limit, page).await
+}
+
+/// Runs a sequence of statements on a single pooled connection so that
+/// session-local state (user variables, `LAST_INSERT_ID()`, transactions,
+/// `TEMPORARY TABLE`, `PREPARE`/`EXECUTE`) is preserved across statements.
+///
+/// Statements run sequentially in input order. A failed statement is
+/// reported in its `BatchStatementResult` slot but does NOT abort the batch
+/// — later statements still run, mirroring MySQL CLI's `--force` behaviour.
+/// When the script uses transactions, MySQL itself will refuse subsequent
+/// statements inside the aborted transaction, surfacing the error.
+pub async fn execute_batch(
+    params: &ConnectionParams,
+    queries: &[String],
+    limit: Option<u32>,
+    page: u32,
+    schema: Option<&str>,
+) -> Result<Vec<crate::models::BatchStatementResult>, String> {
+    let mut conn = acquire_mysql_conn(params, schema).await?;
+    let mut results = Vec::with_capacity(queries.len());
+    for q in queries {
+        let start = std::time::Instant::now();
+        let outcome = exec_on_mysql_conn(&mut *conn, q, limit, page).await;
+        results.push(crate::models::BatchStatementResult::from_outcome(
+            start, outcome,
+        ));
+    }
+    Ok(results)
 }
 
 pub async fn get_triggers(
@@ -1408,6 +1506,17 @@ impl DatabaseDriver for MysqlDriver {
         schema: Option<&str>,
     ) -> Result<crate::models::QueryResult, String> {
         execute_query(params, query, limit, page, schema).await
+    }
+
+    async fn execute_batch(
+        &self,
+        params: &crate::models::ConnectionParams,
+        queries: &[String],
+        limit: Option<u32>,
+        page: u32,
+        schema: Option<&str>,
+    ) -> Result<Vec<crate::models::BatchStatementResult>, String> {
+        execute_batch(params, queries, limit, page, schema).await
     }
 
     async fn explain_query(

--- a/src-tauri/src/drivers/postgres/mod.rs
+++ b/src-tauri/src/drivers/postgres/mod.rs
@@ -17,7 +17,7 @@ use crate::models::{
 };
 use crate::pool_manager::get_postgres_pool;
 use binding::{PgValueOptions, bind_pg_value, build_pk_predicate};
-use client::{execute, format_pg_error, query_all, query_one};
+use client::{execute, format_pg_error, get_client, query_all, query_one};
 pub use explain::explain_query;
 use extract::extract_value;
 use helpers::{escape_identifier, extract_base_type, is_implicit_cast_compatible};
@@ -701,51 +701,71 @@ pub async fn get_table_ddl(
     ))
 }
 
-pub async fn execute_query(
+/// Acquires a single PostgreSQL client from the pool and applies the
+/// optional `search_path` once. Used by both `execute_query` and
+/// `execute_batch`; the latter relies on the schema being set on the
+/// shared connection so all statements in the batch see the same
+/// search_path.
+async fn acquire_pg_client(
     params: &ConnectionParams,
+    schema: Option<&str>,
+) -> Result<deadpool_postgres::Client, String> {
+    let pool = get_postgres_pool(params).await?;
+    let client = get_client(&pool).await?;
+    if let Some(s) = schema {
+        let search_path = format!("SET search_path TO \"{}\"", escape_identifier(s));
+        client
+            .execute(&search_path, &[])
+            .await
+            .map_err(|e| format_pg_error(&e))?;
+    }
+    Ok(client)
+}
+
+/// Runs one statement against an already-acquired client. Pulled out of
+/// `execute_query` so `execute_batch` can reuse it while keeping a single
+/// physical connection open for session-state continuity (`BEGIN`/`COMMIT`,
+/// `SET LOCAL`, `CREATE TEMP TABLE`, `LASTVAL()`, `PREPARE`/`EXECUTE`).
+async fn exec_on_pg_client(
+    client: &tokio_postgres::Client,
     query: &str,
     limit: Option<u32>,
     page: u32,
-    schema: Option<&str>,
 ) -> Result<QueryResult, String> {
-    let pool = get_postgres_pool(params).await?;
+    // Non-result-set statements (INSERT/UPDATE/DELETE/DDL) go through
+    // `client.execute()` so we can return the real affected-row count.
+    // The fetch path below is reserved for SELECT-like statements.
+    if !crate::drivers::common::returns_result_set(query) {
+        let affected = client
+            .execute(query, &[])
+            .await
+            .map_err(|e| format_pg_error(&e))?;
+        return Ok(QueryResult {
+            columns: vec![],
+            rows: vec![],
+            affected_rows: affected,
+            truncated: false,
+            pagination: None,
+        });
+    }
 
-    let is_select = query.trim_start().to_uppercase().starts_with("SELECT");
+    let is_select = crate::drivers::common::is_select_query(query);
     let mut manual_limit = limit;
     let mut truncated = false;
 
-    // Build the paginated data query using LIMIT +1 trick to detect has_more.
-    // No COUNT query is issued; total_rows stays None until explicitly requested.
     let (final_query, pagination_meta) = if is_select && limit.is_some() {
         let l = limit.unwrap();
-
         let data_query = crate::drivers::common::build_paginated_query(query, l, page);
-
         manual_limit = None;
         (data_query, Some((l, page)))
     } else {
         (query.to_string(), None)
     };
 
-    // this comment was for sqlx and i didn't understand it
-    // Acquire main connection for the data fetch (COUNT runs concurrently above)
-    // let mut conn = pool.acquire().await.map_err(map_pg_err)?;
-
-    let client = pool.get().await.map_err(|e| e.to_string())?;
-
-    if let Some(schema) = schema {
-        let search_path = format!("SET search_path TO \"{}\"", escape_identifier(schema));
-        client
-            .execute(&search_path, &[])
-            .await
-            .map_err(|e| format_pg_error(&e))?;
-    }
-
-    let params: Vec<i32> = vec![];
-    // Stream data rows while COUNT runs in the background
+    let pg_params: Vec<i32> = vec![];
     let mut rows_stream = std::pin::pin!(
         client
-            .query_raw(&final_query, &params)
+            .query_raw(&final_query, &pg_params)
             .await
             .map_err(|e| format_pg_error(&e))?
     );
@@ -780,7 +800,6 @@ pub async fn execute_query(
         }
     }
 
-    // Build pagination using LIMIT +1 result: if we got l+1 rows, has_more=true.
     let pagination = if let Some((page_size, p)) = pagination_meta {
         let has_more = json_rows.len() > page_size as usize;
         if has_more {
@@ -804,6 +823,42 @@ pub async fn execute_query(
         truncated,
         pagination,
     })
+}
+
+pub async fn execute_query(
+    params: &ConnectionParams,
+    query: &str,
+    limit: Option<u32>,
+    page: u32,
+    schema: Option<&str>,
+) -> Result<QueryResult, String> {
+    let client = acquire_pg_client(params, schema).await?;
+    exec_on_pg_client(&client, query, limit, page).await
+}
+
+/// Runs a sequence of statements on a single pooled client so
+/// session-local state survives across them. Per-statement errors are
+/// reported in the slot but do not abort the batch — when the script
+/// uses an explicit transaction, PostgreSQL rejects subsequent
+/// statements with "current transaction is aborted" until `ROLLBACK`,
+/// which surfaces the failure naturally in the per-statement result.
+pub async fn execute_batch(
+    params: &ConnectionParams,
+    queries: &[String],
+    limit: Option<u32>,
+    page: u32,
+    schema: Option<&str>,
+) -> Result<Vec<crate::models::BatchStatementResult>, String> {
+    let client = acquire_pg_client(params, schema).await?;
+    let mut results = Vec::with_capacity(queries.len());
+    for q in queries {
+        let start = std::time::Instant::now();
+        let outcome = exec_on_pg_client(&client, q, limit, page).await;
+        results.push(crate::models::BatchStatementResult::from_outcome(
+            start, outcome,
+        ));
+    }
+    Ok(results)
 }
 
 pub async fn get_views(params: &ConnectionParams, schema: &str) -> Result<Vec<ViewInfo>, String> {
@@ -1509,6 +1564,17 @@ impl DatabaseDriver for PostgresDriver {
         schema: Option<&str>,
     ) -> Result<crate::models::QueryResult, String> {
         execute_query(params, query, limit, page, schema).await
+    }
+
+    async fn execute_batch(
+        &self,
+        params: &crate::models::ConnectionParams,
+        queries: &[String],
+        limit: Option<u32>,
+        page: u32,
+        schema: Option<&str>,
+    ) -> Result<Vec<crate::models::BatchStatementResult>, String> {
+        execute_batch(params, queries, limit, page, schema).await
     }
 
     async fn explain_query(

--- a/src-tauri/src/drivers/sqlite/mod.rs
+++ b/src-tauri/src/drivers/sqlite/mod.rs
@@ -494,16 +494,34 @@ pub async fn get_table_ddl(params: &ConnectionParams, table_name: &str) -> Resul
     Ok(format!("{};", row.0))
 }
 
-pub async fn execute_query(
-    params: &ConnectionParams,
+/// Executes one statement against an already-acquired SQLite connection.
+/// Shared between `execute_query` and `execute_batch` so the latter can
+/// keep a single connection open for transaction (`BEGIN`/`COMMIT`) and
+/// temporary table continuity across statements.
+async fn exec_on_sqlite_conn(
+    conn: &mut sqlx::SqliteConnection,
     query: &str,
     limit: Option<u32>,
     page: u32,
 ) -> Result<QueryResult, String> {
-    let pool = get_sqlite_pool(params).await?;
-    let mut conn = pool.acquire().await.map_err(|e| e.to_string())?;
+    // INSERT/UPDATE/DELETE/DDL go through `execute()` so we report the
+    // real `rows_affected`.
+    if !crate::drivers::common::returns_result_set(query) {
+        use sqlx::Executor;
+        let exec_result = conn
+            .execute(sqlx::query(query))
+            .await
+            .map_err(|e| e.to_string())?;
+        return Ok(QueryResult {
+            columns: vec![],
+            rows: vec![],
+            affected_rows: exec_result.rows_affected(),
+            truncated: false,
+            pagination: None,
+        });
+    }
 
-    let is_select = query.trim_start().to_uppercase().starts_with("SELECT");
+    let is_select = crate::drivers::common::is_select_query(query);
     let mut pagination: Option<Pagination> = None;
     let final_query: String;
     let mut manual_limit = limit;
@@ -576,6 +594,40 @@ pub async fn execute_query(
         truncated,
         pagination,
     })
+}
+
+pub async fn execute_query(
+    params: &ConnectionParams,
+    query: &str,
+    limit: Option<u32>,
+    page: u32,
+) -> Result<QueryResult, String> {
+    let pool = get_sqlite_pool(params).await?;
+    let mut conn = pool.acquire().await.map_err(|e| e.to_string())?;
+    exec_on_sqlite_conn(&mut *conn, query, limit, page).await
+}
+
+/// Runs a sequence of statements on a single pooled connection so
+/// `BEGIN`/`COMMIT` and temporary-table visibility survive across
+/// statements. SQLite has no user variables, but transactions and temp
+/// tables still require a stable connection.
+pub async fn execute_batch(
+    params: &ConnectionParams,
+    queries: &[String],
+    limit: Option<u32>,
+    page: u32,
+) -> Result<Vec<crate::models::BatchStatementResult>, String> {
+    let pool = get_sqlite_pool(params).await?;
+    let mut conn = pool.acquire().await.map_err(|e| e.to_string())?;
+    let mut results = Vec::with_capacity(queries.len());
+    for q in queries {
+        let start = std::time::Instant::now();
+        let outcome = exec_on_sqlite_conn(&mut *conn, q, limit, page).await;
+        results.push(crate::models::BatchStatementResult::from_outcome(
+            start, outcome,
+        ));
+    }
+    Ok(results)
 }
 
 pub async fn get_views(params: &ConnectionParams) -> Result<Vec<ViewInfo>, String> {
@@ -1070,6 +1122,17 @@ impl DatabaseDriver for SqliteDriver {
         _schema: Option<&str>,
     ) -> Result<crate::models::QueryResult, String> {
         execute_query(params, query, limit, page).await
+    }
+
+    async fn execute_batch(
+        &self,
+        params: &crate::models::ConnectionParams,
+        queries: &[String],
+        limit: Option<u32>,
+        page: u32,
+        _schema: Option<&str>,
+    ) -> Result<Vec<crate::models::BatchStatementResult>, String> {
+        execute_batch(params, queries, limit, page).await
     }
 
     async fn explain_query(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -280,6 +280,7 @@ pub fn run() {
             commands::get_file_stats,
             commands::read_file_as_data_url,
             commands::execute_query,
+            commands::execute_query_batch,
             commands::get_server_now,
             commands::explain_query_plan,
             commands::count_query,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -246,6 +246,43 @@ pub struct QueryResult {
     pub pagination: Option<Pagination>,
 }
 
+/// One statement's outcome within an `execute_batch` call. Exactly one of
+/// `result` / `error` is `Some` — kept as separate optionals (not a tagged
+/// enum) so the TypeScript side can do `if (item.error) ... else ... item.result`
+/// without a discriminated-union helper. Use [`BatchStatementResult::from_outcome`]
+/// to construct so the invariant is enforced.
+///
+/// `execution_time_ms` is measured server-side because a batch is one
+/// Tauri round-trip but the history UI wants per-statement timings.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BatchStatementResult {
+    pub result: Option<QueryResult>,
+    pub error: Option<String>,
+    pub execution_time_ms: Option<f64>,
+}
+
+impl BatchStatementResult {
+    /// Builds a result from a started `Instant` and the outcome of executing
+    /// one statement. Centralises the `Ok` / `Err` -> struct mapping that
+    /// would otherwise be duplicated across every driver's `execute_batch`
+    /// and the trait default.
+    pub fn from_outcome(start: std::time::Instant, outcome: Result<QueryResult, String>) -> Self {
+        let execution_time_ms = Some(start.elapsed().as_secs_f64() * 1000.0);
+        match outcome {
+            Ok(r) => Self {
+                result: Some(r),
+                error: None,
+                execution_time_ms,
+            },
+            Err(e) => Self {
+                result: None,
+                error: Some(e),
+                execution_time_ms,
+            },
+        }
+    }
+}
+
 /// A single node in a query execution plan tree.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ExplainNode {

--- a/src-tauri/tests/integration_tests.rs
+++ b/src-tauri/tests/integration_tests.rs
@@ -183,3 +183,366 @@ async fn test_postgres_integration_flow() {
     // 6. Cleanup
     let _ = postgres::execute_query(&params, "DROP TABLE test_users", None, 1, None).await;
 }
+
+// ---------------------------------------------------------------------------
+// execute_batch — session-state continuity across statements.
+// Each test invokes the driver-level `execute_batch` directly; the Tauri
+// command layer is a thin wrapper so verifying the driver contract is
+// sufficient.
+// ---------------------------------------------------------------------------
+
+async fn wait_for_mysql(params: &ConnectionParams) -> bool {
+    for _ in 0..10 {
+        if mysql::get_tables(params, None).await.is_ok() {
+            return true;
+        }
+        sleep(Duration::from_millis(500)).await;
+    }
+    false
+}
+
+async fn wait_for_postgres(params: &ConnectionParams) -> bool {
+    for _ in 0..10 {
+        if postgres::get_tables(params, "public").await.is_ok() {
+            return true;
+        }
+        sleep(Duration::from_millis(500)).await;
+    }
+    false
+}
+
+/// `SET @pid = LAST_INSERT_ID()` must survive into the two following
+/// INSERT statements so the children link to the freshly inserted parent.
+#[tokio::test]
+#[ignore]
+async fn test_mysql_batch_preserves_user_variable_and_last_insert_id() {
+    let params = get_mysql_params();
+    if !wait_for_mysql(&params).await {
+        eprintln!("SKIPPING: MySQL not reachable on 33060");
+        return;
+    }
+
+    // Ensure a clean slate. Child first because of the FK-shaped dependency.
+    let _ = mysql::execute_query(
+        &params,
+        "DROP TABLE IF EXISTS test_batch_child",
+        None,
+        1,
+        None,
+    )
+    .await;
+    let _ = mysql::execute_query(
+        &params,
+        "DROP TABLE IF EXISTS test_batch_parent",
+        None,
+        1,
+        None,
+    )
+    .await;
+
+    let queries: Vec<String> = [
+        "CREATE TABLE test_batch_parent (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(50))",
+        "CREATE TABLE test_batch_child (id INT AUTO_INCREMENT PRIMARY KEY, parent_id INT, name VARCHAR(50))",
+        "INSERT INTO test_batch_parent (name) VALUES ('A')",
+        "SET @pid = LAST_INSERT_ID()",
+        "INSERT INTO test_batch_child (parent_id, name) VALUES (@pid, 'A-1')",
+        "INSERT INTO test_batch_child (parent_id, name) VALUES (@pid, 'A-2')",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+
+    let results = mysql::execute_batch(&params, &queries, None, 1, None)
+        .await
+        .expect("batch setup should succeed");
+
+    assert_eq!(results.len(), queries.len(), "one result per statement");
+    for (i, r) in results.iter().enumerate() {
+        assert!(
+            r.error.is_none(),
+            "stmt {} ({}) failed: {:?}",
+            i,
+            queries[i],
+            r.error
+        );
+    }
+
+    let select = mysql::execute_query(
+        &params,
+        "SELECT id, parent_id FROM test_batch_child ORDER BY id",
+        None,
+        1,
+        None,
+    )
+    .await
+    .expect("select should succeed");
+    assert_eq!(select.rows.len(), 2, "both children should be inserted");
+    let parent_id_col = select
+        .columns
+        .iter()
+        .position(|c| c == "parent_id")
+        .expect("parent_id column");
+    let pid1 = select.rows[0][parent_id_col].as_i64();
+    let pid2 = select.rows[1][parent_id_col].as_i64();
+    assert!(
+        pid1.is_some(),
+        "child 1 parent_id must not be NULL — @pid didn't survive across statements"
+    );
+    assert_eq!(
+        pid1, pid2,
+        "both children must reference the same parent (got {:?} and {:?})",
+        pid1, pid2
+    );
+
+    // Cleanup
+    let _ =
+        mysql::execute_query(&params, "DROP TABLE test_batch_child", None, 1, None).await;
+    let _ =
+        mysql::execute_query(&params, "DROP TABLE test_batch_parent", None, 1, None).await;
+}
+
+/// Explicit `BEGIN`/`COMMIT` must span the batch — both inserts commit
+/// atomically inside the transaction.
+#[tokio::test]
+#[ignore]
+async fn test_mysql_batch_preserves_transaction_atomicity() {
+    let params = get_mysql_params();
+    if !wait_for_mysql(&params).await {
+        eprintln!("SKIPPING: MySQL not reachable on 33060");
+        return;
+    }
+
+    let _ = mysql::execute_query(&params, "DROP TABLE IF EXISTS test_batch_tx", None, 1, None)
+        .await;
+
+    let queries: Vec<String> = [
+        "CREATE TABLE test_batch_tx (id INT AUTO_INCREMENT PRIMARY KEY, val VARCHAR(20))",
+        "BEGIN",
+        "INSERT INTO test_batch_tx (val) VALUES ('tx-1')",
+        "INSERT INTO test_batch_tx (val) VALUES ('tx-2')",
+        "COMMIT",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+
+    let results = mysql::execute_batch(&params, &queries, None, 1, None)
+        .await
+        .expect("batch setup should succeed");
+    for (i, r) in results.iter().enumerate() {
+        assert!(
+            r.error.is_none(),
+            "stmt {} ({}) failed: {:?}",
+            i,
+            queries[i],
+            r.error
+        );
+    }
+
+    let select = mysql::execute_query(
+        &params,
+        "SELECT val FROM test_batch_tx ORDER BY id",
+        None,
+        1,
+        None,
+    )
+    .await
+    .expect("select should succeed");
+    assert_eq!(select.rows.len(), 2, "both inserts must be committed");
+    let val_col = select
+        .columns
+        .iter()
+        .position(|c| c == "val")
+        .expect("val column");
+    assert_eq!(select.rows[0][val_col].as_str(), Some("tx-1"));
+    assert_eq!(select.rows[1][val_col].as_str(), Some("tx-2"));
+
+    let _ = mysql::execute_query(&params, "DROP TABLE test_batch_tx", None, 1, None).await;
+}
+
+/// A `TEMP TABLE` created inside a transaction must be visible to a
+/// subsequent `SELECT` in the same batch — i.e. all statements observe
+/// the same session.
+#[tokio::test]
+#[ignore]
+async fn test_postgres_batch_preserves_temp_table_and_transaction() {
+    let params = get_postgres_params();
+    if !wait_for_postgres(&params).await {
+        eprintln!("SKIPPING: Postgres not reachable on 54320");
+        return;
+    }
+
+    let queries: Vec<String> = [
+        "BEGIN",
+        "CREATE TEMP TABLE test_batch_tmp (id SERIAL PRIMARY KEY, val TEXT)",
+        "INSERT INTO test_batch_tmp (val) VALUES ('a'), ('b'), ('c')",
+        "SELECT COUNT(*)::int AS n FROM test_batch_tmp",
+        "COMMIT",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+
+    let results = postgres::execute_batch(&params, &queries, None, 1, None)
+        .await
+        .expect("batch setup should succeed");
+
+    assert_eq!(results.len(), queries.len());
+    for (i, r) in results.iter().enumerate() {
+        assert!(
+            r.error.is_none(),
+            "stmt {} ({}) failed: {:?}",
+            i,
+            queries[i],
+            r.error
+        );
+    }
+
+    // The SELECT is at index 3; verify the temp table was visible and held 3 rows.
+    let count_result = results[3]
+        .result
+        .as_ref()
+        .expect("SELECT statement must return a result set");
+    assert_eq!(count_result.rows.len(), 1);
+    let n = count_result.rows[0][0].as_i64();
+    assert_eq!(
+        n,
+        Some(3),
+        "temp table must contain 3 rows and be visible to the SELECT (got {:?})",
+        n
+    );
+}
+
+// ---------------------------------------------------------------------------
+// affected_rows — drivers must report the real INSERT/UPDATE/DELETE row
+// count rather than a constant zero.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+async fn test_mysql_affected_rows_reported_correctly() {
+    let params = get_mysql_params();
+    if !wait_for_mysql(&params).await {
+        eprintln!("SKIPPING: MySQL not reachable on 33060");
+        return;
+    }
+
+    let _ = mysql::execute_query(
+        &params,
+        "DROP TABLE IF EXISTS test_affected",
+        None,
+        1,
+        None,
+    )
+    .await;
+
+    let queries: Vec<String> = [
+        "CREATE TABLE test_affected (id INT AUTO_INCREMENT PRIMARY KEY, v INT)",
+        "INSERT INTO test_affected (v) VALUES (1), (2), (3)",
+        "UPDATE test_affected SET v = v + 10 WHERE v >= 2",
+        "DELETE FROM test_affected WHERE v >= 12",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+
+    let results = mysql::execute_batch(&params, &queries, None, 1, None)
+        .await
+        .expect("batch setup should succeed");
+
+    for (i, r) in results.iter().enumerate() {
+        assert!(
+            r.error.is_none(),
+            "stmt {} ({}) failed: {:?}",
+            i,
+            queries[i],
+            r.error
+        );
+    }
+
+    // Index 1: INSERT 3 rows → 3
+    let insert_result = results[1]
+        .result
+        .as_ref()
+        .expect("INSERT should return a QueryResult");
+    assert_eq!(
+        insert_result.affected_rows, 3,
+        "INSERT of 3 rows should report 3 affected"
+    );
+
+    // Index 2: UPDATE matching 2 rows → 2
+    let update_result = results[2]
+        .result
+        .as_ref()
+        .expect("UPDATE should return a QueryResult");
+    assert_eq!(
+        update_result.affected_rows, 2,
+        "UPDATE matching 2 rows should report 2 affected"
+    );
+
+    // Index 3: DELETE matching 2 rows → 2
+    let delete_result = results[3]
+        .result
+        .as_ref()
+        .expect("DELETE should return a QueryResult");
+    assert_eq!(
+        delete_result.affected_rows, 2,
+        "DELETE matching 2 rows should report 2 affected"
+    );
+
+    let _ = mysql::execute_query(&params, "DROP TABLE test_affected", None, 1, None).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_postgres_affected_rows_reported_correctly() {
+    let params = get_postgres_params();
+    if !wait_for_postgres(&params).await {
+        eprintln!("SKIPPING: Postgres not reachable on 54320");
+        return;
+    }
+
+    let _ = postgres::execute_query(
+        &params,
+        "DROP TABLE IF EXISTS test_affected",
+        None,
+        1,
+        None,
+    )
+    .await;
+
+    let queries: Vec<String> = [
+        "CREATE TABLE test_affected (id SERIAL PRIMARY KEY, v INT)",
+        "INSERT INTO test_affected (v) VALUES (1), (2), (3)",
+        "UPDATE test_affected SET v = v + 10 WHERE v >= 2",
+        "DELETE FROM test_affected WHERE v >= 12",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+
+    let results = postgres::execute_batch(&params, &queries, None, 1, None)
+        .await
+        .expect("batch setup should succeed");
+
+    for (i, r) in results.iter().enumerate() {
+        assert!(
+            r.error.is_none(),
+            "stmt {} ({}) failed: {:?}",
+            i,
+            queries[i],
+            r.error
+        );
+    }
+
+    let insert_result = results[1].result.as_ref().expect("INSERT result");
+    assert_eq!(insert_result.affected_rows, 3, "INSERT should report 3");
+
+    let update_result = results[2].result.as_ref().expect("UPDATE result");
+    assert_eq!(update_result.affected_rows, 2, "UPDATE should report 2");
+
+    let delete_result = results[3].result.as_ref().expect("DELETE result");
+    assert_eq!(delete_result.affected_rows, 2, "DELETE should report 2");
+
+    let _ = postgres::execute_query(&params, "DROP TABLE test_affected", None, 1, None).await;
+}

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -94,6 +94,7 @@ import { useEditor } from "../hooks/useEditor";
 import { useConnectionLayoutContext } from "../hooks/useConnectionLayoutContext";
 import { useKeybindings } from "../hooks/useKeybindings";
 import type {
+  BatchStatementResult,
   QueryResult,
   Tab,
   PendingInsertion,
@@ -802,14 +803,10 @@ export const Editor = () => {
         || undefined;
 
       const entries = createResultEntries(targetTabId, queries);
-      // Local mutable array shared across concurrent promises.
-      // JS is single-threaded: between each `await` resume and the next
-      // yield point, mutations are atomic — no interleaving can occur.
-      const liveResults = [...entries];
 
       setIsResultsCollapsed(false);
       updateTab(targetTabId, {
-        results: liveResults,
+        results: entries,
         activeResultId: entries[0].id,
         result: null,
         error: "",
@@ -820,66 +817,92 @@ export const Editor = () => {
       const shouldRecordHistory =
         targetTab?.type === "console" || targetTab?.type === "query_builder";
 
-      // Execute all queries concurrently
-      await Promise.allSettled(
-        entries.map(async (entry, idx) => {
-          const start = performance.now();
-          try {
-            const res = await invoke<QueryResult>("execute_query", {
-              connectionId: activeConnectionId,
-              query: entry.query,
-              limit: pageSize,
-              page: 1,
-              ...(schema ? { schema } : {}),
-            });
-            const end = performance.now();
-            const tableName = extractTableName(entry.query) ?? null;
-
-            liveResults[idx] = {
-              ...liveResults[idx],
-              result: res,
-              executionTime: end - start,
-              isLoading: false,
-              activeTable: tableName,
-            };
-            updateTab(targetTabId, { results: [...liveResults] });
-
-            if (shouldRecordHistory) {
-              addHistoryEntry(
-                entry.query,
-                end - start,
-                "success",
-                res.pagination?.total_rows ?? null,
-                null,
-                historyDb,
-              );
-            }
-          } catch (err) {
-            const end = performance.now();
-            liveResults[idx] = {
-              ...liveResults[idx],
-              error:
-                typeof err === "string" ? err : t("editor.queryFailed"),
-              executionTime: end - start,
-              isLoading: false,
-            };
-            updateTab(targetTabId, { results: [...liveResults] });
-
-            if (shouldRecordHistory) {
-              addHistoryEntry(
-                entry.query,
-                end - start,
-                "error",
-                null,
-                typeof err === "string" ? err : t("editor.queryFailed"),
-                historyDb,
-              );
-            }
+      // Run the whole script on a single pooled connection so statements
+      // can share session state (SET @var, LAST_INSERT_ID(), transactions,
+      // TEMP TABLE).
+      const batchStart = performance.now();
+      let batchResults: BatchStatementResult[];
+      try {
+        batchResults = await invoke<BatchStatementResult[]>(
+          "execute_query_batch",
+          {
+            connectionId: activeConnectionId,
+            queries: entries.map((e) => e.query),
+            limit: pageSize,
+            page: 1,
+            ...(schema ? { schema } : {}),
+          },
+        );
+      } catch (err) {
+        // Batch-level failure (e.g. connection acquisition, cancellation):
+        // mark every entry as failed so the UI doesn't sit in "loading".
+        const fallbackElapsed = performance.now() - batchStart;
+        const message = typeof err === "string" ? err : t("editor.queryFailed");
+        const failed = entries.map((entry) => ({
+          ...entry,
+          error: message,
+          executionTime: fallbackElapsed,
+          isLoading: false,
+        }));
+        updateTab(targetTabId, { results: failed, isLoading: false });
+        if (shouldRecordHistory) {
+          for (const entry of entries) {
+            addHistoryEntry(
+              entry.query,
+              fallbackElapsed,
+              "error",
+              null,
+              message,
+              historyDb,
+            );
           }
-        }),
-      );
+        }
+        return;
+      }
 
-      updateTab(targetTabId, { isLoading: false });
+      const liveResults = entries.map((entry, idx) => {
+        const item = batchResults[idx];
+        const execTime = item?.execution_time_ms ?? null;
+        if (item?.error) {
+          if (shouldRecordHistory) {
+            addHistoryEntry(
+              entry.query,
+              execTime,
+              "error",
+              null,
+              item.error,
+              historyDb,
+            );
+          }
+          return {
+            ...entry,
+            error: item.error,
+            executionTime: execTime,
+            isLoading: false,
+          };
+        }
+        const res = item?.result ?? null;
+        const tableName = extractTableName(entry.query) ?? null;
+        if (shouldRecordHistory) {
+          addHistoryEntry(
+            entry.query,
+            execTime,
+            "success",
+            res?.pagination?.total_rows ?? null,
+            null,
+            historyDb,
+          );
+        }
+        return {
+          ...entry,
+          result: res,
+          executionTime: execTime,
+          isLoading: false,
+          activeTable: tableName,
+        };
+      });
+
+      updateTab(targetTabId, { results: liveResults, isLoading: false });
     },
     [activeConnectionId, updateTab, settings.resultPageSize, activeSchema, t, isMultiDb, activeDatabaseName, addHistoryEntry],
   );

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -39,6 +39,17 @@ export interface QueryResult {
   pagination?: Pagination;
 }
 
+/// One statement's outcome inside an `execute_query_batch` invocation.
+/// Mirrors `src-tauri/src/models.rs::BatchStatementResult`. Exactly one of
+/// `result` / `error` is non-null; `execution_time_ms` is measured
+/// server-side per statement so the history UI shows accurate timings even
+/// though the whole batch shares one Tauri round-trip.
+export interface BatchStatementResult {
+  result: QueryResult | null;
+  error: string | null;
+  execution_time_ms: number | null;
+}
+
 export interface QueryResultEntry {
   id: string;
   queryIndex: number;


### PR DESCRIPTION
## Summary

Closes #199.

Multi-statement scripts run via the editor's "run all" path now share a single physical database connection across all statements, instead of fanning out via `Promise.allSettled` (each invoke acquiring its own pooled connection). Cross-statement session state — `SET @var`, `LAST_INSERT_ID()` / `LASTVAL()`, `BEGIN`/`COMMIT`, `TEMP TABLE`, `PREPARE`/`EXECUTE` — now survives the way it does in `mysql` CLI / `psql` / DBeaver.

Side fix: the three built-in drivers were hardcoding `affected_rows: 0`; they now report the real count from `execute()`.

## Approach

- **Trait**: new `execute_batch` method on `DatabaseDriver`, with a default implementation that sequentially calls `execute_query` (preserves backwards compat for plugin drivers — ordering only, no session-state continuity).
- **Built-in drivers**: MySQL / Postgres / SQLite override `execute_batch` to acquire one pooled connection (or `deadpool` client) and run every statement on it in order. Refactored `execute_query` to share `exec_on_*_conn` helpers with `execute_batch`.
- **MySQL transaction-control**: routed through `sqlx::raw_sql()` (text protocol) to bypass server error 1295 ("This command is not supported in the prepared statement protocol yet") for `BEGIN`, `START TRANSACTION`, `COMMIT`, `ROLLBACK`, `SAVEPOINT`, `RELEASE SAVEPOINT`, `LOCK TABLES`, `UNLOCK TABLES`.
- **Tauri command**: new `execute_query_batch`, single cancellation handle for the whole batch.
- **Frontend**: `runMultipleQueries` replaced with a single `invoke("execute_query_batch")`; misleading "JS is single-threaded between awaits" comment removed.
- **`affected_rows`**: new shared `returns_result_set` keyword classifier; non-result-set statements go through `execute()` and return the real `rows_affected`.

## Test plan

Integration tests (`cargo test --test integration_tests -- --ignored`, requires local MySQL on 33060 and Postgres on 54320 with credentials matching `get_*_params()`):

- [x] `test_mysql_batch_preserves_user_variable_and_last_insert_id` — Issue's exact repro
- [x] `test_mysql_batch_preserves_transaction_atomicity` — explicit BEGIN/COMMIT
- [x] `test_postgres_batch_preserves_temp_table_and_transaction` — TEMP TABLE visibility inside a transaction
- [x] `test_mysql_affected_rows_reported_correctly` — INSERT/UPDATE/DELETE row counts
- [x] `test_postgres_affected_rows_reported_correctly` — same on Postgres
- [x] Existing `test_mysql_integration_flow` / `test_postgres_integration_flow` — regression check
- [x] Manual UI verification on macOS 26.4.1 against MySQL 8.0: repro script writes 1 parent + 2 children with correct `parent_id`

7/7 integration tests pass; `cargo check` + `npm run typecheck` clean.

## Not in scope (follow-ups)

- `QueryOptions` struct to flatten the `(limit, page, schema)` parameter sprawl shared by `execute_query` / `execute_batch`
- Extract a `run_cancellable` helper to dedupe the cancellation-handle bookkeeping between `execute_query` and `execute_query_batch`
- Stream batch results via Tauri events instead of materialising the whole `Vec<BatchStatementResult>` (currently bounded by N × page_size rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)