### PR TITLE
fix(settings): center SettingToggle knob

### DIFF
--- a/src/components/settings/SettingControls.tsx
+++ b/src/components/settings/SettingControls.tsx
@@ -72,11 +72,6 @@ export function SettingRow({
 
 /* ── Toggle ── */
 
-const TOGGLE_CLASS =
-  "w-10 h-6 rounded-full appearance-none relative transition-colors bg-base border border-strong " +
-  "after:content-[''] after:absolute after:top-1 after:left-1 after:w-4 after:h-4 after:bg-white after:rounded-full after:transition-transform " +
-  "checked:bg-blue-600 checked:border-blue-600 checked:after:translate-x-4";
-
 interface SettingToggleProps {
   checked: boolean;
   onChange: (checked: boolean) => void;
@@ -89,16 +84,28 @@ export function SettingToggle({
   disabled,
 }: SettingToggleProps) {
   return (
-    <input
-      type="checkbox"
-      checked={checked}
-      disabled={disabled}
-      onChange={(e) => onChange(e.target.checked)}
+    <label
       className={clsx(
-        TOGGLE_CLASS,
+        "relative inline-flex items-center w-10 h-6 shrink-0",
         disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer",
       )}
-    />
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+        className="peer sr-only"
+      />
+      <span
+        aria-hidden="true"
+        className="absolute inset-0 rounded-full bg-base border border-strong transition-colors peer-checked:bg-blue-600 peer-checked:border-blue-600"
+      />
+      <span
+        aria-hidden="true"
+        className="relative ml-1 w-4 h-4 rounded-full bg-white transition-transform peer-checked:translate-x-4"
+      />
+    </label>
   );
 }
 

--- a/tests/components/settings/SettingControls.test.tsx
+++ b/tests/components/settings/SettingControls.test.tsx
@@ -136,7 +136,9 @@ describe("SettingToggle", () => {
       <SettingToggle checked={false} onChange={() => {}} disabled />,
     );
     const input = screen.getByRole("checkbox");
-    expect(input.className).toContain("cursor-not-allowed");
+    const label = input.closest("label");
+    expect(label).not.toBeNull();
+    expect(label!.className).toContain("cursor-not-allowed");
   });
 });
 


### PR DESCRIPTION
The knob was rendered via `::after` on `<input type="checkbox">`. Pseudo-elements on void elements have implementation-defined behavior; on WebKit (Tauri/macOS) the knob landed below the center of the track.

Rewrite as `<label>` + `peer sr-only <input>` + two `<span aria-hidden>` for track and knob. Vertical centering comes from flex `items-center` on the label (geometric, no transform). Same size, colors, and API.

Noticed while reading `SettingControls.tsx` referenced in #195.

## Before / After

| Before | After |
|--------|-------|
| <img width="70" height="49" alt="image" src="https://github.com/user-attachments/assets/f9498984-3f4b-4ca3-86e6-3792795c6121" /> | <img width="68" height="50" alt="image" src="https://github.com/user-attachments/assets/32c7a8cf-afc5-4b14-8f8f-176058f88eae" /> |

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 31/31 pass (one assertion updated to query the label, where `cursor-not-allowed` now lives)
- [x] Manual: click, keyboard (Space), disabled state, animation