### PR TITLE
feat(text): chevron expand + Monaco diff for long text/longtext cells

### DIFF
--- a/demo/init/mysql/01-tabularis-demo.sql
+++ b/demo/init/mysql/01-tabularis-demo.sql
@@ -5,6 +5,8 @@
 --         customers, orders, order_items)
 -- =============================================================
 
+SET NAMES utf8mb4;
+
 CREATE DATABASE IF NOT EXISTS tabularis_demo
     CHARACTER SET utf8mb4
     COLLATE utf8mb4_unicode_ci;

--- a/demo/init/mysql/02-blog-demo.sql
+++ b/demo/init/mysql/02-blog-demo.sql
@@ -4,6 +4,8 @@
 -- Domain: Multi-author blog with posts, comments, tags
 -- =============================================================
 
+SET NAMES utf8mb4;
+
 CREATE DATABASE IF NOT EXISTS blog_demo
     CHARACTER SET utf8mb4
     COLLATE utf8mb4_unicode_ci;

--- a/demo/init/mysql/03-json-demo.sql
+++ b/demo/init/mysql/03-json-demo.sql
@@ -7,6 +7,8 @@
 --                  testing the "detect JSON in text columns" opt-in
 -- =============================================================
 
+SET NAMES utf8mb4;
+
 USE tabularis_demo;
 
 DROP TABLE IF EXISTS json_demo;

--- a/demo/init/mysql/04-text-demo.sql
+++ b/demo/init/mysql/04-text-demo.sql
@@ -1,0 +1,79 @@
+-- =============================================================
+-- Tabularis Demo — Long text showcase (MySQL 8)
+-- Database: tabularis_demo
+-- Purpose: exercise the long-text chevron + Monaco diff editor
+--   (see issue #207). Each row targets a specific edge case:
+--   short, long single-line, multi-line, markdown, code,
+--   varchar-over-threshold, NULLs, unicode.
+-- =============================================================
+
+SET NAMES utf8mb4;
+
+USE tabularis_demo;
+
+DROP TABLE IF EXISTS text_demo;
+CREATE TABLE text_demo (
+  id        INT AUTO_INCREMENT PRIMARY KEY,
+  label     VARCHAR(80)  NOT NULL,
+  summary   VARCHAR(500),
+  body      TEXT,
+  notes     LONGTEXT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO text_demo (label, summary, body, notes) VALUES
+  -- Row 1: everything short — no chevron should appear anywhere.
+  ('short', 'just a brief note', 'hello world', NULL),
+
+  -- Row 2: body is a single-line value over the 80-char threshold.
+  -- Chevron should appear but the cell preview stays single-line.
+  ('long single-line',
+   NULL,
+   'A practical tour of EXPLAIN ANALYZE, missing indexes, and the cost of unnecessary sorts that turn a 10ms query into a 4s nightmare.',
+   NULL),
+
+  -- Row 3: body is short overall (< 80) but contains newlines.
+  -- Chevron triggers via the newline branch; preview shows the
+  -- U+23CE return symbol between lines.
+  ('multi-line short',
+   NULL,
+   'line one\nline two\nline three',
+   NULL),
+
+  -- Row 4: realistic multi-line markdown content. Primary test case
+  -- for the chevron + diff editor with rich content.
+  ('markdown article',
+   'Field notes from migrating a 50M-row Postgres table without downtime',
+   '# Zero-downtime migration\n\nWe needed to add a `tenant_id` column to a 50M-row table\nwithout pausing writes. Here is what worked.\n\n## Step 1 — Backfill in batches\n\nA single `UPDATE … SET tenant_id = …` would have locked the\ntable for hours. We batched by primary-key range:\n\n```sql\nUPDATE events\nSET tenant_id = derive_tenant(account_id)\nWHERE id BETWEEN $1 AND $1 + 10000\n  AND tenant_id IS NULL;\n```\n\n## Step 2 — Add the NOT NULL constraint\n\nOnly after the backfill completed did we promote the column\nto `NOT NULL` and add the index, both as concurrent operations.\n\n## What we would do differently\n\n- Run the batches at lower priority during peak hours.\n- Add a kill-switch env var, not a code redeploy.\n',
+   'Original draft — reviewed by SRE 2026-04-11.'),
+
+  -- Row 5: code snippet with indentation. Tests Monaco plain-text
+  -- preserves whitespace and that the diff handles indentation
+  -- changes cleanly.
+  ('code snippet',
+   'Quicksort in Python — recursive variant for teaching, not production',
+   'def quicksort(items):\n    if len(items) <= 1:\n        return items\n    pivot = items[len(items) // 2]\n    left = [x for x in items if x < pivot]\n    middle = [x for x in items if x == pivot]\n    right = [x for x in items if x > pivot]\n    return quicksort(left) + middle + quicksort(right)\n\n\nif __name__ == "__main__":\n    sample = [3, 6, 1, 8, 2, 9, 4, 7, 5]\n    print(quicksort(sample))\n',
+   NULL),
+
+  -- Row 6: multi-line SQL with comments — diffs should show clear
+  -- per-line changes when the user edits a clause.
+  ('SQL query',
+   NULL,
+   '-- Top 10 slowest endpoints in the last hour\nSELECT\n    endpoint,\n    COUNT(*)            AS hits,\n    AVG(duration_ms)    AS avg_ms,\n    MAX(duration_ms)    AS max_ms,\n    PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY duration_ms) AS p95_ms\nFROM request_log\nWHERE created_at >= NOW() - INTERVAL ''1 hour''\nGROUP BY endpoint\nORDER BY p95_ms DESC\nLIMIT 10;\n',
+   'Saved query — pinned in Grafana dashboard "API latency".'),
+
+  -- Row 7: VARCHAR(500) holds a single-line value over threshold.
+  -- Confirms the chevron also fires on VARCHAR columns, not only TEXT.
+  ('long varchar',
+   'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+   'see summary column',
+   NULL),
+
+  -- Row 8: all NULL — chevron must NOT appear on null cells.
+  ('all null', NULL, NULL, NULL),
+
+  -- Row 9: unicode + emoji across multiple lines. Monaco should
+  -- render glyphs correctly and the diff view should align them.
+  ('unicode + emoji',
+   'Greetings from around the world 🌍',
+   'こんにちは — Japanese\n안녕하세요 — Korean\nПривет — Russian\n∑(α+β)² — math\n🦊🐾 — fox tracks\nمرحبا — Arabic\n',
+   '⚙️ technical note: ensure utf8mb4 collation');

--- a/demo/init/postgres/04-text-demo.sql
+++ b/demo/init/postgres/04-text-demo.sql
@@ -1,0 +1,77 @@
+-- =============================================================
+-- Tabularis Demo — Long text showcase (PostgreSQL 16)
+-- Database: tabularis_demo
+-- Purpose: exercise the long-text chevron + Monaco diff editor
+--   (see issue #207). Each row targets a specific edge case:
+--   short, long single-line, multi-line, markdown, code,
+--   varchar-over-threshold, NULLs, unicode.
+-- =============================================================
+
+\c tabularis_demo
+
+DROP TABLE IF EXISTS text_demo;
+CREATE TABLE text_demo (
+  id        SERIAL PRIMARY KEY,
+  label     VARCHAR(80)  NOT NULL,
+  summary   VARCHAR(500),
+  body      TEXT,
+  notes     TEXT
+);
+
+INSERT INTO text_demo (label, summary, body, notes) VALUES
+  -- Row 1: everything short — no chevron should appear anywhere.
+  ('short', 'just a brief note', 'hello world', NULL),
+
+  -- Row 2: body is a single-line value over the 80-char threshold.
+  -- Chevron should appear but the cell preview stays single-line.
+  ('long single-line',
+   NULL,
+   'A practical tour of EXPLAIN ANALYZE, missing indexes, and the cost of unnecessary sorts that turn a 10ms query into a 4s nightmare.',
+   NULL),
+
+  -- Row 3: body is short overall (< 80) but contains newlines.
+  -- Chevron triggers via the newline branch; preview shows the
+  -- U+23CE return symbol between lines.
+  ('multi-line short',
+   NULL,
+   E'line one\nline two\nline three',
+   NULL),
+
+  -- Row 4: realistic multi-line markdown content. Primary test case
+  -- for the chevron + diff editor with rich content.
+  ('markdown article',
+   'Field notes from migrating a 50M-row Postgres table without downtime',
+   E'# Zero-downtime migration\n\nWe needed to add a `tenant_id` column to a 50M-row table\nwithout pausing writes. Here is what worked.\n\n## Step 1 — Backfill in batches\n\nA single `UPDATE … SET tenant_id = …` would have locked the\ntable for hours. We batched by primary-key range:\n\n```sql\nUPDATE events\nSET tenant_id = derive_tenant(account_id)\nWHERE id BETWEEN $1 AND $1 + 10000\n  AND tenant_id IS NULL;\n```\n\n## Step 2 — Add the NOT NULL constraint\n\nOnly after the backfill completed did we promote the column\nto `NOT NULL` and add the index, both as concurrent operations.\n\n## What we would do differently\n\n- Run the batches at lower priority during peak hours.\n- Add a kill-switch env var, not a code redeploy.\n',
+   'Original draft — reviewed by SRE 2026-04-11.'),
+
+  -- Row 5: code snippet with indentation. Tests Monaco plain-text
+  -- preserves whitespace and that the diff handles indentation
+  -- changes cleanly.
+  ('code snippet',
+   'Quicksort in Python — recursive variant for teaching, not production',
+   E'def quicksort(items):\n    if len(items) <= 1:\n        return items\n    pivot = items[len(items) // 2]\n    left = [x for x in items if x < pivot]\n    middle = [x for x in items if x == pivot]\n    right = [x for x in items if x > pivot]\n    return quicksort(left) + middle + quicksort(right)\n\n\nif __name__ == "__main__":\n    sample = [3, 6, 1, 8, 2, 9, 4, 7, 5]\n    print(quicksort(sample))\n',
+   NULL),
+
+  -- Row 6: multi-line SQL with comments — diffs should show clear
+  -- per-line changes when the user edits a clause.
+  ('SQL query',
+   NULL,
+   E'-- Top 10 slowest endpoints in the last hour\nSELECT\n    endpoint,\n    COUNT(*)            AS hits,\n    AVG(duration_ms)    AS avg_ms,\n    MAX(duration_ms)    AS max_ms,\n    PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY duration_ms) AS p95_ms\nFROM request_log\nWHERE created_at >= NOW() - INTERVAL ''1 hour''\nGROUP BY endpoint\nORDER BY p95_ms DESC\nLIMIT 10;\n',
+   'Saved query — pinned in Grafana dashboard "API latency".'),
+
+  -- Row 7: VARCHAR(500) holds a single-line value over threshold.
+  -- Confirms the chevron also fires on VARCHAR columns, not only TEXT.
+  ('long varchar',
+   'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+   'see summary column',
+   NULL),
+
+  -- Row 8: all NULL — chevron must NOT appear on null cells.
+  ('all null', NULL, NULL, NULL),
+
+  -- Row 9: unicode + emoji across multiple lines. Monaco should
+  -- render glyphs correctly and the diff view should align them.
+  ('unicode + emoji',
+   'Greetings from around the world 🌍',
+   E'こんにちは — Japanese\n안녕하세요 — Korean\nПривет — Russian\n∑(α+β)² — math\n🦊🐾 — fox tracks\nمرحبا — Arabic\n',
+   '⚙️ technical note: ensure UTF-8 client encoding');

--- a/src/components/ui/CellCodeEditor.tsx
+++ b/src/components/ui/CellCodeEditor.tsx
@@ -7,23 +7,25 @@ import type * as MonacoTypes from "monaco-editor";
 import { ThemeContext } from "../../contexts/ThemeContext";
 import { loadMonacoTheme } from "../../themes/themeUtils";
 
-interface JsonCodeEditorProps {
+interface CellCodeEditorProps {
   value: string;
   onChange: (text: string) => void;
   onValidate?: (markers: MonacoTypes.editor.IMarker[]) => void;
   height?: string | number;
   readOnly?: boolean;
+  language?: "json" | "plaintext";
 }
 
 const DEFAULT_THEME = "vs-dark";
 
-export const JsonCodeEditor = ({
+export const CellCodeEditor = ({
   value,
   onChange,
   onValidate,
   height = "100%",
   readOnly = false,
-}: JsonCodeEditorProps) => {
+  language = "json",
+}: CellCodeEditorProps) => {
   const themeCtx = useContext(ThemeContext);
   const currentTheme = themeCtx?.currentTheme;
   const monacoRef = useRef<typeof MonacoTypes | null>(null);
@@ -52,7 +54,7 @@ export const JsonCodeEditor = ({
   return (
     <MonacoEditor
       height={height}
-      language="json"
+      language={language}
       theme={currentTheme?.id ?? DEFAULT_THEME}
       value={value}
       beforeMount={handleBeforeMount}
@@ -63,7 +65,7 @@ export const JsonCodeEditor = ({
         minimap: { enabled: false },
         lineNumbers: "on",
         automaticLayout: true,
-        formatOnPaste: true,
+        formatOnPaste: language === "json",
         scrollBeyondLastLine: false,
         wordWrap: "on",
         wrappingIndent: "indent",

--- a/src/components/ui/CellDiffEditor.tsx
+++ b/src/components/ui/CellDiffEditor.tsx
@@ -4,25 +4,27 @@ import type * as MonacoTypes from "monaco-editor";
 import { ThemeContext } from "../../contexts/ThemeContext";
 import { loadMonacoTheme } from "../../themes/themeUtils";
 
-interface JsonDiffEditorProps {
+interface CellDiffEditorProps {
   original: string;
   modified: string;
   onChange?: (next: string) => void;
   height?: string | number;
   readOnly?: boolean;
   renderSideBySide?: boolean;
+  language?: "json" | "plaintext";
 }
 
 const DEFAULT_THEME = "vs-dark";
 
-export const JsonDiffEditor = ({
+export const CellDiffEditor = ({
   original,
   modified,
   onChange,
   height = "100%",
   readOnly = false,
   renderSideBySide = false,
-}: JsonDiffEditorProps) => {
+  language = "json",
+}: CellDiffEditorProps) => {
   const themeCtx = useContext(ThemeContext);
   const currentTheme = themeCtx?.currentTheme;
   const monacoRef = useRef<typeof MonacoTypes | null>(null);
@@ -52,7 +54,7 @@ export const JsonDiffEditor = ({
   return (
     <DiffEditor
       height={height}
-      language="json"
+      language={language}
       theme={currentTheme?.id ?? DEFAULT_THEME}
       original={original}
       modified={modified}

--- a/src/components/ui/CellDiffEditor.tsx
+++ b/src/components/ui/CellDiffEditor.tsx
@@ -44,6 +44,9 @@ export const CellDiffEditor = ({
     if (currentTheme) {
       loadMonacoTheme(currentTheme, monaco);
     }
+
+    editor.getOriginalEditor().updateOptions({ readOnly: true });
+    editor.getModifiedEditor().updateOptions({ readOnly });
     if (onChange) {
       editor.getModifiedEditor().onDidChangeModelContent(() => {
         onChange(editor.getModifiedEditor().getValue());
@@ -53,6 +56,7 @@ export const CellDiffEditor = ({
 
   return (
     <DiffEditor
+      key={renderSideBySide ? "sbs" : "inline"}
       height={height}
       language={language}
       theme={currentTheme?.id ?? DEFAULT_THEME}
@@ -60,15 +64,15 @@ export const CellDiffEditor = ({
       modified={modified}
       onMount={handleMount}
       options={{
-        readOnly,
-        originalEditable: false,
         renderSideBySide,
+        useInlineViewWhenSpaceIsLimited: false,
         minimap: { enabled: false },
         lineNumbers: "on",
         automaticLayout: true,
         scrollBeyondLastLine: false,
         wordWrap: "on",
         wrappingIndent: "indent",
+        diffWordWrap: "on",
         renderOverviewRuler: false,
       }}
     />

--- a/src/components/ui/DataGrid.tsx
+++ b/src/components/ui/DataGrid.tsx
@@ -49,6 +49,7 @@ import {
 import { isGeometricType, formatGeometricValue } from "../../utils/geometry";
 import { isBlobColumn, isBlobWireFormat } from "../../utils/blob";
 import { isJsonColumn, isJsonContent } from "../../utils/json";
+import { isLongTextCellTarget } from "../../utils/text";
 import {
   pickPrimaryForeignKeyByColumn,
   isForeignKeyValueNavigable,
@@ -63,6 +64,8 @@ import { DateInput } from "./DateInput";
 import { RowEditorSidebar } from "./RowEditorSidebar";
 import { JsonCell } from "./JsonCell";
 import { JsonExpansionEditor } from "./JsonExpansionEditor";
+import { TextCell } from "./TextCell";
+import { TextExpansionEditor } from "./TextExpansionEditor";
 import { useDatabase } from "../../hooks/useDatabase";
 import {
   rowsToCSV,
@@ -191,13 +194,14 @@ export const DataGrid = React.memo(
       rowIndex: number;
       focusField?: string;
     } | null>(null);
-    const [expandedJsonCell, setExpandedJsonCell] = useState<{
+    const [expandedCell, setExpandedCell] = useState<{
       rowIndex: number;
       colIndex: number;
+      kind: "json" | "text";
     } | null>(null);
 
     useEffect(() => {
-      setExpandedJsonCell(null);
+      setExpandedCell(null);
     }, [data]);
 
     const [internalSelectedRowIndices, setInternalSelectedRowIndices] =
@@ -1204,7 +1208,7 @@ export const DataGrid = React.memo(
                       ? pendingDeletions?.[pkVal] !== undefined
                       : false;
                   const expansionMatchesRow =
-                    expandedJsonCell?.rowIndex === rowIndex;
+                    expandedCell?.rowIndex === rowIndex;
 
                   return (
                     <React.Fragment key={row.id}>
@@ -1280,6 +1284,13 @@ export const DataGrid = React.memo(
                         const isJsonCell =
                           isJsonCellTarget(colTypeForCell, rawCellValue) &&
                           !isPendingDelete;
+                        const isLongTextCell =
+                          !isJsonCell &&
+                          !isPendingDelete &&
+                          isLongTextCellTarget(
+                            colTypeForCell,
+                            hasPendingChange ? displayValue : rawCellValue,
+                          );
 
                         const stateClass = getCellStateClass({
                           isPendingDelete,
@@ -1475,9 +1486,9 @@ export const DataGrid = React.memo(
 
                                     if (isJsonCell) {
                                       const isExpanded =
-                                        expandedJsonCell?.rowIndex ===
-                                          rowIndex &&
-                                        expandedJsonCell?.colIndex === colIndex;
+                                        expandedCell?.kind === "json" &&
+                                        expandedCell?.rowIndex === rowIndex &&
+                                        expandedCell?.colIndex === colIndex;
                                       return (
                                         <JsonCell
                                           value={displayValue}
@@ -1485,10 +1496,14 @@ export const DataGrid = React.memo(
                                           isExpanded={isExpanded}
                                           isPendingDelete={isPendingDelete}
                                           onToggleExpand={() =>
-                                            setExpandedJsonCell(
+                                            setExpandedCell(
                                               isExpanded
                                                 ? null
-                                                : { rowIndex, colIndex },
+                                                : {
+                                                    rowIndex,
+                                                    colIndex,
+                                                    kind: "json",
+                                                  },
                                             )
                                           }
                                           onOpenViewer={() => {
@@ -1508,6 +1523,32 @@ export const DataGrid = React.memo(
                                               readonlyProp ?? false,
                                             );
                                           }}
+                                        />
+                                      );
+                                    }
+
+                                    if (isLongTextCell) {
+                                      const isExpanded =
+                                        expandedCell?.kind === "text" &&
+                                        expandedCell?.rowIndex === rowIndex &&
+                                        expandedCell?.colIndex === colIndex;
+                                      return (
+                                        <TextCell
+                                          value={displayValue}
+                                          displayText={formattedDisplay}
+                                          isExpanded={isExpanded}
+                                          isPendingDelete={isPendingDelete}
+                                          onToggleExpand={() =>
+                                            setExpandedCell(
+                                              isExpanded
+                                                ? null
+                                                : {
+                                                    rowIndex,
+                                                    colIndex,
+                                                    kind: "text",
+                                                  },
+                                            )
+                                          }
                                         />
                                       );
                                     }
@@ -1605,87 +1646,94 @@ export const DataGrid = React.memo(
                         );
                       })}
                     </tr>
-                    {expansionMatchesRow && expandedJsonCell && (
-                      <tr
-                        ref={rowVirtualizer.measureElement}
-                        data-expansion-for={virtualRow.index}
-                      >
-                        <td
-                          colSpan={columns.length + 1}
-                          className="p-0 border-b border-default"
+                    {expansionMatchesRow && expandedCell && (() => {
+                      const expColName = columns[expandedCell.colIndex];
+                      const mergedRow = mergedRows[rowIndex];
+                      const pendingExpansionValue = (() => {
+                        if (!mergedRow) return undefined;
+                        if (
+                          mergedRow.type === "existing" &&
+                          pkIndexMap !== null
+                        ) {
+                          const pkVal = mergedRow.rowData[pkIndexMap];
+                          const pendingVal =
+                            pkVal !== null &&
+                            pkVal !== undefined &&
+                            pkVal !== ""
+                              ? pendingChanges?.[String(pkVal)]?.changes?.[
+                                  expColName
+                                ]
+                              : undefined;
+                          if (pendingVal !== undefined) return pendingVal;
+                        }
+                        return mergedRow.rowData?.[expandedCell.colIndex];
+                      })();
+                      const expansionOriginalValue =
+                        mergedRow?.type === "existing"
+                          ? mergedRow?.rowData?.[expandedCell.colIndex]
+                          : undefined;
+                      const persistExpansionSave = (next: unknown) => {
+                        if (!mergedRow || !expandedCell) return;
+                        if (
+                          mergedRow.type === "insertion" &&
+                          onPendingInsertionChange &&
+                          mergedRow.tempId
+                        ) {
+                          onPendingInsertionChange(
+                            mergedRow.tempId,
+                            expColName,
+                            next,
+                          );
+                        } else if (
+                          mergedRow.type === "existing" &&
+                          onPendingChange &&
+                          pkIndexMap !== null
+                        ) {
+                          const pkVal = mergedRow.rowData[pkIndexMap];
+                          onPendingChange(pkVal, expColName, next);
+                        }
+                        setExpandedCell(null);
+                      };
+                      return (
+                        <tr
+                          ref={rowVirtualizer.measureElement}
+                          data-expansion-for={virtualRow.index}
                         >
-                          <div
-                            className="sticky left-0 bg-base/60 p-3"
-                            style={{
-                              width:
-                                parentViewportWidth > 0
-                                  ? `${parentViewportWidth}px`
-                                  : "100%",
-                            }}
+                          <td
+                            colSpan={columns.length + 1}
+                            className="p-0 border-b border-default"
                           >
-                            <JsonExpansionEditor
-                              value={(() => {
-                                const mergedRow = mergedRows[rowIndex];
-                                if (!mergedRow) return undefined;
-                                const expColName =
-                                  columns[expandedJsonCell.colIndex];
-                                if (
-                                  mergedRow.type === "existing" &&
-                                  pkIndexMap !== null
-                                ) {
-                                  const pkVal = mergedRow.rowData[pkIndexMap];
-                                  const pendingVal =
-                                    pkVal !== null &&
-                                    pkVal !== undefined &&
-                                    pkVal !== ""
-                                      ? pendingChanges?.[String(pkVal)]
-                                          ?.changes?.[expColName]
-                                      : undefined;
-                                  if (pendingVal !== undefined) return pendingVal;
-                                }
-                                return mergedRow.rowData?.[
-                                  expandedJsonCell.colIndex
-                                ];
-                              })()}
-                              originalValue={
-                                mergedRows[rowIndex]?.type === "existing"
-                                  ? mergedRows[rowIndex]?.rowData?.[
-                                      expandedJsonCell.colIndex
-                                    ]
-                                  : undefined
-                              }
-                              readOnly={readonlyProp ?? false}
-                              onCancel={() => setExpandedJsonCell(null)}
-                              onSave={(next) => {
-                                const mergedRow = mergedRows[rowIndex];
-                                if (!mergedRow || !expandedJsonCell) return;
-                                const colName =
-                                  columns[expandedJsonCell.colIndex];
-                                if (
-                                  mergedRow.type === "insertion" &&
-                                  onPendingInsertionChange &&
-                                  mergedRow.tempId
-                                ) {
-                                  onPendingInsertionChange(
-                                    mergedRow.tempId,
-                                    colName,
-                                    next,
-                                  );
-                                } else if (
-                                  mergedRow.type === "existing" &&
-                                  onPendingChange &&
-                                  pkIndexMap !== null
-                                ) {
-                                  const pkVal = mergedRow.rowData[pkIndexMap];
-                                  onPendingChange(pkVal, colName, next);
-                                }
-                                setExpandedJsonCell(null);
+                            <div
+                              className="sticky left-0 bg-base/60 p-3"
+                              style={{
+                                width:
+                                  parentViewportWidth > 0
+                                    ? `${parentViewportWidth}px`
+                                    : "100%",
                               }}
-                            />
-                          </div>
-                        </td>
-                      </tr>
-                    )}
+                            >
+                              {expandedCell.kind === "json" ? (
+                                <JsonExpansionEditor
+                                  value={pendingExpansionValue}
+                                  originalValue={expansionOriginalValue}
+                                  readOnly={readonlyProp ?? false}
+                                  onCancel={() => setExpandedCell(null)}
+                                  onSave={persistExpansionSave}
+                                />
+                              ) : (
+                                <TextExpansionEditor
+                                  value={pendingExpansionValue}
+                                  originalValue={expansionOriginalValue}
+                                  readOnly={readonlyProp ?? false}
+                                  onCancel={() => setExpandedCell(null)}
+                                  onSave={persistExpansionSave}
+                                />
+                              )}
+                            </div>
+                          </td>
+                        </tr>
+                      );
+                    })()}
                     </React.Fragment>
                   );
                 })}

--- a/src/components/ui/FieldEditor.tsx
+++ b/src/components/ui/FieldEditor.tsx
@@ -5,9 +5,11 @@ import { GeometryInput } from "./GeometryInput";
 import { BlobInput } from "./BlobInput";
 import { DateInput } from "./DateInput";
 import { JsonInput } from "./JsonInput";
+import { TextInput } from "./TextInput";
 import { isGeometricType, formatGeometricValue } from "../../utils/geometry";
 import { isBlobColumn } from "../../utils/blob";
 import { isJsonColumn, isJsonContent } from "../../utils/json";
+import { isLongTextValue, isTextColumn } from "../../utils/text";
 import { getDateInputMode } from "../../utils/dateInput";
 import { USE_DEFAULT_SENTINEL } from "../../utils/dataGrid";
 
@@ -70,6 +72,13 @@ export const FieldEditor = ({
       isJsonContent(originalValue));
   const isJson = isJsonByType || detectedJson;
   const dateMode = !isJson && type ? getDateInputMode(type) : null;
+  const isLongText =
+    !isBlob &&
+    !isGeometric &&
+    !isJson &&
+    !dateMode &&
+    isTextColumn(type) &&
+    (isLongTextValue(value) || isLongTextValue(originalValue));
 
   const defaultPlaceholder = placeholder || t("rowEditor.enterValue");
 
@@ -122,6 +131,14 @@ export const FieldEditor = ({
       value={String(value ?? "")}
       mode={dateMode}
       onChange={(newValue) => onChange(newValue)}
+      className={className}
+    />
+  ) : isLongText ? (
+    <TextInput
+      value={value}
+      originalValue={originalValue}
+      onChange={(newValue) => onChange(newValue)}
+      placeholder={defaultPlaceholder}
       className={className}
     />
   ) : (

--- a/src/components/ui/JsonInput.tsx
+++ b/src/components/ui/JsonInput.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import {
   Check,
   Code,
+  Columns2,
   FileText,
   GitCompare,
   Maximize2,
@@ -16,9 +17,13 @@ import {
   parseJsonEditorValue,
   validateJson,
 } from "../../utils/json";
-import { JsonCodeEditor } from "./JsonCodeEditor";
-import { JsonDiffEditor } from "./JsonDiffEditor";
+import { CellCodeEditor } from "./CellCodeEditor";
+import { CellDiffEditor } from "./CellDiffEditor";
 import { JsonTreeView } from "./JsonTreeView";
+import {
+  MIN_SIDE_BY_SIDE_WIDTH,
+  useContainerWidth,
+} from "../../hooks/useContainerWidth";
 
 type JsonInputMode = "code" | "tree" | "raw";
 
@@ -54,6 +59,10 @@ export const JsonInput: React.FC<JsonInputProps> = ({
   const [error, setError] = useState<string | null>(null);
   const [prevValueKey, setPrevValueKey] = useState(valueKey);
   const [diffEnabled, setDiffEnabled] = useState(false);
+  const [sideBySide, setSideBySide] = useState(false);
+  const { ref: rootRef, width: containerWidth } = useContainerWidth<HTMLDivElement>();
+  const sideBySideFits = containerWidth >= MIN_SIDE_BY_SIDE_WIDTH;
+  const renderSideBySide = sideBySide && sideBySideFits;
 
   if (valueKey !== prevValueKey) {
     setPrevValueKey(valueKey);
@@ -170,7 +179,7 @@ export const JsonInput: React.FC<JsonInputProps> = ({
     : "relative";
 
   return (
-    <div className={rootClass}>
+    <div ref={rootRef} className={rootClass}>
       {/* Mode selector */}
       <div
         role="tablist"
@@ -213,15 +222,18 @@ export const JsonInput: React.FC<JsonInputProps> = ({
             style={fillHeight ? undefined : { height: 220 }}
           >
             {diffEnabled && hasDiff && originalText !== null ? (
-              <JsonDiffEditor
+              <CellDiffEditor
+                language="json"
                 original={originalText}
                 modified={text}
                 onChange={handleCodeChange}
                 readOnly={readOnly}
                 height="100%"
+                renderSideBySide={renderSideBySide}
               />
             ) : (
-              <JsonCodeEditor
+              <CellCodeEditor
+                language="json"
                 value={text}
                 onChange={handleCodeChange}
                 height="100%"
@@ -305,6 +317,22 @@ export const JsonInput: React.FC<JsonInputProps> = ({
                     className="ml-0.5 inline-block w-1.5 h-1.5 rounded-full bg-amber-400"
                   />
                 )}
+              </button>
+            )}
+            {mode === "code" && diffEnabled && hasDiff && sideBySideFits && (
+              <button
+                type="button"
+                onClick={() => setSideBySide((v) => !v)}
+                aria-pressed={sideBySide}
+                className={`px-2 py-1 text-xs rounded border transition-colors flex items-center gap-1 ${
+                  sideBySide
+                    ? "bg-blue-600/30 text-blue-100 border-blue-500/50"
+                    : "bg-surface-secondary text-secondary border-default hover:bg-surface-tertiary"
+                }`}
+                title={t("jsonInput.sideBySide", { defaultValue: "Side by side" })}
+              >
+                <Columns2 size={12} />
+                {t("jsonInput.sideBySide", { defaultValue: "Side by side" })}
               </button>
             )}
             {!disableExpand && (

--- a/src/components/ui/RowEditorSidebar.tsx
+++ b/src/components/ui/RowEditorSidebar.tsx
@@ -4,6 +4,7 @@ import { X } from "lucide-react";
 import { FieldEditor } from "./FieldEditor";
 import { SlotAnchor } from "./SlotAnchor";
 import { useRowEditor } from "../../hooks/useRowEditor";
+import { useRowEditorResize } from "../../hooks/useRowEditorResize";
 
 interface RowEditorSidebarProps {
   isOpen: boolean;
@@ -45,6 +46,7 @@ export const RowEditorSidebar = ({
   schema,
 }: RowEditorSidebarProps) => {
   const { t } = useTranslation();
+  const { width, startResize } = useRowEditorResize();
   const { editedData, updateField } = useRowEditor({
     initialData: rowData,
     onChange: (fieldName, value) => onChange(fieldName, value),
@@ -78,7 +80,26 @@ export const RowEditorSidebar = ({
   return (
     <>
       {/* Sidebar */}
-      <div className="fixed right-0 top-0 bottom-0 w-96 bg-elevated border-l border-strong shadow-2xl z-[1001] flex flex-col animate-slide-in-right">
+      <div
+        className="fixed right-0 top-0 bottom-0 bg-elevated border-l border-strong shadow-2xl z-[1001] flex flex-col animate-slide-in-right"
+        style={{ width: `${width}px` }}
+      >
+        {/* Drag handle */}
+        <button
+          type="button"
+          onMouseDown={startResize}
+          aria-label={t("rowEditor.resize", {
+            defaultValue: "Resize sidebar",
+          })}
+          title={t("rowEditor.resize", { defaultValue: "Resize sidebar" })}
+          className="absolute top-0 bottom-0 -left-1 w-2 cursor-col-resize group/resize z-10"
+        >
+          <span
+            aria-hidden
+            className="absolute inset-y-0 left-1/2 -translate-x-1/2 w-px bg-default group-hover/resize:bg-blue-500 group-hover/resize:w-0.5 transition-all"
+          />
+        </button>
+
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-default bg-base">
           <div>

--- a/src/components/ui/TextCell.tsx
+++ b/src/components/ui/TextCell.tsx
@@ -1,0 +1,70 @@
+import { useLayoutEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ChevronRight } from "lucide-react";
+
+interface TextCellProps {
+  value: unknown;
+  displayText: string;
+  isExpanded: boolean;
+  isPendingDelete: boolean;
+  onToggleExpand: () => void;
+}
+
+export const TextCell = ({
+  value,
+  displayText,
+  isExpanded,
+  isPendingDelete,
+  onToggleExpand,
+}: TextCellProps) => {
+  const { t } = useTranslation();
+  const textRef = useRef<HTMLSpanElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useLayoutEffect(() => {
+    const el = textRef.current;
+    if (!el) return;
+    setIsTruncated(el.scrollWidth > el.clientWidth);
+  }, [displayText]);
+
+  const isNullish = value === null || value === undefined;
+  const showChevron = !isNullish && !isPendingDelete;
+  const iconVisibilityClass = isTruncated
+    ? "opacity-100"
+    : "opacity-0 group-hover/textcell:opacity-100";
+
+  const preview = displayText.includes("\n")
+    ? displayText.replace(/\n/g, " ⏎ ")
+    : displayText;
+
+  return (
+    <span
+      className="flex items-center gap-1 group/textcell w-full"
+      title={displayText}
+    >
+      <span ref={textRef} className="truncate flex-1">
+        {preview}
+      </span>
+      {showChevron && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleExpand();
+          }}
+          className={`${iconVisibilityClass} transition-all p-0.5 rounded text-muted hover:text-secondary hover:bg-surface-tertiary flex-shrink-0 ${
+            isExpanded ? "rotate-90" : ""
+          }`}
+          title={t("textCell.expand", {
+            defaultValue: "Toggle inline text editor",
+          })}
+          aria-label={t("textCell.expand", {
+            defaultValue: "Toggle inline text editor",
+          })}
+        >
+          <ChevronRight size={11} />
+        </button>
+      )}
+    </span>
+  );
+};

--- a/src/components/ui/TextExpansionEditor.tsx
+++ b/src/components/ui/TextExpansionEditor.tsx
@@ -3,42 +3,37 @@ import { useTranslation } from "react-i18next";
 import { Columns2, GitCompare } from "lucide-react";
 import { CellCodeEditor } from "./CellCodeEditor";
 import { CellDiffEditor } from "./CellDiffEditor";
+import { formatTextForEditor } from "../../utils/text";
 import {
   MIN_SIDE_BY_SIDE_WIDTH,
   useContainerWidth,
 } from "../../hooks/useContainerWidth";
-import {
-  formatJsonForEditor,
-  parseJsonEditorValue,
-  validateJson,
-} from "../../utils/json";
 
-interface JsonExpansionEditorProps {
+interface TextExpansionEditorProps {
   value: unknown;
   readOnly: boolean;
-  onSave: (next: unknown) => void;
+  onSave: (next: string) => void;
   onCancel: () => void;
   originalValue?: unknown;
 }
 
-export const JsonExpansionEditor = ({
+export const TextExpansionEditor = ({
   value,
   readOnly,
   onSave,
   onCancel,
   originalValue,
-}: JsonExpansionEditorProps) => {
+}: TextExpansionEditorProps) => {
   const { t } = useTranslation();
-  const initial = useMemo(() => formatJsonForEditor(value), [value]);
+  const initial = useMemo(() => formatTextForEditor(value), [value]);
   const originalText = useMemo(
     () =>
-      originalValue !== undefined ? formatJsonForEditor(originalValue) : null,
+      originalValue !== undefined ? formatTextForEditor(originalValue) : null,
     [originalValue],
   );
   const [draft, setDraft] = useState(initial);
-  const [error, setError] = useState<string | null>(null);
   const [prevInitial, setPrevInitial] = useState(initial);
-  const [diffEnabled, setDiffEnabled] = useState(true);
+  const [diffEnabled, setDiffEnabled] = useState(false);
   const [sideBySide, setSideBySide] = useState(false);
   const { ref: rootRef, width: containerWidth } = useContainerWidth<HTMLDivElement>();
   const sideBySideFits = containerWidth >= MIN_SIDE_BY_SIDE_WIDTH;
@@ -47,22 +42,14 @@ export const JsonExpansionEditor = ({
   if (initial !== prevInitial) {
     setPrevInitial(initial);
     setDraft(initial);
-    setError(null);
   }
 
   const isDirty = draft !== initial;
-  const hasError = error !== null;
   const hasDiff = originalText !== null && originalText !== draft;
   const showDiff = diffEnabled && hasDiff && originalText !== null;
 
-  const handleChange = (next: string) => {
-    setDraft(next);
-    setError(validateJson(next));
-  };
-
   const handleSave = () => {
-    if (hasError) return;
-    onSave(parseJsonEditorValue(draft));
+    onSave(draft);
   };
 
   return (
@@ -80,10 +67,10 @@ export const JsonExpansionEditor = ({
                   ? "bg-blue-600/30 text-blue-100 border-blue-500/50"
                   : "bg-surface-secondary text-secondary border-default hover:bg-surface-tertiary"
               }`}
-              title={t("jsonInput.diff", { defaultValue: "Diff" })}
+              title={t("textInput.diff", { defaultValue: "Diff" })}
             >
               <GitCompare size={12} />
-              {t("jsonInput.diff", { defaultValue: "Diff" })}
+              {t("textInput.diff", { defaultValue: "Diff" })}
               {hasDiff && (
                 <span
                   aria-hidden
@@ -101,10 +88,10 @@ export const JsonExpansionEditor = ({
                     ? "bg-blue-600/30 text-blue-100 border-blue-500/50"
                     : "bg-surface-secondary text-secondary border-default hover:bg-surface-tertiary"
                 }`}
-                title={t("jsonInput.sideBySide", { defaultValue: "Side by side" })}
+                title={t("textInput.sideBySide", { defaultValue: "Side by side" })}
               >
                 <Columns2 size={12} />
-                {t("jsonInput.sideBySide", { defaultValue: "Side by side" })}
+                {t("textInput.sideBySide", { defaultValue: "Side by side" })}
               </button>
             )}
           </div>
@@ -113,15 +100,6 @@ export const JsonExpansionEditor = ({
         )}
         {!readOnly && (
           <div className="flex items-center gap-2">
-            {error && (
-              <span
-                className="text-red-400 mr-auto truncate"
-                title={error}
-                data-testid="json-expansion-error"
-              >
-                {error}
-              </span>
-            )}
             <button
               type="button"
               onClick={onCancel}
@@ -132,10 +110,10 @@ export const JsonExpansionEditor = ({
             <button
               type="button"
               onClick={handleSave}
-              disabled={hasError || !isDirty}
+              disabled={!isDirty}
               className="px-3 py-1 bg-blue-600 hover:bg-blue-500 disabled:opacity-40 disabled:cursor-not-allowed text-white rounded font-medium transition-colors"
             >
-              {t("jsonViewer.save")}
+              {t("textViewer.save", { defaultValue: "Save" })}
             </button>
           </div>
         )}
@@ -143,19 +121,19 @@ export const JsonExpansionEditor = ({
       <div className="h-[320px] border border-default rounded overflow-hidden">
         {showDiff ? (
           <CellDiffEditor
-            language="json"
+            language="plaintext"
             original={originalText}
             modified={draft}
-            onChange={handleChange}
+            onChange={setDraft}
             readOnly={readOnly}
             height="100%"
             renderSideBySide={renderSideBySide}
           />
         ) : (
           <CellCodeEditor
-            language="json"
+            language="plaintext"
             value={draft}
-            onChange={handleChange}
+            onChange={setDraft}
             readOnly={readOnly}
             height="100%"
           />

--- a/src/components/ui/TextInput.tsx
+++ b/src/components/ui/TextInput.tsx
@@ -1,0 +1,140 @@
+import React, { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Columns2, GitCompare } from "lucide-react";
+import { formatTextForEditor } from "../../utils/text";
+import { CellCodeEditor } from "./CellCodeEditor";
+import { CellDiffEditor } from "./CellDiffEditor";
+import {
+  MIN_SIDE_BY_SIDE_WIDTH,
+  useContainerWidth,
+} from "../../hooks/useContainerWidth";
+
+interface TextInputProps {
+  value: unknown;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  className?: string;
+  readOnly?: boolean;
+  originalValue?: unknown;
+}
+
+export const TextInput: React.FC<TextInputProps> = ({
+  value,
+  onChange,
+  placeholder,
+  className = "",
+  readOnly = false,
+  originalValue,
+}) => {
+  const { t } = useTranslation();
+  const valueKey = useMemo(() => formatTextForEditor(value), [value]);
+  const [text, setText] = useState(valueKey);
+  const [prevValueKey, setPrevValueKey] = useState(valueKey);
+  const [diffEnabled, setDiffEnabled] = useState(false);
+  const [sideBySide, setSideBySide] = useState(false);
+  const { ref: rootRef, width: containerWidth } = useContainerWidth<HTMLDivElement>();
+  const sideBySideFits = containerWidth >= MIN_SIDE_BY_SIDE_WIDTH;
+  const renderSideBySide = sideBySide && sideBySideFits;
+
+  if (valueKey !== prevValueKey) {
+    setPrevValueKey(valueKey);
+    setText(valueKey);
+  }
+
+  const applyTextChange = useCallback(
+    (next: string) => {
+      setText(next);
+      onChange(next);
+    },
+    [onChange],
+  );
+
+  const originalText = useMemo(
+    () =>
+      originalValue !== undefined ? formatTextForEditor(originalValue) : null,
+    [originalValue],
+  );
+  const hasDiff = originalText !== null && originalText !== text;
+
+  return (
+    <div ref={rootRef} className={`space-y-1 ${className}`}>
+      <div className="relative">
+        <div
+          data-testid="text-input-code"
+          className="w-full border border-strong rounded-lg overflow-hidden transition-colors"
+          style={{ height: 220 }}
+        >
+          {diffEnabled && hasDiff && originalText !== null ? (
+            <CellDiffEditor
+              language="plaintext"
+              original={originalText}
+              modified={text}
+              onChange={applyTextChange}
+              readOnly={readOnly}
+              height="100%"
+              renderSideBySide={renderSideBySide}
+            />
+          ) : (
+            <CellCodeEditor
+              language="plaintext"
+              value={text}
+              onChange={applyTextChange}
+              height="100%"
+              readOnly={readOnly}
+            />
+          )}
+        </div>
+        {placeholder && text === "" && (
+          <span
+            aria-hidden
+            className="pointer-events-none absolute top-2 left-12 text-muted text-sm font-mono"
+          >
+            {placeholder}
+          </span>
+        )}
+      </div>
+
+      {originalText !== null && (
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setDiffEnabled((v) => !v)}
+            aria-pressed={diffEnabled}
+            disabled={!hasDiff}
+            className={`px-2 py-1 text-xs rounded border transition-colors flex items-center gap-1 disabled:opacity-40 disabled:cursor-not-allowed ${
+              diffEnabled && hasDiff
+                ? "bg-blue-600/30 text-blue-100 border-blue-500/50"
+                : "bg-surface-secondary text-secondary border-default hover:bg-surface-tertiary"
+            }`}
+            title={t("textInput.diff", { defaultValue: "Diff" })}
+          >
+            <GitCompare size={12} />
+            {t("textInput.diff", { defaultValue: "Diff" })}
+            {hasDiff && (
+              <span
+                aria-hidden
+                className="ml-0.5 inline-block w-1.5 h-1.5 rounded-full bg-amber-400"
+              />
+            )}
+          </button>
+          {diffEnabled && hasDiff && sideBySideFits && (
+            <button
+              type="button"
+              onClick={() => setSideBySide((v) => !v)}
+              aria-pressed={sideBySide}
+              className={`px-2 py-1 text-xs rounded border transition-colors flex items-center gap-1 ${
+                sideBySide
+                  ? "bg-blue-600/30 text-blue-100 border-blue-500/50"
+                  : "bg-surface-secondary text-secondary border-default hover:bg-surface-tertiary"
+              }`}
+              title={t("textInput.sideBySide", { defaultValue: "Side by side" })}
+            >
+              <Columns2 size={12} />
+              {t("textInput.sideBySide", { defaultValue: "Side by side" })}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/hooks/useContainerWidth.ts
+++ b/src/hooks/useContainerWidth.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef, useState } from "react";
+
+export const useContainerWidth = <T extends HTMLElement>(): {
+  ref: React.RefObject<T | null>;
+  width: number;
+} => {
+  const ref = useRef<T | null>(null);
+  const [width, setWidth] = useState(0);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    if (typeof ResizeObserver === "undefined") {
+      setWidth(el.clientWidth);
+      return;
+    }
+    setWidth(el.clientWidth);
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setWidth(Math.round(entry.contentRect.width));
+      }
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return { ref, width };
+};
+
+// 480px ≈ ~240px per Monaco pane — minimum where each side still
+// fits a meaningful chunk of text.
+export const MIN_SIDE_BY_SIDE_WIDTH = 480;

--- a/src/hooks/useRowEditorResize.ts
+++ b/src/hooks/useRowEditorResize.ts
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const MIN_WIDTH = 320;
+const DEFAULT_WIDTH = 384;
+const STORAGE_KEY = "tabularis_row_editor_sidebar_width";
+
+const computeMaxWidth = () =>
+  typeof window === "undefined"
+    ? 1200
+    : Math.max(MIN_WIDTH, Math.floor(window.innerWidth * 0.9));
+
+export const useRowEditorResize = () => {
+  const [width, setWidth] = useState<number>(() => {
+    if (typeof window === "undefined") return DEFAULT_WIDTH;
+    const saved = window.localStorage.getItem(STORAGE_KEY);
+    if (!saved) return DEFAULT_WIDTH;
+    const parsed = parseInt(saved, 10);
+    if (Number.isNaN(parsed)) return DEFAULT_WIDTH;
+    return Math.max(MIN_WIDTH, parsed);
+  });
+  const isDragging = useRef(false);
+
+  const startResize = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    isDragging.current = true;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+
+    const handleMove = (ev: MouseEvent) => {
+      if (!isDragging.current) return;
+      const maxWidth = computeMaxWidth();
+      const next = window.innerWidth - ev.clientX;
+      if (next < MIN_WIDTH) {
+        setWidth(MIN_WIDTH);
+      } else if (next > maxWidth) {
+        setWidth(maxWidth);
+      } else {
+        setWidth(next);
+      }
+    };
+
+    const stop = () => {
+      isDragging.current = false;
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      document.removeEventListener("mousemove", handleMove);
+      document.removeEventListener("mouseup", stop);
+    };
+
+    document.addEventListener("mousemove", handleMove);
+    document.addEventListener("mouseup", stop);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(STORAGE_KEY, String(width));
+  }, [width]);
+
+  return { width, startResize };
+};

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1172,7 +1172,9 @@
     "copyPath": "Copy Path",
     "copyValue": "Copy Value",
     "addItem": "Add Item",
-    "removeItem": "Remove Item"
+    "removeItem": "Remove Item",
+    "diff": "Diff",
+    "sideBySide": "Side by side"
   },
   "jsonViewer": {
     "close": "Close",
@@ -1181,6 +1183,16 @@
   "jsonCell": {
     "expand": "Toggle inline JSON tree",
     "openViewer": "Open JSON viewer"
+  },
+  "textCell": {
+    "expand": "Toggle inline text editor"
+  },
+  "textInput": {
+    "diff": "Diff",
+    "sideBySide": "Side by side"
+  },
+  "textViewer": {
+    "save": "Save"
   },
   "rowEditor": {
     "title": "Edit Row",

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -1,0 +1,44 @@
+const TEXT_TYPES = [
+  "TEXT",
+  "TINYTEXT",
+  "MEDIUMTEXT",
+  "LONGTEXT",
+  "NTEXT",
+  "CLOB",
+  "CHARACTER VARYING",
+  "VARCHAR",
+  "NVARCHAR",
+  "CHARACTER",
+  "CHAR",
+  "NCHAR",
+  "STRING",
+];
+
+export const LONG_TEXT_THRESHOLD = 80;
+
+// Substring match so parameterised forms like "VARCHAR(255)" or
+// "CHARACTER VARYING(50)" still resolve as text.
+export function isTextColumn(dataType: string | undefined): boolean {
+  if (!dataType) return false;
+  const normalized = dataType.toUpperCase();
+  return TEXT_TYPES.some((type) => normalized.includes(type));
+}
+
+export function isLongTextValue(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  if (value.length > LONG_TEXT_THRESHOLD) return true;
+  return value.includes("\n");
+}
+
+export function isLongTextCellTarget(
+  colType: string | undefined,
+  value: unknown,
+): boolean {
+  if (!isTextColumn(colType)) return false;
+  return isLongTextValue(value);
+}
+
+export function formatTextForEditor(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  return String(value);
+}

--- a/tests/components/ui/CellCodeEditor.test.tsx
+++ b/tests/components/ui/CellCodeEditor.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { JsonCodeEditor } from "../../../src/components/ui/JsonCodeEditor";
+import { CellCodeEditor } from "../../../src/components/ui/CellCodeEditor";
 import { ThemeContext, type ThemeContextType } from "../../../src/contexts/ThemeContext";
 import type { Theme } from "../../../src/types/theme";
 import type { ReactNode } from "react";
@@ -23,7 +23,6 @@ vi.mock("@monaco-editor/react", () => {
     __esModule: true,
     default: (props: MonacoMockProps) => {
       lastProps.current = props;
-      // Invoke beforeMount with a stub monaco instance
       props.beforeMount?.({});
       return (
         <textarea
@@ -74,22 +73,32 @@ const withTheme =
     </ThemeContext.Provider>
   );
 
-describe("JsonCodeEditor", () => {
+describe("CellCodeEditor", () => {
   beforeEach(() => {
     lastProps.current = null;
     vi.clearAllMocks();
   });
 
-  it("renders with the provided value and json language", () => {
-    render(<JsonCodeEditor value='{"a":1}' onChange={vi.fn()} />);
+  it("defaults to the json language when language is omitted", () => {
+    render(<CellCodeEditor value='{"a":1}' onChange={vi.fn()} />);
 
     const editor = screen.getByTestId("monaco-editor");
     expect(editor).toHaveValue('{"a":1}');
     expect(editor.getAttribute("data-language")).toBe("json");
   });
 
+  it("renders with the plaintext language when requested", () => {
+    render(
+      <CellCodeEditor value="hello" onChange={vi.fn()} language="plaintext" />,
+    );
+
+    expect(
+      screen.getByTestId("monaco-editor").getAttribute("data-language"),
+    ).toBe("plaintext");
+  });
+
   it("falls back to vs-dark when no ThemeContext is present", () => {
-    render(<JsonCodeEditor value="" onChange={vi.fn()} />);
+    render(<CellCodeEditor value="" onChange={vi.fn()} />);
 
     expect(screen.getByTestId("monaco-editor").getAttribute("data-theme")).toBe(
       "vs-dark",
@@ -97,7 +106,7 @@ describe("JsonCodeEditor", () => {
   });
 
   it("uses currentTheme.id when ThemeContext provides one", () => {
-    render(<JsonCodeEditor value="" onChange={vi.fn()} />, {
+    render(<CellCodeEditor value="" onChange={vi.fn()} />, {
       wrapper: withTheme(makeTheme("tabularis-dark")),
     });
 
@@ -108,7 +117,7 @@ describe("JsonCodeEditor", () => {
 
   it("forwards edits through onChange", () => {
     const onChange = vi.fn();
-    render(<JsonCodeEditor value="" onChange={onChange} />);
+    render(<CellCodeEditor value="" onChange={onChange} />);
 
     fireEvent.change(screen.getByTestId("monaco-editor"), {
       target: { value: '{"updated":true}' },
@@ -119,7 +128,7 @@ describe("JsonCodeEditor", () => {
 
   it("passes an empty string when Monaco reports undefined", () => {
     const onChange = vi.fn();
-    render(<JsonCodeEditor value="x" onChange={onChange} />);
+    render(<CellCodeEditor value="x" onChange={onChange} />);
 
     lastProps.current?.onChange?.(undefined);
 
@@ -129,7 +138,7 @@ describe("JsonCodeEditor", () => {
   it("surfaces validation markers via onValidate", () => {
     const onValidate = vi.fn();
     render(
-      <JsonCodeEditor value="" onChange={vi.fn()} onValidate={onValidate} />,
+      <CellCodeEditor value="" onChange={vi.fn()} onValidate={onValidate} />,
     );
 
     const markers = [{ message: "bad", severity: 8 }];
@@ -138,8 +147,8 @@ describe("JsonCodeEditor", () => {
     expect(onValidate).toHaveBeenCalledWith(markers);
   });
 
-  it("configures Monaco options per spec", () => {
-    render(<JsonCodeEditor value="" onChange={vi.fn()} />);
+  it("configures Monaco options per spec for json", () => {
+    render(<CellCodeEditor value="" onChange={vi.fn()} />);
 
     const opts = lastProps.current?.options ?? {};
     expect(opts).toMatchObject({
@@ -152,8 +161,16 @@ describe("JsonCodeEditor", () => {
     });
   });
 
+  it("disables formatOnPaste for plaintext", () => {
+    render(
+      <CellCodeEditor value="" onChange={vi.fn()} language="plaintext" />,
+    );
+
+    expect(lastProps.current?.options?.formatOnPaste).toBe(false);
+  });
+
   it("respects the readOnly prop", () => {
-    render(<JsonCodeEditor value="" onChange={vi.fn()} readOnly />);
+    render(<CellCodeEditor value="" onChange={vi.fn()} readOnly />);
 
     expect(
       screen.getByTestId("monaco-editor").getAttribute("data-readonly"),
@@ -162,7 +179,7 @@ describe("JsonCodeEditor", () => {
   });
 
   it("forwards the height prop", () => {
-    render(<JsonCodeEditor value="" onChange={vi.fn()} height="240px" />);
+    render(<CellCodeEditor value="" onChange={vi.fn()} height="240px" />);
 
     expect(lastProps.current?.height).toBe("240px");
   });

--- a/tests/components/ui/JsonExpansionEditor.test.tsx
+++ b/tests/components/ui/JsonExpansionEditor.test.tsx
@@ -2,8 +2,8 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { JsonExpansionEditor } from "../../../src/components/ui/JsonExpansionEditor";
 
-vi.mock("../../../src/components/ui/JsonCodeEditor", () => ({
-  JsonCodeEditor: ({
+vi.mock("../../../src/components/ui/CellCodeEditor", () => ({
+  CellCodeEditor: ({
     value,
     onChange,
     readOnly,

--- a/tests/components/ui/JsonInput.test.tsx
+++ b/tests/components/ui/JsonInput.test.tsx
@@ -17,8 +17,8 @@ interface TreeViewMockProps {
 const codeProps: { current: CodeEditorMockProps | null } = { current: null };
 const treeProps: { current: TreeViewMockProps | null } = { current: null };
 
-vi.mock("../../../src/components/ui/JsonCodeEditor", () => ({
-  JsonCodeEditor: (props: CodeEditorMockProps) => {
+vi.mock("../../../src/components/ui/CellCodeEditor", () => ({
+  CellCodeEditor: (props: CodeEditorMockProps) => {
     codeProps.current = props;
     return (
       <textarea
@@ -190,7 +190,7 @@ describe("JsonInput", () => {
   });
 
   describe("readOnly mode", () => {
-    it("forwards readOnly to JsonCodeEditor in code mode", () => {
+    it("forwards readOnly to CellCodeEditor in code mode", () => {
       render(<JsonInput value={{ a: 1 }} onChange={vi.fn()} readOnly />);
 
       expect(codeProps.current?.readOnly).toBe(true);

--- a/tests/hooks/useRowEditorResize.test.ts
+++ b/tests/hooks/useRowEditorResize.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useRowEditorResize } from "../../src/hooks/useRowEditorResize";
+
+const STORAGE_KEY = "tabularis_row_editor_sidebar_width";
+
+const createLocalStorageStub = () => {
+  const store = new Map<string, string>();
+  return {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => {
+      store.set(k, String(v));
+    },
+    removeItem: (k: string) => {
+      store.delete(k);
+    },
+    clear: () => store.clear(),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+};
+
+describe("useRowEditorResize", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      writable: true,
+      value: createLocalStorageStub(),
+    });
+    vi.restoreAllMocks();
+    // Pin innerWidth so clamps are deterministic.
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      writable: true,
+      value: 1600,
+    });
+  });
+
+  it("initializes with the default width when localStorage is empty", () => {
+    const { result } = renderHook(() => useRowEditorResize());
+    expect(result.current.width).toBe(384);
+  });
+
+  it("reads a persisted width from localStorage", () => {
+    window.localStorage.setItem(STORAGE_KEY, "720");
+    const { result } = renderHook(() => useRowEditorResize());
+    expect(result.current.width).toBe(720);
+  });
+
+  it("never starts below the minimum even if localStorage was corrupted", () => {
+    window.localStorage.setItem(STORAGE_KEY, "50");
+    const { result } = renderHook(() => useRowEditorResize());
+    expect(result.current.width).toBe(320);
+  });
+
+  it("widens when the mouse moves left (toward smaller clientX)", () => {
+    const { result } = renderHook(() => useRowEditorResize());
+
+    act(() => {
+      result.current.startResize({
+        preventDefault: vi.fn(),
+      } as unknown as React.MouseEvent);
+    });
+    expect(document.body.style.cursor).toBe("col-resize");
+
+    // clientX = 1000  →  width = 1600 - 1000 = 600
+    act(() => {
+      document.dispatchEvent(new MouseEvent("mousemove", { clientX: 1000 }));
+    });
+    expect(result.current.width).toBe(600);
+  });
+
+  it("clamps below the minimum width", () => {
+    const { result } = renderHook(() => useRowEditorResize());
+
+    act(() => {
+      result.current.startResize({
+        preventDefault: vi.fn(),
+      } as unknown as React.MouseEvent);
+    });
+
+    // clientX = 1500  →  raw width = 100, below MIN 320
+    act(() => {
+      document.dispatchEvent(new MouseEvent("mousemove", { clientX: 1500 }));
+    });
+    expect(result.current.width).toBe(320);
+  });
+
+  it("clamps above the maximum width (90% of viewport)", () => {
+    const { result } = renderHook(() => useRowEditorResize());
+
+    act(() => {
+      result.current.startResize({
+        preventDefault: vi.fn(),
+      } as unknown as React.MouseEvent);
+    });
+
+    // clientX = 0  →  raw width = 1600, max is floor(1600 * 0.9) = 1440
+    act(() => {
+      document.dispatchEvent(new MouseEvent("mousemove", { clientX: 0 }));
+    });
+    expect(result.current.width).toBe(1440);
+  });
+
+  it("stops resizing on mouseup and persists the final width", () => {
+    const { result } = renderHook(() => useRowEditorResize());
+
+    act(() => {
+      result.current.startResize({
+        preventDefault: vi.fn(),
+      } as unknown as React.MouseEvent);
+    });
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent("mousemove", { clientX: 1100 }));
+    });
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent("mouseup"));
+    });
+
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("500");
+  });
+});

--- a/tests/utils/text.test.ts
+++ b/tests/utils/text.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import {
+  LONG_TEXT_THRESHOLD,
+  formatTextForEditor,
+  isLongTextCellTarget,
+  isLongTextValue,
+  isTextColumn,
+} from "../../src/utils/text";
+
+describe("text", () => {
+  describe("isTextColumn", () => {
+    it("matches common text aliases case-insensitively", () => {
+      expect(isTextColumn("TEXT")).toBe(true);
+      expect(isTextColumn("text")).toBe(true);
+      expect(isTextColumn("LongText")).toBe(true);
+      expect(isTextColumn("MEDIUMTEXT")).toBe(true);
+      expect(isTextColumn("TINYTEXT")).toBe(true);
+      expect(isTextColumn("NTEXT")).toBe(true);
+      expect(isTextColumn("CLOB")).toBe(true);
+      expect(isTextColumn("STRING")).toBe(true);
+    });
+
+    it("matches parameterised varchar / character varying", () => {
+      expect(isTextColumn("VARCHAR(255)")).toBe(true);
+      expect(isTextColumn("varchar(50)")).toBe(true);
+      expect(isTextColumn("character varying(100)")).toBe(true);
+      expect(isTextColumn("NVARCHAR(MAX)")).toBe(true);
+      expect(isTextColumn("CHAR(36)")).toBe(true);
+      expect(isTextColumn("NCHAR(10)")).toBe(true);
+    });
+
+    it("returns false for non-text types", () => {
+      expect(isTextColumn("INTEGER")).toBe(false);
+      expect(isTextColumn("BIGINT")).toBe(false);
+      expect(isTextColumn("BOOLEAN")).toBe(false);
+      expect(isTextColumn("JSON")).toBe(false);
+      expect(isTextColumn("JSONB")).toBe(false);
+      expect(isTextColumn("BLOB")).toBe(false);
+      expect(isTextColumn("BYTEA")).toBe(false);
+      expect(isTextColumn("DATE")).toBe(false);
+      expect(isTextColumn("TIMESTAMP")).toBe(false);
+    });
+
+    it("returns false for missing or empty type", () => {
+      expect(isTextColumn(undefined)).toBe(false);
+      expect(isTextColumn("")).toBe(false);
+    });
+  });
+
+  describe("isLongTextValue", () => {
+    it("returns false for non-string values", () => {
+      expect(isLongTextValue(null)).toBe(false);
+      expect(isLongTextValue(undefined)).toBe(false);
+      expect(isLongTextValue(123)).toBe(false);
+      expect(isLongTextValue(true)).toBe(false);
+      expect(isLongTextValue(["a"])) .toBe(false);
+      expect(isLongTextValue({ a: 1 })).toBe(false);
+    });
+
+    it("returns false for short single-line strings", () => {
+      expect(isLongTextValue("")).toBe(false);
+      expect(isLongTextValue("hello")).toBe(false);
+      expect(isLongTextValue("a".repeat(LONG_TEXT_THRESHOLD))).toBe(false);
+    });
+
+    it("returns true for strings beyond the threshold", () => {
+      expect(isLongTextValue("a".repeat(LONG_TEXT_THRESHOLD + 1))).toBe(true);
+    });
+
+    it("returns true for strings containing a newline regardless of length", () => {
+      expect(isLongTextValue("a\nb")).toBe(true);
+      expect(isLongTextValue("line1\nline2")).toBe(true);
+    });
+  });
+
+  describe("isLongTextCellTarget", () => {
+    it("requires both a text column AND a long value", () => {
+      expect(isLongTextCellTarget("TEXT", "short")).toBe(false);
+      expect(
+        isLongTextCellTarget("TEXT", "a".repeat(LONG_TEXT_THRESHOLD + 1)),
+      ).toBe(true);
+      expect(isLongTextCellTarget("VARCHAR(255)", "line1\nline2")).toBe(true);
+    });
+
+    it("returns false for non-text columns even with long values", () => {
+      expect(
+        isLongTextCellTarget("INTEGER", "a".repeat(LONG_TEXT_THRESHOLD + 1)),
+      ).toBe(false);
+      expect(isLongTextCellTarget("JSON", "very long string\nwith newlines")).toBe(
+        false,
+      );
+      expect(isLongTextCellTarget("BLOB", "x".repeat(200))).toBe(false);
+    });
+
+    it("returns false when the column type is missing", () => {
+      expect(isLongTextCellTarget(undefined, "x".repeat(200))).toBe(false);
+    });
+
+    it("returns false for null / non-string values regardless of column", () => {
+      expect(isLongTextCellTarget("TEXT", null)).toBe(false);
+      expect(isLongTextCellTarget("TEXT", undefined)).toBe(false);
+      expect(isLongTextCellTarget("TEXT", 12345)).toBe(false);
+    });
+  });
+
+  describe("formatTextForEditor", () => {
+    it("returns empty string for null and undefined", () => {
+      expect(formatTextForEditor(null)).toBe("");
+      expect(formatTextForEditor(undefined)).toBe("");
+    });
+
+    it("returns strings unchanged", () => {
+      expect(formatTextForEditor("hello")).toBe("hello");
+      expect(formatTextForEditor("line1\nline2")).toBe("line1\nline2");
+    });
+
+    it("stringifies primitives", () => {
+      expect(formatTextForEditor(42)).toBe("42");
+      expect(formatTextForEditor(true)).toBe("true");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Extends the chevron-expand + Monaco diff affordance (PR #181) from JSON/JSONB cells to plain string columns whose value is long enough to be cumbersome inline. Closes #207.

- New `isLongTextCellTarget`: text-like column AND value > 80 chars or contains a newline. Scoped so JSON / BLOB / geometry / date paths are untouched.
- `TextCell` renders a single-line preview with a chevron (multi-line values get a `⏎` substitution). Per request, **no separate viewer window** for text — the chevron is the only entry point.
- `TextExpansionEditor` opens inline below the row: Monaco in `plaintext` mode with a manual Diff toggle (default off) against the original cell value.
- `FieldEditor` swaps the plain textarea for a Monaco-based `TextInput` when the value is long, giving the sidebar a diff toggle too.
- **Side-by-side toggle** added when diff is active — applied uniformly to JSON and text, in both the inline expansion and the input panel. Default stays unified.

## Files

- New: `src/utils/text.ts`, `tests/utils/text.test.ts`
- New: `TextCell`, `TextCodeEditor`, `TextDiffEditor`, `TextExpansionEditor`, `TextInput`
- Modified: `DataGrid.tsx` (expansion state generalised with a `kind` discriminator; JSON path unchanged), `FieldEditor.tsx`, `JsonInput.tsx`, `JsonExpansionEditor.tsx` (side-by-side toggle), `i18n/locales/en.json`
- Seed: `demo/init/{mysql,postgres}/04-text-demo.sql` — `tabularis_demo.text_demo`, 9 rows covering every edge case below

## Test setup

```fish
docker compose -f demo/docker-compose.yml down -v
docker compose -f demo/docker-compose.yml up -d
```

Then open the `tabularis_demo` database (MySQL or Postgres) and browse the `text_demo` table.

## Test plan

Automated:
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test tests/utils/text.test.ts` (15/15)
- [x] `pnpm build`

Manual — DataGrid chevron + inline expansion, by row in `text_demo`:
- [ ] Row 1 (`short`): no chevron on any column — values stay in the inline textarea editor on double-click.
- [ ] Row 2 (`long single-line`): `body` shows a chevron; preview is single-line; expand → plain Monaco editor, no `⏎` symbol.
- [ ] Row 3 (`multi-line short`): chevron triggers via newline branch even though length < 80; preview shows ` ⏎ ` separators.
- [ ] Row 4 (`markdown article`): expand `body`, edit a heading, toggle Diff on → modified lines highlighted; toggle Side-by-side → two-pane view; cancel restores original.
- [ ] Row 5 (`code snippet`): expand `body`, change indentation on one line, Diff toggle shows whitespace-aware hunks.
- [ ] Row 6 (`SQL query`): expand `body`, edit a clause, save → row gets the pending-change indicator; refresh confirms persistence.
- [ ] Row 7 (`long varchar`): chevron fires on the **`summary` VARCHAR(500)** column, not just on TEXT.
- [ ] Row 8 (`all null`): no chevron anywhere; null cells render the regular `NULL` placeholder.
- [ ] Row 9 (`unicode + emoji`): Monaco renders multi-script + emoji glyphs correctly in editor, Diff, and Side-by-side.

Manual — RowEditorSidebar (open via context menu → "Open Sidebar Editor"):
- [ ] Long fields (`body` on rows 2/4/5/6/9, `summary` on row 7) render the Monaco-based `TextInput` with the Diff / Side-by-side toggles.
- [ ] Short fields (`label` everywhere, `summary` on row 1) keep the plain textarea.

Regressions:
- [ ] JSON cells (`tabularis_demo.json_demo`) still get the chevron, the open-viewer window button, and the same JSON tokenizer — unchanged from `main`.
- [ ] BLOB / geometry / date columns unchanged.