### PR TITLE
fix(mcp): correct app config directory path on Windows in mcp mode

### DIFF
--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -3,7 +3,15 @@ use std::path::PathBuf;
 
 pub fn get_app_config_dir() -> PathBuf {
     if let Some(proj_dirs) = ProjectDirs::from("", "", "tabularis") {
-        proj_dirs.config_dir().to_path_buf()
+
+        #[cfg(target_os = "windows")]
+        {
+            proj_dirs.config_dir().parent().unwrap().to_path_buf()
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            proj_dirs.config_dir().to_path_buf()
+        }
     } else {
         // Fallback for weird environments
         PathBuf::from(".config/tabularis")


### PR DESCRIPTION
## Description
This PR fixes an issue where the application configuration directory was incorrectly resolved on Windows, which directly caused the **MCP server to return an empty connections list**.

### The Issue
On Windows, the `directories` crate's `config_dir()` returns a path that includes an additional `config` subdirectory (e.g., `%AppData%\Roaming\tabularis\config`). However, the application stores its connection definitions and settings in the base directory (`%AppData%\Roaming\tabularis`). 
When running in MCP mode, the server was looking in the nested `config` folder, found no configuration files, and consequently reported an empty connections list to the client.

### The Fix
The fix ensures that on Windows, we use the parent of the default `config_dir()`, correctly pointing the application to the folder containing `connections.json` and other essential settings.