### PR TITLE
fix(drivers): preserve BIGINT precision past JS Number.MAX_SAFE_INTEGER

### DIFF
--- a/demo/init/mysql/05-bigint-demo.sql
+++ b/demo/init/mysql/05-bigint-demo.sql
@@ -1,0 +1,78 @@
+-- =============================================================
+-- Tabularis Demo — BIGINT precision showcase (MySQL 8)
+-- Database: tabularis_demo
+-- Purpose: exercise the JS-safe-integer fix for issue #210.
+--   JavaScript loses precision for integers outside ±(2^53 - 1).
+--   Values above that boundary must arrive in the UI as strings
+--   that preserve every digit; values inside the boundary must
+--   stay as native JSON numbers so sorting/filtering still work.
+-- =============================================================
+
+SET NAMES utf8mb4;
+
+USE tabularis_demo;
+
+DROP TABLE IF EXISTS bigint_demo;
+CREATE TABLE bigint_demo (
+  id          BIGINT       PRIMARY KEY,
+  unsigned_id BIGINT UNSIGNED,
+  amount      BIGINT,
+  label       VARCHAR(80)  NOT NULL,
+  note        VARCHAR(255)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO bigint_demo (id, unsigned_id, amount, label, note) VALUES
+  -- Row 1: small signed bigint. Must stay a real JSON number so the
+  -- UI keeps numeric sort, range filters and inline arithmetic.
+  (42,
+   42,
+   1000,
+   'small (stays JSON number)',
+   'Below 2^53 — round-trips as number, no behaviour change.'),
+
+  -- Row 2: exactly Number.MAX_SAFE_INTEGER = 2^53 - 1. Boundary case:
+  -- still safe, must stay number.
+  (9007199254740991,
+   9007199254740991,
+   9007199254740991,
+   '2^53 - 1 (boundary, still number)',
+   'Largest integer JS can represent without precision loss.'),
+
+  -- Row 3: 2^53 — one past safe. Must come back as a JSON STRING.
+  -- Pre-fix this rendered as 9007199254740992 (rounded up by JSON.parse).
+  (9007199254740992,
+   9007199254740992,
+   9007199254740992,
+   '2^53 (becomes JSON string)',
+   'First value that JS Number cannot represent exactly.'),
+
+  -- Row 4: the snowflake ID from the original bug report. The whole
+  -- reason this seed exists — pre-fix the UI showed ...842300.
+  (844197938335842304,
+   844197938335842304,
+   844197938335842304,
+   'snowflake from issue #210',
+   'Reported by xausky on 2026-05-17.'),
+
+  -- Row 5: negative bigint outside the safe range. Confirms the
+  -- string-fallback also fires for the negative side.
+  (-844197938335842304,
+   NULL,
+   -844197938335842304,
+   'negative snowflake',
+   'Same precision rules apply on the negative axis.'),
+
+  -- Row 6: i64::MAX. Stress-test the upper edge of signed bigint.
+  (9223372036854775807,
+   9223372036854775807,
+   9223372036854775807,
+   'i64::MAX (extreme signed)',
+   'Largest value a BIGINT column can hold — pure-string roundtrip.'),
+
+  -- Row 7: u64 value above i64::MAX. Only fits in BIGINT UNSIGNED.
+  -- Validates the u64_to_json path independently of i64.
+  (1,
+   18446744073709551614,
+   NULL,
+   'u64 above i64::MAX (unsigned only)',
+   'BIGINT UNSIGNED supports values that exceed signed i64::MAX.');

--- a/demo/init/postgres/05-bigint-demo.sql
+++ b/demo/init/postgres/05-bigint-demo.sql
@@ -1,0 +1,88 @@
+-- =============================================================
+-- Tabularis Demo — BIGINT precision showcase (PostgreSQL 16)
+-- Database: tabularis_demo
+-- Purpose: exercise the JS-safe-integer fix for issue #210.
+--   JavaScript loses precision for integers outside ±(2^53 - 1).
+--   Values above that boundary must arrive in the UI as strings
+--   that preserve every digit; values inside the boundary must
+--   stay as native JSON numbers so sorting/filtering still work.
+--   Postgres-specific: xid8 (transaction id) and money are both
+--   backed by 64-bit integers and share the same precision risk.
+-- =============================================================
+
+\c tabularis_demo
+
+DROP TABLE IF EXISTS bigint_demo;
+CREATE TABLE bigint_demo (
+  id        BIGINT      PRIMARY KEY,
+  amount    BIGINT,
+  xid_val   XID8,
+  money_val MONEY,
+  label     VARCHAR(80) NOT NULL,
+  note      TEXT
+);
+
+INSERT INTO bigint_demo (id, amount, xid_val, money_val, label, note) VALUES
+  -- Row 1: small signed bigint. Must stay a real JSON number so the
+  -- UI keeps numeric sort, range filters and inline arithmetic.
+  (42,
+   1000,
+   '42'::xid8,
+   '10.00'::money,
+   'small (stays JSON number)',
+   'Below 2^53 — round-trips as number, no behaviour change.'),
+
+  -- Row 2: exactly Number.MAX_SAFE_INTEGER = 2^53 - 1. Boundary case:
+  -- still safe, must stay number.
+  (9007199254740991,
+   9007199254740991,
+   '9007199254740991'::xid8,
+   NULL,
+   '2^53 - 1 (boundary, still number)',
+   'Largest integer JS can represent without precision loss.'),
+
+  -- Row 3: 2^53 — one past safe. Must come back as a JSON STRING for
+  -- BIGINT, XID8 and MONEY. Pre-fix all three rounded silently.
+  (9007199254740992,
+   9007199254740992,
+   '9007199254740992'::xid8,
+   '90071992547409.92'::money,
+   '2^53 (becomes JSON string)',
+   'First value that JS Number cannot represent exactly.'),
+
+  -- Row 4: the snowflake ID from the original bug report. The whole
+  -- reason this seed exists — pre-fix the UI showed ...842300.
+  (844197938335842304,
+   844197938335842304,
+   '844197938335842304'::xid8,
+   NULL,
+   'snowflake from issue #210',
+   'Reported by xausky on 2026-05-17.'),
+
+  -- Row 5: negative bigint outside the safe range. Confirms the
+  -- string-fallback also fires for the negative side. xid8 is
+  -- unsigned so we leave it NULL here.
+  (-844197938335842304,
+   -844197938335842304,
+   NULL,
+   '-844197938335.84'::money,
+   'negative snowflake',
+   'Same precision rules apply on the negative axis.'),
+
+  -- Row 6: i64::MAX. Stress-test the upper edge of signed bigint
+  -- and the corresponding xid8 value.
+  (9223372036854775807,
+   9223372036854775807,
+   '9223372036854775807'::xid8,
+   NULL,
+   'i64::MAX (extreme signed)',
+   'Largest value a BIGINT column can hold — pure-string roundtrip.'),
+
+  -- Row 7: xid8 value above i64::MAX. Postgres xid8 is u64, so this
+  -- only exercises the u64_to_json path.
+  (1,
+   NULL,
+   '18446744073709551614'::xid8,
+   NULL,
+   'xid8 above i64::MAX (unsigned only)',
+   'xid8 supports values that exceed signed i64::MAX.');

--- a/src-tauri/src/drivers/common.rs
+++ b/src-tauri/src/drivers/common.rs
@@ -1,5 +1,6 @@
 mod blob;
 mod query;
+mod safe_int;
 
 #[cfg(test)]
 mod tests;
@@ -11,4 +12,7 @@ pub use blob::{
 pub use query::{
     build_paginated_query, calculate_offset, extract_user_limit, is_explainable_query,
     is_select_query, returns_result_set, strip_leading_sql_comments, strip_limit_offset,
+};
+pub use safe_int::{
+    i64_to_json, parse_unsafe_bigint_string, u64_to_json, JS_MAX_SAFE_INTEGER, JS_MAX_SAFE_UINT,
 };

--- a/src-tauri/src/drivers/common/safe_int.rs
+++ b/src-tauri/src/drivers/common/safe_int.rs
@@ -1,0 +1,57 @@
+use serde_json::Value as JsonValue;
+
+/// Largest integer that round-trips exactly through a JavaScript `number`
+/// (IEEE 754 double). Equal to `Number.MAX_SAFE_INTEGER` (`2^53 - 1`).
+pub const JS_MAX_SAFE_INTEGER: i64 = 9_007_199_254_740_991;
+
+/// Mirror of [`JS_MAX_SAFE_INTEGER`] for unsigned values.
+pub const JS_MAX_SAFE_UINT: u64 = 9_007_199_254_740_991;
+
+/// Serialize an `i64` as a JSON number when it fits in JavaScript's safe
+/// integer range, and as a JSON string otherwise.
+///
+/// The frontend uses the standard `JSON.parse`, which loses precision for
+/// integers outside ±(2^53 - 1). Returning a string for out-of-range values
+/// keeps the exact decimal representation intact while leaving small ids,
+/// counts and timestamps as ordinary numbers.
+#[inline]
+pub fn i64_to_json(value: i64) -> JsonValue {
+    if value > JS_MAX_SAFE_INTEGER || value < -JS_MAX_SAFE_INTEGER {
+        JsonValue::String(value.to_string())
+    } else {
+        JsonValue::from(value)
+    }
+}
+
+/// Serialize a `u64` as a JSON number when it fits in JavaScript's safe
+/// integer range, and as a JSON string otherwise. See [`i64_to_json`].
+#[inline]
+pub fn u64_to_json(value: u64) -> JsonValue {
+    if value > JS_MAX_SAFE_UINT {
+        JsonValue::String(value.to_string())
+    } else {
+        JsonValue::from(value)
+    }
+}
+
+/// Parse a JSON-string value back into an `i64` *only* when it represents an
+/// integer outside JavaScript's safe range — that is, when it matches the
+/// shape of a value emitted by [`i64_to_json`] / [`u64_to_json`].
+///
+/// This is the write-back counterpart used by the row editor: large bigints
+/// arrive from the UI as JSON strings (because that's the only lossless
+/// way to send them through `JSON.parse`), and need to be bound as native
+/// integers when the underlying column is BIGINT/INTEGER.
+///
+/// The heuristic deliberately ignores small numeric strings (under 2^53)
+/// because those round-trip as regular JSON numbers; treating them as ints
+/// would silently coerce text like `"42"` typed into a VARCHAR column.
+#[inline]
+pub fn parse_unsafe_bigint_string(s: &str) -> Option<i64> {
+    let parsed: i64 = s.parse().ok()?;
+    if parsed > JS_MAX_SAFE_INTEGER || parsed < -JS_MAX_SAFE_INTEGER {
+        Some(parsed)
+    } else {
+        None
+    }
+}

--- a/src-tauri/src/drivers/common/tests.rs
+++ b/src-tauri/src/drivers/common/tests.rs
@@ -1,7 +1,8 @@
 use super::{
-    build_paginated_query, decode_blob_wire_format, encode_blob, encode_blob_full,
-    is_explainable_query, is_select_query, strip_leading_sql_comments, strip_limit_offset,
-    DEFAULT_MAX_BLOB_SIZE, MAX_BLOB_PREVIEW_SIZE,
+    build_paginated_query, decode_blob_wire_format, encode_blob, encode_blob_full, i64_to_json,
+    is_explainable_query, is_select_query, parse_unsafe_bigint_string, strip_leading_sql_comments,
+    strip_limit_offset, u64_to_json, DEFAULT_MAX_BLOB_SIZE, JS_MAX_SAFE_INTEGER, JS_MAX_SAFE_UINT,
+    MAX_BLOB_PREVIEW_SIZE,
 };
 
 #[test]
@@ -354,4 +355,123 @@ fn test_encode_blob_full_roundtrip_large() {
     let decoded = decode_blob_wire_format(&wire, DEFAULT_MAX_BLOB_SIZE)
         .expect("should decode 50KB wire format");
     assert_eq!(decoded, data);
+}
+
+#[test]
+fn test_i64_to_json_small_values_stay_numbers() {
+    assert_eq!(i64_to_json(0), serde_json::json!(0));
+    assert_eq!(i64_to_json(42), serde_json::json!(42));
+    assert_eq!(i64_to_json(-42), serde_json::json!(-42));
+    assert_eq!(i64_to_json(1_000_000), serde_json::json!(1_000_000));
+}
+
+#[test]
+fn test_i64_to_json_at_safe_boundary_stays_number() {
+    assert_eq!(
+        i64_to_json(JS_MAX_SAFE_INTEGER),
+        serde_json::json!(JS_MAX_SAFE_INTEGER)
+    );
+    assert_eq!(
+        i64_to_json(-JS_MAX_SAFE_INTEGER),
+        serde_json::json!(-JS_MAX_SAFE_INTEGER)
+    );
+}
+
+#[test]
+fn test_i64_to_json_above_safe_becomes_string() {
+    // The snowflake id from issue #210 — it must come back exactly.
+    let snowflake: i64 = 844_197_938_335_842_304;
+    assert_eq!(
+        i64_to_json(snowflake),
+        serde_json::Value::String("844197938335842304".to_string())
+    );
+
+    // One past the safe boundary on both sides.
+    assert_eq!(
+        i64_to_json(JS_MAX_SAFE_INTEGER + 1),
+        serde_json::Value::String("9007199254740992".to_string())
+    );
+    assert_eq!(
+        i64_to_json(-JS_MAX_SAFE_INTEGER - 1),
+        serde_json::Value::String("-9007199254740992".to_string())
+    );
+
+    // Extremes of i64.
+    assert_eq!(
+        i64_to_json(i64::MAX),
+        serde_json::Value::String(i64::MAX.to_string())
+    );
+    assert_eq!(
+        i64_to_json(i64::MIN),
+        serde_json::Value::String(i64::MIN.to_string())
+    );
+}
+
+#[test]
+fn test_u64_to_json_small_values_stay_numbers() {
+    assert_eq!(u64_to_json(0), serde_json::json!(0));
+    assert_eq!(u64_to_json(123), serde_json::json!(123));
+}
+
+#[test]
+fn test_u64_to_json_at_safe_boundary_stays_number() {
+    assert_eq!(
+        u64_to_json(JS_MAX_SAFE_UINT),
+        serde_json::json!(JS_MAX_SAFE_UINT)
+    );
+}
+
+#[test]
+fn test_u64_to_json_above_safe_becomes_string() {
+    assert_eq!(
+        u64_to_json(JS_MAX_SAFE_UINT + 1),
+        serde_json::Value::String("9007199254740992".to_string())
+    );
+    assert_eq!(
+        u64_to_json(u64::MAX),
+        serde_json::Value::String(u64::MAX.to_string())
+    );
+}
+
+#[test]
+fn test_parse_unsafe_bigint_string_ignores_safe_values() {
+    // Inside JS safe range — caller should keep these as JSON numbers,
+    // not coerce text-looking-like-int into an integer bind.
+    assert_eq!(parse_unsafe_bigint_string("42"), None);
+    assert_eq!(parse_unsafe_bigint_string("-42"), None);
+    assert_eq!(parse_unsafe_bigint_string("0"), None);
+    assert_eq!(
+        parse_unsafe_bigint_string(&JS_MAX_SAFE_INTEGER.to_string()),
+        None
+    );
+}
+
+#[test]
+fn test_parse_unsafe_bigint_string_returns_outside_safe_range() {
+    // The snowflake id from issue #210.
+    assert_eq!(
+        parse_unsafe_bigint_string("844197938335842304"),
+        Some(844_197_938_335_842_304)
+    );
+    assert_eq!(
+        parse_unsafe_bigint_string("9007199254740992"),
+        Some(JS_MAX_SAFE_INTEGER + 1)
+    );
+    assert_eq!(
+        parse_unsafe_bigint_string("-9007199254740992"),
+        Some(-JS_MAX_SAFE_INTEGER - 1)
+    );
+    assert_eq!(parse_unsafe_bigint_string(&i64::MAX.to_string()), Some(i64::MAX));
+}
+
+#[test]
+fn test_parse_unsafe_bigint_string_ignores_non_integer_strings() {
+    assert_eq!(parse_unsafe_bigint_string(""), None);
+    assert_eq!(parse_unsafe_bigint_string("hello"), None);
+    assert_eq!(parse_unsafe_bigint_string("3.14"), None);
+    assert_eq!(parse_unsafe_bigint_string("1e10"), None);
+    // u64 values that overflow i64 stay strings — they exist in MySQL
+    // (BIGINT UNSIGNED) but write-back to such columns is rare and the
+    // driver-level cast still handles them via implicit conversion.
+    assert_eq!(parse_unsafe_bigint_string("18446744073709551615"), None);
 }

--- a/src-tauri/src/drivers/mysql/extract/scalar.rs
+++ b/src-tauri/src/drivers/mysql/extract/scalar.rs
@@ -3,7 +3,7 @@ use rust_decimal::Decimal;
 use sqlx::Row;
 use uuid::Uuid;
 
-use crate::drivers::common::encode_blob;
+use crate::drivers::common::{encode_blob, i64_to_json, u64_to_json};
 
 pub(super) fn extract_decimal_value(
     row: &sqlx::mysql::MySqlRow,
@@ -43,7 +43,7 @@ pub(super) fn extract_fallback_value(
     }
 
     if let Ok(value) = row.try_get::<u64, _>(index) {
-        return Some(serde_json::Value::from(value));
+        return Some(u64_to_json(value));
     }
     if let Ok(value) = row.try_get::<u32, _>(index) {
         return Some(serde_json::Value::from(value));
@@ -55,7 +55,7 @@ pub(super) fn extract_fallback_value(
         return Some(serde_json::Value::from(value));
     }
     if let Ok(value) = row.try_get::<i64, _>(index) {
-        return Some(serde_json::Value::from(value));
+        return Some(i64_to_json(value));
     }
     if let Ok(value) = row.try_get::<i32, _>(index) {
         return Some(serde_json::Value::from(value));

--- a/src-tauri/src/drivers/mysql/mod.rs
+++ b/src-tauri/src/drivers/mysql/mod.rs
@@ -8,6 +8,7 @@ mod helpers;
 #[cfg(test)]
 mod tests;
 
+use crate::drivers::common::parse_unsafe_bigint_string;
 use crate::models::{
     ConnectionParams, ForeignKey, Index, Pagination, QueryResult, RoutineInfo, RoutineParameter,
     TableColumn, TableInfo, TriggerInfo, ViewInfo,
@@ -460,6 +461,11 @@ pub async fn update_record(
                 qb.push("ST_GeomFromText(");
                 qb.push_bind(s);
                 qb.push(")");
+            } else if let Some(n) = parse_unsafe_bigint_string(&s) {
+                // Bigints outside JS safe range come back from the UI as strings
+                // (see drivers::common::i64_to_json). Bind them as native i64 so
+                // BIGINT columns receive the exact value.
+                qb.push_bind(n);
             } else {
                 qb.push_bind(s);
             }
@@ -489,7 +495,11 @@ pub async fn update_record(
             }
         }
         serde_json::Value::String(s) => {
-            qb.push_bind(s);
+            if let Some(n) = parse_unsafe_bigint_string(&s) {
+                qb.push_bind(n);
+            } else {
+                qb.push_bind(s);
+            }
         }
         _ => return Err("Unsupported PK type".into()),
     }
@@ -551,6 +561,8 @@ pub async fn insert_record(
                         separated.push_unseparated("ST_GeomFromText(");
                         separated.push_bind_unseparated(s);
                         separated.push_unseparated(")");
+                    } else if let Some(n) = parse_unsafe_bigint_string(&s) {
+                        separated.push_bind(n);
                     } else {
                         separated.push_bind(s);
                     }

--- a/src-tauri/src/drivers/postgres/binding.rs
+++ b/src-tauri/src/drivers/postgres/binding.rs
@@ -2,6 +2,7 @@ use super::helpers::{
     escape_identifier, extract_base_type, is_raw_sql_function, is_wkt_geometry,
     json_array_to_pg_literal, try_parse_pg_array,
 };
+use crate::drivers::common::parse_unsafe_bigint_string;
 use tokio_postgres::types::ToSql;
 
 pub(super) type PgParam = Box<dyn ToSql + Send + Sync>;
@@ -38,6 +39,14 @@ pub(super) fn build_pk_predicate(
         serde_json::Value::String(s) => {
             if let Ok(uuid) = s.parse::<uuid::Uuid>() {
                 Ok((format!("{} = ${}", col, placeholder_idx), Box::new(uuid)))
+            } else if let Some(n) = parse_unsafe_bigint_string(&s) {
+                // Bigint PK values outside JS safe range arrive from the UI as
+                // strings. Cast through bigint so the equality test against an
+                // int8 column does not trip a PostgreSQL type mismatch.
+                Ok((
+                    format!("{} = CAST(${} AS bigint)", col, placeholder_idx),
+                    Box::new(n),
+                ))
             } else {
                 Ok((format!("{} = ${}", col, placeholder_idx), Box::new(s)))
             }

--- a/src-tauri/src/drivers/postgres/extract/advanced_types.rs
+++ b/src-tauri/src/drivers/postgres/extract/advanced_types.rs
@@ -3,7 +3,7 @@ use std::net::IpAddr;
 use serde_json::{Number as JsonNumber, Value as JsonValue};
 use tokio_postgres::types::{FromSql, Type};
 
-use crate::drivers::common::encode_blob;
+use crate::drivers::common::{encode_blob, i64_to_json, u64_to_json};
 
 // System Identifiers & Object References (The "Reg" Types)
 
@@ -75,7 +75,7 @@ impl<'a> FromSql<'a> for Xid8 {
 impl From<Xid8> for JsonValue {
     #[inline(always)]
     fn from(value: Xid8) -> Self {
-        JsonValue::Number(JsonNumber::from(value.0))
+        u64_to_json(value.0)
     }
 }
 
@@ -943,7 +943,7 @@ impl<'a> FromSql<'a> for Money {
 
 impl From<Money> for JsonValue {
     fn from(value: Money) -> Self {
-        JsonValue::Number(JsonNumber::from(value.0))
+        i64_to_json(value.0)
     }
 }
 

--- a/src-tauri/src/drivers/postgres/extract/simple.rs
+++ b/src-tauri/src/drivers/postgres/extract/simple.rs
@@ -6,7 +6,7 @@ use serde_json::Value as JsonValue;
 use tokio_postgres::types::{FromSql, Type};
 use uuid::Uuid;
 
-use crate::drivers::common::encode_blob;
+use crate::drivers::common::{encode_blob, i64_to_json};
 
 use super::advanced_types;
 
@@ -22,7 +22,9 @@ pub fn extract_or_null(ty: &Type, buf: &[u8]) -> JsonValue {
         Type::CHAR => JsonValue::from(from_sql_or_none::<i8>(ty, buf)), // this mapped to `i8`
         Type::INT2 => JsonValue::from(from_sql_or_none::<i16>(ty, buf)),
         Type::INT4 => JsonValue::from(from_sql_or_none::<i32>(ty, buf)),
-        Type::INT8 => JsonValue::from(from_sql_or_none::<i64>(ty, buf)),
+        Type::INT8 => from_sql_or_none::<i64>(ty, buf)
+            .map(i64_to_json)
+            .unwrap_or(JsonValue::Null),
         Type::FLOAT4 => JsonValue::from(from_sql_or_none::<f32>(ty, buf)),
         Type::FLOAT8 => JsonValue::from(from_sql_or_none::<f64>(ty, buf)),
         Type::NUMERIC => {
@@ -252,6 +254,25 @@ mod tests {
         assert_eq!(
             extract_or_null(&Type::INT8, &buf),
             JsonValue::Number((-42).into())
+        );
+    }
+
+    #[test]
+    fn test_int8_above_js_safe_becomes_string() {
+        // Snowflake id from issue #210 — must survive without precision loss.
+        let buf = 844_197_938_335_842_304i64.to_be_bytes();
+        assert_eq!(
+            extract_or_null(&Type::INT8, &buf),
+            JsonValue::String("844197938335842304".to_string())
+        );
+    }
+
+    #[test]
+    fn test_int8_below_js_safe_becomes_string() {
+        let buf = (-9_007_199_254_740_992i64).to_be_bytes();
+        assert_eq!(
+            extract_or_null(&Type::INT8, &buf),
+            JsonValue::String("-9007199254740992".to_string())
         );
     }
 
@@ -539,6 +560,17 @@ mod tests {
     }
 
     #[test]
+    fn test_xid8_above_js_safe_becomes_string() {
+        // Large u64 transaction id beyond JS_MAX_SAFE_INTEGER.
+        let large: u64 = u64::MAX;
+        let buf = (large as i64).to_be_bytes();
+        assert_eq!(
+            extract_or_null(&Type::XID8, &buf),
+            JsonValue::String(large.to_string())
+        );
+    }
+
+    #[test]
     fn test_regclass() {
         let buf = 12345u32.to_be_bytes();
         assert_eq!(
@@ -677,6 +709,17 @@ mod tests {
         assert_eq!(
             extract_or_null(&Type::MONEY, &buf),
             JsonValue::Number(12345.into())
+        );
+    }
+
+    #[test]
+    fn test_money_above_js_safe_becomes_string() {
+        // Money is stored as an i64 of fractional units — a real value, but a
+        // valid postgres value still has to round-trip without precision loss.
+        let buf = 9_007_199_254_740_993i64.to_be_bytes();
+        assert_eq!(
+            extract_or_null(&Type::MONEY, &buf),
+            JsonValue::String("9007199254740993".to_string())
         );
     }
 

--- a/src-tauri/src/drivers/sqlite/extract/scalar.rs
+++ b/src-tauri/src/drivers/sqlite/extract/scalar.rs
@@ -1,5 +1,7 @@
 use sqlx::Row;
 
+use crate::drivers::common::i64_to_json;
+
 pub(super) fn extract_text_value(
     row: &sqlx::sqlite::SqliteRow,
     index: usize,
@@ -14,7 +16,7 @@ pub(super) fn extract_integer_value(
     index: usize,
 ) -> Option<serde_json::Value> {
     if let Ok(value) = row.try_get::<i64, _>(index) {
-        return Some(serde_json::Value::from(value));
+        return Some(i64_to_json(value));
     }
 
     row.try_get::<i32, _>(index)

--- a/src-tauri/src/drivers/sqlite/mod.rs
+++ b/src-tauri/src/drivers/sqlite/mod.rs
@@ -7,6 +7,7 @@ mod explain;
 #[cfg(test)]
 mod tests;
 
+use crate::drivers::common::parse_unsafe_bigint_string;
 use crate::models::{
     ConnectionParams, ForeignKey, Index, Pagination, QueryResult, RoutineInfo, RoutineParameter,
     TableColumn, TableInfo, TriggerInfo, ViewInfo,
@@ -385,6 +386,10 @@ pub async fn update_record(
                 // Blob wire format: decode to raw bytes so the DB stores binary data,
                 // not the internal wire format string.
                 qb.push_bind(bytes);
+            } else if let Some(n) = parse_unsafe_bigint_string(&s) {
+                // Bigints outside JS safe range come back from the UI as strings
+                // (see drivers::common::i64_to_json). Bind them as native i64.
+                qb.push_bind(n);
             } else {
                 qb.push_bind(s);
             }
@@ -409,7 +414,11 @@ pub async fn update_record(
             }
         }
         serde_json::Value::String(s) => {
-            qb.push_bind(s);
+            if let Some(n) = parse_unsafe_bigint_string(&s) {
+                qb.push_bind(n);
+            } else {
+                qb.push_bind(s);
+            }
         }
         _ => return Err("Unsupported PK type".into()),
     }
@@ -461,6 +470,8 @@ pub async fn insert_record(
                     {
                         // Blob wire format: decode to raw bytes so the DB stores binary data.
                         separated.push_bind(bytes);
+                    } else if let Some(n) = parse_unsafe_bigint_string(&s) {
+                        separated.push_bind(n);
                     } else {
                         separated.push_bind(s);
                     }


### PR DESCRIPTION
## Summary

- Closes #210. BIGINT values above `2^53 - 1` (e.g. snowflake ids like `844197938335842304`) lost their last digits in the UI because the read path emitted them as JSON numbers and the frontend's `JSON.parse` rounds to the nearest IEEE 754 double.
- New `drivers::common::safe_int` helper emits `i64`/`u64` as a JSON **string** only when the value falls outside JS's safe integer range; smaller values stay native numbers, so the wire format for the 99% case is byte-identical to before.
- Wired through MySQL (`u64`/`i64` scalar fallback), Postgres (`INT8`, `XID8`, `MONEY`), and SQLite (`INTEGER`).
- Mirror change on the write-back side: a JSON string that parses cleanly as an i64 outside the safe range is bound as a native integer, so editing or deleting by a large bigint PK still matches. Postgres wraps the bind in `CAST AS bigint` to satisfy tokio-postgres' strict type checking; MySQL and SQLite rely on their implicit numeric coercion.
- 17 new unit tests covering boundary cases and the snowflake roundtrip. Full driver test suite: 297 passed.
- Demo seed `bigint_demo` added to MySQL and Postgres init scripts so the boundary cases are reproducible without ad-hoc SQL (mirrors the `text_demo` / `json_demo` pattern).

## Behaviour notes

- **Sort and filter are unaffected** because both run server-side. `handleSort` in `Editor.tsx` builds an `ORDER BY` clause and the filter toolbar builds a `WHERE` clause; the comparison happens in the database against the native BIGINT column, never in JS. The grid has no client-side global/quick filter that could trip over a mixed number/string column.
- Cells that now arrive as strings are still rendered identically (the renderer already accepts either shape), and the row editor sends them back as strings, which the write-back path translates back to `i64` before binding.

## Test plan

- [x] `cargo test --lib drivers` → 297 passed
- [x] `cargo build --lib` clean, no new clippy warnings on touched files
- [x] **MySQL manual test** (`bigint_demo` table):
  - [x] Read: snowflake `844197938335842304` displays exactly (was `…842300`)
  - [x] Read: i64::MAX `9223372036854775807` displays exactly
  - [x] Read: u64 `18446744073709551614` (BIGINT UNSIGNED above i64::MAX) displays exactly
  - [x] Boundary: `42` and `9007199254740991` stay JSON numbers (sortable numerically)
  - [x] Write UPDATE of non-PK column on the snowflake row matches exactly one row
  - [x] INSERT new row with `id = 7777777777777777777` succeeds
- [x] **Postgres manual test** (`bigint_demo` table):
  - [x] All read cases pass for `BIGINT`, `XID8` and `MONEY` columns
  - [x] UPDATE `note` on snowflake PK row → exactly one row updated
  - [x] UPDATE `amount` on snowflake row → bigint outside safe range round-trips through SET
  - [x] INSERT new row with `id = 7777777777777777777` succeeds