### PR TITLE
feat: Delete selected rows with keyboard shortcut

### DIFF
--- a/src/components/ui/DataGrid.tsx
+++ b/src/components/ui/DataGrid.tsx
@@ -846,17 +846,7 @@ export const DataGrid = React.memo(
       pendingDeletions,
     ]);
 
-    const deleteSelectedRow = useCallback(() => {
-      if (!contextMenu) return;
-
-      // If the right-clicked row is part of a multi-selection, delete all selected rows.
-      // Otherwise fall back to deleting just the right-clicked row.
-      const rightClickedIsSelected = selectedRowIndices.has(contextMenu.rowIndex);
-      const indicesToDelete =
-        rightClickedIsSelected && selectedRowIndices.size > 1
-          ? Array.from(selectedRowIndices)
-          : [contextMenu.rowIndex];
-
+    const deleteRowsByIndices = useCallback((indicesToDelete: number[]) => {
       const pkVals: unknown[] = [];
       for (const idx of indicesToDelete) {
         const mergedRow = mergedRows[idx];
@@ -877,18 +867,22 @@ export const DataGrid = React.memo(
           pkVals.forEach((v) => onMarkForDeletion(v));
         }
       }
+    }, [mergedRows, onDiscardInsertion, onMarkForDeletion, onMarkMultipleForDeletion, pkColumn, pkIndexMap]);
 
+    const deleteSelectedRow = useCallback(() => {
+      if (!contextMenu) return;
+
+      // If the right-clicked row is part of a multi-selection, delete all selected rows.
+      // Otherwise fall back to deleting just the right-clicked row.
+      const rightClickedIsSelected = selectedRowIndices.has(contextMenu.rowIndex);
+      const indicesToDelete =
+        rightClickedIsSelected && selectedRowIndices.size > 1
+          ? Array.from(selectedRowIndices)
+          : [contextMenu.rowIndex];
+
+      deleteRowsByIndices(indicesToDelete);
       setContextMenu(null);
-    }, [
-      contextMenu,
-      selectedRowIndices,
-      mergedRows,
-      onDiscardInsertion,
-      onMarkForDeletion,
-      onMarkMultipleForDeletion,
-      pkColumn,
-      pkIndexMap,
-    ]);
+    }, [contextMenu, selectedRowIndices, deleteRowsByIndices]);
 
     const duplicateSelectedRow = useCallback(() => {
       if (!contextMenu || !onDuplicateRow) return;
@@ -1118,11 +1112,17 @@ export const DataGrid = React.memo(
             }
           }
         }
+
+        // Delete / Backspace — delete selected rows
+        if ((e.key === "Delete" || e.key === "Backspace") && !editingCell && !readonlyProp && selectedRowIndices.size > 0) {
+          e.preventDefault();
+          deleteRowsByIndices(Array.from(selectedRowIndices));
+        }
       };
 
       document.addEventListener("keydown", handleKeyDown);
       return () => document.removeEventListener("keydown", handleKeyDown);
-    }, [editingCell, selectedRowIndices, focusedCell, copyCellValue, copySelectedCells]);
+    }, [editingCell, selectedRowIndices, focusedCell, copyCellValue, copySelectedCells, readonlyProp, deleteRowsByIndices]);
 
     // Show "no data" if there are no columns (even with pending insertions, we can't render without column info)
     // OR if there are columns but no data and no pending insertions


### PR DESCRIPTION
## Delete selected rows with keyboard shortcut

  Pressing `Delete` or `Backspace` now marks all selected rows for deletion, matching the behaviour already available
  via the right-click context menu.

  ### Changes

  **`src/components/ui/DataGrid.tsx`**

  - Extracted the deletion logic from `deleteSelectedRow` into a new `deleteRowsByIndices(indicesToDelete: number[])`
  callback. The original context-menu handler now delegates to it, keeping behaviour identical.
  - Added `Delete` / `Backspace` handling to the document-level `keydown` listener. The shortcut fires only when all
  three conditions are true: rows are selected, no cell is currently being edited, and the grid is not in readonly
  mode.

  ### Behaviour

  | Scenario | Result |
  |---|---|
  | One or more rows selected, press `Delete` or `Backspace` | Rows are marked for deletion (pending commit) |
  | Cell is being edited, press `Backspace` | Normal text editing — no rows deleted |
  | Grid is readonly | Key is ignored |
  | No rows selected | Key is ignored |

  Existing rows follow the same pending-deletion flow as the context menu (committed on save). Pending insertions are
  discarded immediately, also matching existing behaviour.

Closes #218 