### PR TITLE
perf: eliminate per-query disk I/O and unblock result display from me…

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -310,17 +310,25 @@ pub fn find_connection_by_id<R: Runtime>(
     app: &AppHandle<R>,
     id: &str,
 ) -> Result<SavedConnection, String> {
-    let path = get_config_path(app)?;
-    if !path.exists() {
-        return Err("Connection not found".into());
-    }
-    // Use persistence module to properly load connections (handles both old and new formats)
-    let conn_file = persistence::load_connections_file(&path)?;
-    let mut conn = conn_file
-        .connections
-        .into_iter()
-        .find(|c| c.id == id)
-        .ok_or_else(|| "Connection not found".to_string())?;
+    let conn_cache =
+        app.state::<std::sync::Arc<crate::connection_cache::ConnectionCache>>();
+
+    let mut conn = match conn_cache.lookup(id) {
+        crate::connection_cache::CacheLookup::Hit(c) => c,
+        crate::connection_cache::CacheLookup::Miss => {
+            return Err("Connection not found".to_string())
+        }
+        crate::connection_cache::CacheLookup::Cold => {
+            let path = get_config_path(app)?;
+            let conn_file = persistence::load_connections_file(&path).unwrap_or_default();
+            conn_cache.populate(&conn_file.connections);
+            conn_file
+                .connections
+                .into_iter()
+                .find(|c| c.id == id)
+                .ok_or_else(|| "Connection not found".to_string())?
+        }
+    };
 
     // Load passwords from keychain if needed, via the in-memory cache.
     // On a warm cache hit this is a HashMap lookup (nanoseconds); on a cold miss
@@ -351,6 +359,19 @@ pub fn find_connection_by_id<R: Runtime>(
     }
 
     Ok(conn)
+}
+
+/// Write the connections file and invalidate the in-memory connection cache so
+/// the next `find_connection_by_id` call re-reads fresh data from disk.
+fn save_connections_and_invalidate<R: Runtime>(
+    app: &AppHandle<R>,
+    path: &std::path::Path,
+    file: &crate::models::ConnectionsFile,
+) -> Result<(), String> {
+    persistence::save_connections_file(path, file)?;
+    app.state::<std::sync::Arc<crate::connection_cache::ConnectionCache>>()
+        .invalidate();
+    Ok(())
 }
 
 // --- Commands ---
@@ -519,7 +540,7 @@ pub async fn save_connection<R: Runtime>(
         detect_json_in_text_columns,
     };
     conn_file.connections.push(new_conn.clone());
-    persistence::save_connections_file(&path, &conn_file)?;
+    save_connections_and_invalidate(&app, &path, &conn_file)?;
 
     log::info!("Connection saved successfully: {} (ID: {})", name, id);
 
@@ -551,7 +572,7 @@ pub async fn delete_connection<R: Runtime>(app: AppHandle<R>, id: String) -> Res
     let cache = app.state::<std::sync::Arc<crate::credential_cache::CredentialCache>>();
     credential_cache::invalidate_all_for_connection(&cache, &id);
 
-    persistence::save_connections_file(&path, &conn_file)?;
+    save_connections_and_invalidate(&app, &path, &conn_file)?;
 
     // Clean up query history for this connection
     if let Err(e) = crate::query_history::remove_history_for_connection(&app, &id) {
@@ -635,7 +656,7 @@ pub async fn update_connection<R: Runtime>(
 
     conn_file.connections[conn_idx] = updated.clone();
 
-    persistence::save_connections_file(&path, &conn_file)?;
+    save_connections_and_invalidate(&app, &path, &conn_file)?;
 
     // On single→multi transition, associate existing favorites/history (with no
     // database set) to the original single database name.
@@ -751,7 +772,7 @@ pub async fn duplicate_connection<R: Runtime>(
 
     conn_file.connections.push(new_conn.clone());
 
-    persistence::save_connections_file(&path, &conn_file)?;
+    save_connections_and_invalidate(&app, &path, &conn_file)?;
 
     let mut returned_conn = new_conn;
     // Return with passwords for frontend consistency
@@ -895,7 +916,7 @@ async fn migrate_ssh_connections<R: Runtime>(app: &AppHandle<R>) -> Result<(), S
 
     // Save migrated connections using new format (preserving groups)
     conn_file.connections = migrated_connections;
-    persistence::save_connections_file(&conn_path, &conn_file)?;
+    save_connections_and_invalidate(app, &conn_path, &conn_file)?;
 
     println!(
         "[Migration] Successfully migrated {} SSH connections",
@@ -3339,7 +3360,7 @@ pub async fn create_connection_group<R: Runtime>(
     };
 
     file.groups.push(group.clone());
-    persistence::save_connections_file(&path, &file)?;
+    save_connections_and_invalidate(&app, &path, &file)?;
 
     Ok(group)
 }
@@ -3372,7 +3393,7 @@ pub async fn update_connection_group<R: Runtime>(
     }
 
     let updated = group.clone();
-    persistence::save_connections_file(&path, &file)?;
+    save_connections_and_invalidate(&app, &path, &file)?;
 
     Ok(updated)
 }
@@ -3394,7 +3415,7 @@ pub async fn delete_connection_group<R: Runtime>(
 
     // Remove the group
     file.groups.retain(|g| g.id != id);
-    persistence::save_connections_file(&path, &file)?;
+    save_connections_and_invalidate(&app, &path, &file)?;
 
     Ok(())
 }
@@ -3421,7 +3442,7 @@ pub async fn move_connection_to_group<R: Runtime>(
     }
 
     let updated = conn.clone();
-    persistence::save_connections_file(&path, &file)?;
+    save_connections_and_invalidate(&app, &path, &file)?;
 
     Ok(updated)
 }
@@ -3440,7 +3461,7 @@ pub async fn reorder_groups<R: Runtime>(
         }
     }
 
-    persistence::save_connections_file(&path, &file)?;
+    save_connections_and_invalidate(&app, &path, &file)?;
     Ok(())
 }
 
@@ -3458,7 +3479,7 @@ pub async fn reorder_connections_in_group<R: Runtime>(
         }
     }
 
-    persistence::save_connections_file(&path, &file)?;
+    save_connections_and_invalidate(&app, &path, &file)?;
     Ok(())
 }
 
@@ -3643,7 +3664,7 @@ pub async fn import_connections_payload<R: Runtime>(
     }
 
     // Save files
-    persistence::save_connections_file(&conn_path, &current_file)?;
+    save_connections_and_invalidate(&app, &conn_path, &current_file)?;
     let ssh_json = serde_json::to_string_pretty(&current_ssh).map_err(|e| e.to_string())?;
     fs::write(ssh_path, ssh_json).map_err(|e| e.to_string())?;
 

--- a/src-tauri/src/connection_cache.rs
+++ b/src-tauri/src/connection_cache.rs
@@ -1,0 +1,57 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use crate::models::SavedConnection;
+
+pub enum CacheLookup {
+    Hit(SavedConnection),
+    Miss,
+    Cold,
+}
+
+/// In-memory cache for saved connections, keyed by connection ID.
+///
+/// Uses `std::sync::Mutex` (not `tokio::sync::Mutex`) because all critical
+/// sections are pure HashMap operations (nanoseconds) and are never held
+/// across `.await` points.
+pub struct ConnectionCache {
+    entries: Mutex<Option<HashMap<String, SavedConnection>>>,
+}
+
+impl Default for ConnectionCache {
+    fn default() -> Self {
+        Self {
+            entries: Mutex::new(None),
+        }
+    }
+}
+
+impl ConnectionCache {
+    /// Atomically look up a connection by ID.
+    /// Returns Cold when the cache has never been populated, Miss when it has
+    /// been populated but the ID is absent, Hit when found.
+    pub fn lookup(&self, id: &str) -> CacheLookup {
+        let guard = self.entries.lock().unwrap();
+        match guard.as_ref() {
+            None => CacheLookup::Cold,
+            Some(map) => match map.get(id) {
+                Some(conn) => CacheLookup::Hit(conn.clone()),
+                None => CacheLookup::Miss,
+            },
+        }
+    }
+
+    /// Fill the cache from a full connection list (called on Cold miss).
+    pub fn populate(&self, connections: &[SavedConnection]) {
+        let map = connections
+            .iter()
+            .map(|c| (c.id.clone(), c.clone()))
+            .collect();
+        *self.entries.lock().unwrap() = Some(map);
+    }
+
+    /// Discard cached data. Must be called after any write to the connections file.
+    pub fn invalidate(&self) {
+        *self.entries.lock().unwrap() = None;
+    }
+}

--- a/src-tauri/src/connection_cache_tests.rs
+++ b/src-tauri/src/connection_cache_tests.rs
@@ -1,0 +1,120 @@
+#[cfg(test)]
+mod tests {
+    use crate::connection_cache::{CacheLookup, ConnectionCache};
+    use crate::models::{ConnectionParams, SavedConnection};
+
+    fn make_connection(id: &str, name: &str) -> SavedConnection {
+        SavedConnection {
+            id: id.to_string(),
+            name: name.to_string(),
+            params: ConnectionParams::default(),
+            group_id: None,
+            sort_order: None,
+            detect_json_in_text_columns: None,
+        }
+    }
+
+    #[test]
+    fn lookup_on_fresh_cache_returns_cold() {
+        let cache = ConnectionCache::default();
+        assert!(matches!(cache.lookup("any-id"), CacheLookup::Cold));
+    }
+
+    #[test]
+    fn lookup_after_populate_with_present_id_returns_hit() {
+        let cache = ConnectionCache::default();
+        cache.populate(&[make_connection("c1", "First")]);
+
+        match cache.lookup("c1") {
+            CacheLookup::Hit(conn) => {
+                assert_eq!(conn.id, "c1");
+                assert_eq!(conn.name, "First");
+            }
+            other => panic!("expected Hit, got {:?}", discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn lookup_after_populate_with_absent_id_returns_miss() {
+        let cache = ConnectionCache::default();
+        cache.populate(&[make_connection("c1", "First")]);
+
+        assert!(matches!(cache.lookup("missing"), CacheLookup::Miss));
+    }
+
+    #[test]
+    fn populate_with_empty_slice_yields_miss_not_cold() {
+        let cache = ConnectionCache::default();
+        cache.populate(&[]);
+
+        assert!(matches!(cache.lookup("anything"), CacheLookup::Miss));
+    }
+
+    #[test]
+    fn populate_replaces_previous_entries() {
+        let cache = ConnectionCache::default();
+        cache.populate(&[make_connection("c1", "First")]);
+        cache.populate(&[make_connection("c2", "Second")]);
+
+        assert!(matches!(cache.lookup("c1"), CacheLookup::Miss));
+        assert!(matches!(cache.lookup("c2"), CacheLookup::Hit(_)));
+    }
+
+    #[test]
+    fn populate_with_duplicate_ids_keeps_last_occurrence() {
+        let cache = ConnectionCache::default();
+        cache.populate(&[
+            make_connection("c1", "First"),
+            make_connection("c1", "Override"),
+        ]);
+
+        match cache.lookup("c1") {
+            CacheLookup::Hit(conn) => assert_eq!(conn.name, "Override"),
+            _ => panic!("expected Hit"),
+        }
+    }
+
+    #[test]
+    fn invalidate_after_populate_returns_to_cold() {
+        let cache = ConnectionCache::default();
+        cache.populate(&[make_connection("c1", "First")]);
+        cache.invalidate();
+
+        assert!(matches!(cache.lookup("c1"), CacheLookup::Cold));
+    }
+
+    #[test]
+    fn invalidate_on_cold_cache_is_noop() {
+        let cache = ConnectionCache::default();
+        cache.invalidate();
+
+        assert!(matches!(cache.lookup("c1"), CacheLookup::Cold));
+    }
+
+    #[test]
+    fn lookup_returns_independent_clone() {
+        let cache = ConnectionCache::default();
+        cache.populate(&[make_connection("c1", "First")]);
+
+        let first_hit = match cache.lookup("c1") {
+            CacheLookup::Hit(c) => c,
+            _ => panic!("expected Hit"),
+        };
+        // Mutating the returned clone must not affect what the cache stores.
+        let mut mutated = first_hit;
+        mutated.name = "Mutated".to_string();
+
+        match cache.lookup("c1") {
+            CacheLookup::Hit(c) => assert_eq!(c.name, "First"),
+            _ => panic!("expected Hit on second lookup"),
+        }
+    }
+
+    fn discriminant(lookup: &CacheLookup) -> &'static str {
+        match lookup {
+            CacheLookup::Hit(_) => "Hit",
+            CacheLookup::Miss => "Miss",
+            CacheLookup::Cold => "Cold",
+        }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,8 @@ pub mod clipboard_import;
 pub mod commands;
 pub mod config;
 pub mod connection_cache;
+#[cfg(test)]
+pub mod connection_cache_tests;
 pub mod credential_cache;
 pub mod dump_commands; // Added
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ pub mod cli;
 pub mod clipboard_import;
 pub mod commands;
 pub mod config;
+pub mod connection_cache;
 pub mod credential_cache;
 pub mod dump_commands; // Added
 #[cfg(test)]
@@ -160,6 +161,9 @@ pub fn run() {
         .manage(log_buffer)
         .manage(std::sync::Arc::new(
             credential_cache::CredentialCache::default(),
+        ))
+        .manage(std::sync::Arc::new(
+            connection_cache::ConnectionCache::default(),
         ))
         .manage(explain_import::PendingExplainFile::default())
         .manage(json_viewer::JsonViewerStore::default())

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -700,14 +700,6 @@ export const Editor = () => {
           }
         }
 
-        if (tableName) {
-          // Wait for PK column to be fetched before showing results
-          await fetchPkColumn(tableName, targetTabId, targetTab?.schema ?? undefined);
-        } else {
-          // No table, explicitly set pkColumn to null (read-only mode)
-          updateTab(targetTabId, { pkColumn: null });
-        }
-
         const resultWithCount =
           res.pagination &&
           res.pagination.total_rows === null &&
@@ -727,6 +719,13 @@ export const Editor = () => {
           isLoading: false,
           activeTable: tableName || null,
         });
+
+        if (tableName) {
+          // Fetch column metadata in the background; tab updates when ready
+          fetchPkColumn(tableName, targetTabId, targetTab?.schema ?? undefined);
+        } else {
+          updateTab(targetTabId, { pkColumn: null });
+        }
 
         if (shouldRecordHistory) {
           addHistoryEntry(


### PR DESCRIPTION
Problem

  Two independent issues were adding latency to every query execution:

  1. Connections file read on every query (backend)

  find_connection_by_id — called for every query, export, explain, schema command, etc. — unconditionally read and
  parsed the entire connections JSON file from disk using blocking std::fs::read_to_string on a Tokio worker thread.
  On SSH connections, expand_ssh_connection_params triggered a second file read for the SSH config. This happened even
   when the connection hadn't changed.

  2. Column/FK metadata fetch blocking result display (frontend)

  After each query completed, runQuery awaited fetchPkColumn — which fires parallel get_columns + get_foreign_keys
  backend calls — before calling updateTab with the query result. The result grid was invisible until both metadata
  requests finished. On a remote database, those two information_schema round-trips could add 100–500 ms of perceived
  query latency.

  Changes

  src-tauri/src/connection_cache.rs (new)

  Introduces ConnectionCache: a Mutex<Option<HashMap<String, SavedConnection>>> registered as Tauri state. Exposes
  three operations:
  - lookup(id) — returns Hit, Miss, or Cold in a single lock acquisition
  - populate(&[SavedConnection]) — fills the map on a cold miss
  - invalidate() — drops the map after any write to the connections file

  src-tauri/src/commands.rs

  - find_connection_by_id now checks the cache first. A cache hit is an O(1) HashMap lookup with no disk I/O. A cold
  miss reads the file once and warms the cache for all subsequent calls.
  - New save_connections_and_invalidate helper wraps every persistence::save_connections_file call and drops the cache
   afterwards, so stale data is never served. Replaces all 12 call sites.

  src/pages/Editor.tsx

  Reorders the post-query flow so updateTab with the result fires immediately after the query returns. fetchPkColumn
  is then started without await — it updates pkColumn, columnMetadata, and foreignKeys in the background via its own
  updateTab call. Both updates target independent tab keys, so the React functional state updater merges them
  correctly without races.

  Notes

  - The connection cache is intentionally whole-map invalidated (not per-key updated) on writes. Connections are saved
   infrequently; the simplicity is worth it.
  - fetchPkColumn already handles its own errors and calls updateTab({ pkColumn: null }) in its catch block, so
  removing the await does not affect error handling.