### PR TITLE
feat(sql): first-party splitter + per-driver dialect

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "buffer": "^6.0.3",
     "clsx": "^2.1.1",
     "dagre": "^0.8.5",
-    "dbgate-query-splitter": "^4.12.0",
     "i18next": "^25.10.10",
     "i18next-browser-languagedetector": "^8.2.1",
     "json-edit-react": "^1.29.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,9 +53,6 @@ importers:
       dagre:
         specifier: ^0.8.5
         version: 0.8.5
-      dbgate-query-splitter:
-        specifier: ^4.12.0
-        version: 4.12.0
       i18next:
         specifier: ^25.10.10
         version: 25.10.10(typescript@5.9.3)
@@ -1560,9 +1557,6 @@ packages:
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  dbgate-query-splitter@4.12.0:
-    resolution: {integrity: sha512-gHxH+QdFg488X8XXDHsWM0k1LwA+K5xcgp0YaA9wWye8A/zMCqaSDc4U6PMUu4LbKNchkIoTvFD4DJNXSsYVcw==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -4238,8 +4232,6 @@ snapshots:
       whatwg-url: 16.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
-
-  dbgate-query-splitter@4.12.0: {}
 
   debug@4.4.3:
     dependencies:

--- a/src-tauri/src/drivers/common/query.rs
+++ b/src-tauri/src/drivers/common/query.rs
@@ -70,8 +70,13 @@ pub fn returns_result_set(query: &str) -> bool {
 ///
 /// MySQL/MariaDB support EXPLAIN for DML statements only:
 /// SELECT, INSERT, UPDATE, DELETE, REPLACE, and WITH (CTE).
+/// PostgreSQL 15+ and Oracle also support EXPLAIN MERGE.
 /// DDL statements (CREATE, DROP, ALTER, TRUNCATE, etc.) are not supported.
 /// Leading SQL comments are stripped before checking.
+///
+/// Kept in sync with the TypeScript classifier in
+/// `src/utils/sqlSplitter/classify.ts` (EXPLAINABLE_KEYWORDS) so the
+/// editor's Explain UI cannot offer a statement the backend will refuse.
 pub fn is_explainable_query(query: &str) -> bool {
     let upper = strip_leading_sql_comments(query).to_uppercase();
     upper.starts_with("SELECT")
@@ -81,6 +86,7 @@ pub fn is_explainable_query(query: &str) -> bool {
         || upper.starts_with("REPLACE")
         || upper.starts_with("WITH")
         || upper.starts_with("TABLE")
+        || upper.starts_with("MERGE")
 }
 
 /// Calculate offset for pagination

--- a/src-tauri/src/drivers/common/tests.rs
+++ b/src-tauri/src/drivers/common/tests.rs
@@ -100,6 +100,9 @@ fn test_is_explainable_query_dml() {
         "WITH cte AS (SELECT 1) SELECT * FROM cte"
     ));
     assert!(is_explainable_query("TABLE users"));
+    assert!(is_explainable_query(
+        "MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET v = s.v"
+    ));
 }
 
 #[test]

--- a/src-tauri/src/drivers/driver_trait.rs
+++ b/src-tauri/src/drivers/driver_trait.rs
@@ -12,6 +12,33 @@ use crate::models::{
     TableSchema, TriggerInfo, ViewInfo,
 };
 
+/// SQL dialect declaration used by the frontend statement splitter
+/// (`src/utils/sqlSplitter/`) to pick per-dialect tokenizer rules:
+/// string-literal quoting, identifier quoting (backticks vs brackets),
+/// dollar-quoted strings, `DELIMITER` / `GO` directives, etc.
+///
+/// Typed at the trait boundary so plugin manifests are validated at
+/// install time rather than crashing the splitter on an unknown value.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SqlDialect {
+    Postgres,
+    Mysql,
+    Mssql,
+    Sqlite,
+    Oracle,
+    Generic,
+}
+
+impl Default for SqlDialect {
+    /// Preserves the behavior shipped before `sql_dialect` was introduced:
+    /// every driver — including PG-compat plugins already in the wild —
+    /// went through postgres-flavored splitting via `postgreSplitterOptions`.
+    fn default() -> Self {
+        Self::Postgres
+    }
+}
+
 /// Capabilities advertised by a driver.
 /// The frontend uses these flags to decide which UI sections to show.
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -78,6 +105,11 @@ pub struct DriverCapabilities {
     /// Defaults to `false`.
     #[serde(default)]
     pub readonly: bool,
+    /// SQL dialect for the statement splitter / classifier. Plugins that
+    /// omit the field fall back to `postgres` (matches pre-existing
+    /// behavior shipped via the previous `postgreSplitterOptions`).
+    #[serde(default)]
+    pub sql_dialect: SqlDialect,
 }
 
 fn default_double_quote() -> String {

--- a/src-tauri/src/drivers/mysql/mod.rs
+++ b/src-tauri/src/drivers/mysql/mod.rs
@@ -1154,7 +1154,7 @@ pub async fn drop_trigger(
 // ============================================================
 
 use crate::drivers::driver_trait::{
-    DatabaseDriver, DriverCapabilities, PluginManifest, PluginSettingDefinition,
+    DatabaseDriver, DriverCapabilities, PluginManifest, PluginSettingDefinition, SqlDialect,
 };
 use async_trait::async_trait;
 use std::collections::HashMap;
@@ -1221,6 +1221,7 @@ impl MysqlDriver {
                     manage_tables: true,
                     readonly: false,
                     triggers: true,
+                    sql_dialect: SqlDialect::Mysql,
                 },
                 is_builtin: true,
                 default_username: "root".to_string(),

--- a/src-tauri/src/drivers/postgres/mod.rs
+++ b/src-tauri/src/drivers/postgres/mod.rs
@@ -1294,7 +1294,7 @@ pub async fn drop_trigger(
 // Plugin wrapper
 // ============================================================
 
-use crate::drivers::driver_trait::{DatabaseDriver, DriverCapabilities, PluginManifest};
+use crate::drivers::driver_trait::{DatabaseDriver, DriverCapabilities, PluginManifest, SqlDialect};
 use async_trait::async_trait;
 use std::collections::HashMap;
 
@@ -1330,6 +1330,7 @@ impl PostgresDriver {
                     manage_tables: true,
                     readonly: false,
                     triggers: true,
+                    sql_dialect: SqlDialect::Postgres,
                 },
                 is_builtin: true,
                 default_username: "postgres".to_string(),

--- a/src-tauri/src/drivers/sqlite/mod.rs
+++ b/src-tauri/src/drivers/sqlite/mod.rs
@@ -855,7 +855,7 @@ pub async fn drop_trigger(
 // Plugin wrapper
 // ============================================================
 
-use crate::drivers::driver_trait::{DatabaseDriver, DriverCapabilities, PluginManifest};
+use crate::drivers::driver_trait::{DatabaseDriver, DriverCapabilities, PluginManifest, SqlDialect};
 use async_trait::async_trait;
 use std::collections::HashMap;
 
@@ -891,6 +891,7 @@ impl SqliteDriver {
                     manage_tables: true,
                     readonly: false,
                     triggers: true,
+                    sql_dialect: SqlDialect::Sqlite,
                 },
                 is_builtin: true,
                 default_username: String::new(),

--- a/src/components/modals/ExplainSelectionModal.tsx
+++ b/src/components/modals/ExplainSelectionModal.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { X, Network } from 'lucide-react';
 import { Modal } from '../ui/Modal';
+import { stripLeadingSqlComments } from '../../utils/sql';
 
 interface ExplainSelectionModalProps {
   isOpen: boolean;
@@ -102,7 +103,7 @@ const ExplainSelectionContent = ({
               {/* SQL */}
               <div className="flex-1 min-w-0">
                 <pre className="text-[13px] font-mono text-secondary leading-relaxed overflow-hidden whitespace-pre-wrap break-all line-clamp-3 group-hover:text-primary transition-colors">
-                  {entry.query}
+                  {stripLeadingSqlComments(entry.query) || entry.query}
                 </pre>
               </div>
 

--- a/src/components/modals/ExplainSelectionModal.tsx
+++ b/src/components/modals/ExplainSelectionModal.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { X, Network } from 'lucide-react';
 import { Modal } from '../ui/Modal';
-import { stripLeadingSqlComments } from '../../utils/sql';
+import { statementLabel } from '../../utils/sql';
 
 interface ExplainSelectionModalProps {
   isOpen: boolean;
@@ -103,7 +103,7 @@ const ExplainSelectionContent = ({
               {/* SQL */}
               <div className="flex-1 min-w-0">
                 <pre className="text-[13px] font-mono text-secondary leading-relaxed overflow-hidden whitespace-pre-wrap break-all line-clamp-3 group-hover:text-primary transition-colors">
-                  {stripLeadingSqlComments(entry.query) || entry.query}
+                  {statementLabel(entry.query)}
                 </pre>
               </div>
 

--- a/src/components/modals/QuerySelectionModal.tsx
+++ b/src/components/modals/QuerySelectionModal.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { X, Play, Check, ListChecks } from 'lucide-react';
 import { Modal } from '../ui/Modal';
+import { stripLeadingSqlComments } from '../../utils/sql';
 
 interface QuerySelectionModalProps {
   isOpen: boolean;
@@ -139,7 +140,7 @@ const QuerySelectionContent = ({ queries, onSelect, onRunAll, onRunSelected, onC
               {/* SQL + run-single on click */}
               <div className="flex-1 min-w-0" onClick={() => onSelect(q)}>
                 <pre className="text-[13px] font-mono text-secondary leading-relaxed overflow-hidden whitespace-pre-wrap break-all line-clamp-3 group-hover:text-primary transition-colors">
-                  {q}
+                  {stripLeadingSqlComments(q) || q}
                 </pre>
               </div>
 

--- a/src/components/modals/QuerySelectionModal.tsx
+++ b/src/components/modals/QuerySelectionModal.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { X, Play, Check, ListChecks } from 'lucide-react';
 import { Modal } from '../ui/Modal';
-import { stripLeadingSqlComments } from '../../utils/sql';
+import { statementLabel } from '../../utils/sql';
 
 interface QuerySelectionModalProps {
   isOpen: boolean;
@@ -140,7 +140,7 @@ const QuerySelectionContent = ({ queries, onSelect, onRunAll, onRunSelected, onC
               {/* SQL + run-single on click */}
               <div className="flex-1 min-w-0" onClick={() => onSelect(q)}>
                 <pre className="text-[13px] font-mono text-secondary leading-relaxed overflow-hidden whitespace-pre-wrap break-all line-clamp-3 group-hover:text-primary transition-colors">
-                  {stripLeadingSqlComments(q) || q}
+                  {statementLabel(q)}
                 </pre>
               </div>
 

--- a/src/hooks/useDrivers.ts
+++ b/src/hooks/useDrivers.ts
@@ -30,6 +30,7 @@ const FALLBACK_DRIVERS: PluginManifest[] = [
       inline_pk: false,
       alter_column: true,
       create_foreign_keys: true,
+      sql_dialect: "postgres",
     },
   },
   {
@@ -87,6 +88,7 @@ const FALLBACK_DRIVERS: PluginManifest[] = [
       inline_pk: false,
       alter_column: true,
       create_foreign_keys: true,
+      sql_dialect: "mysql",
     },
   },
   {
@@ -113,6 +115,7 @@ const FALLBACK_DRIVERS: PluginManifest[] = [
       inline_pk: true,
       alter_column: false,
       create_foreign_keys: false,
+      sql_dialect: "sqlite",
     },
   },
 ];

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -64,7 +64,7 @@ import {
   ExportProgressModal,
   type ExportStatus,
 } from "../components/modals/ExportProgressModal";
-import { splitQueries, extractTableName, getExplainableQueries } from "../utils/sql";
+import { splitQueries, extractTableName, getExplainableQueries, stripLeadingSqlComments } from "../utils/sql";
 import {
   createResultEntries,
   updateResultEntry,
@@ -2525,7 +2525,9 @@ export const Editor = () => {
                           {t("editor.noValidQueries")}
                         </div>
                       ) : (
-                        dropdownQueries.map((q, i) => (
+                        dropdownQueries.map((q, i) => {
+                          const label = stripLeadingSqlComments(q) || q;
+                          return (
                           <div
                             key={i}
                             className="flex items-center border-b border-strong/50 last:border-0 hover:bg-surface-tertiary/50 transition-colors group"
@@ -2538,7 +2540,7 @@ export const Editor = () => {
                               className="text-left px-4 py-2 text-xs font-mono text-secondary hover:text-white flex-1 truncate"
                               title={q}
                             >
-                              {q}
+                              {label}
                             </button>
                             <button
                               onClick={(e) => {
@@ -2552,7 +2554,8 @@ export const Editor = () => {
                               <Save size={14} />
                             </button>
                           </div>
-                        ))
+                          );
+                        })
                       )}
                     </div>
                   </>

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -1075,7 +1075,7 @@ export const Editor = () => {
       setSelectableQueries(queries);
       setIsQuerySelectionModalOpen(true);
     }
-  }, [activeTab, runQuery, runMultipleQueries]);
+  }, [activeTab, activeDialect, runQuery, runMultipleQueries]);
 
   const openExplainForQuery = useCallback((query: string) => {
     setVisualExplainQuery(query);
@@ -1110,7 +1110,7 @@ export const Editor = () => {
       setExplainSelectableQueries(explainable);
       setIsExplainSelectionOpen(true);
     }
-  }, [activeTab, activeConnectionId, openExplainForQuery]);
+  }, [activeTab, activeConnectionId, activeDialect, openExplainForQuery]);
 
   // Keep stable refs in sync for Monaco actions (closure-captured at mount time)
   runQueryRef.current = runQuery;

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -170,6 +170,7 @@ export const Editor = () => {
   const navigate = useNavigate();
 
   const driverReadonly = isReadonly(activeCapabilities);
+  const activeDialect = activeCapabilities?.sql_dialect;
 
   const [tabContextMenu, setTabContextMenu] = useState<{
     x: number;
@@ -386,6 +387,7 @@ export const Editor = () => {
   const runQueryRef = useRef<typeof runQuery>(null!);
   const runMultipleQueriesRef = useRef<typeof runMultipleQueries>(null!);
   const openExplainForQueryRef = useRef<(query: string) => void>(null!);
+  const activeDialectRef = useRef<typeof activeDialect>(undefined);
   const tabScrollRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
@@ -1039,7 +1041,7 @@ export const Editor = () => {
     if (!editorsRef.current[activeTab.id]) {
       // Fallback: use saved query when editor ref is not available (e.g. after tab restore)
       if (activeTab.query?.trim()) {
-        const queries = splitQueries(activeTab.query);
+        const queries = splitQueries(activeTab.query, activeDialect);
         if (queries.length <= 1) runQuery(queries[0] || activeTab.query, 1);
         else {
           setSelectableQueries(queries);
@@ -1055,7 +1057,7 @@ export const Editor = () => {
       : undefined;
 
     if (selectedText && selection && !selection.isEmpty()) {
-      const selectedQueries = splitQueries(selectedText);
+      const selectedQueries = splitQueries(selectedText, activeDialect);
       if (selectedQueries.length > 1) {
         runMultipleQueries(selectedQueries);
       } else {
@@ -1067,7 +1069,7 @@ export const Editor = () => {
     const fullText = editor.getValue();
     if (!fullText.trim()) return;
 
-    const queries = splitQueries(fullText);
+    const queries = splitQueries(fullText, activeDialect);
     if (queries.length <= 1) runQuery(queries[0] || fullText, 1);
     else {
       setSelectableQueries(queries);
@@ -1098,7 +1100,7 @@ export const Editor = () => {
 
     if (!text) return;
 
-    const explainable = getExplainableQueries(text);
+    const explainable = getExplainableQueries(text, activeDialect);
     if (explainable.length === 0) {
       // No explainable queries — open modal with full text so it shows the error
       openExplainForQuery(text);
@@ -1114,6 +1116,7 @@ export const Editor = () => {
   runQueryRef.current = runQuery;
   runMultipleQueriesRef.current = runMultipleQueries;
   openExplainForQueryRef.current = openExplainForQuery;
+  activeDialectRef.current = activeDialect;
 
   // Global Ctrl/Command+F5 shortcut for Run
   useEffect(() => {
@@ -2069,7 +2072,7 @@ export const Editor = () => {
           : undefined;
         const text = (selectedText || ed.getValue()).trim();
         if (!text) return;
-        const queries = splitQueries(text);
+        const queries = splitQueries(text, activeDialectRef.current);
         if (queries.length > 1) {
           runMultipleQueriesRef.current(queries);
         } else {
@@ -2089,7 +2092,7 @@ export const Editor = () => {
           : undefined;
         const text = (selectedText || ed.getValue()).trim();
         if (!text) return;
-        const explainable = getExplainableQueries(text);
+        const explainable = getExplainableQueries(text, activeDialectRef.current);
         if (explainable.length === 0) {
           openExplainForQueryRef.current(text);
         } else if (explainable.length === 1) {
@@ -2326,22 +2329,22 @@ export const Editor = () => {
             : undefined;
 
           if (selectedText && selection && !selection.isEmpty()) {
-            const queries = splitQueries(selectedText);
+            const queries = splitQueries(selectedText, activeDialect);
             setSelectableQueries(queries);
           } else {
             const text = editor.getValue();
-            const queries = splitQueries(text);
+            const queries = splitQueries(text, activeDialect);
             setSelectableQueries(queries);
           }
         } else if (activeTab.query?.trim()) {
           // Fallback: use saved query when editor ref is not available
-          const queries = splitQueries(activeTab.query);
+          const queries = splitQueries(activeTab.query, activeDialect);
           setSelectableQueries(queries);
         }
       }
     }
     setIsRunDropdownOpen((prev) => !prev);
-  }, [isRunDropdownOpen, activeTab]);
+  }, [isRunDropdownOpen, activeTab, activeDialect]);
 
   if (!activeTab) {
     return (

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -64,7 +64,7 @@ import {
   ExportProgressModal,
   type ExportStatus,
 } from "../components/modals/ExportProgressModal";
-import { splitQueries, extractTableName, getExplainableQueries, stripLeadingSqlComments } from "../utils/sql";
+import { splitQueries, extractTableName, getExplainableQueries, statementLabel } from "../utils/sql";
 import {
   createResultEntries,
   updateResultEntry,
@@ -1061,7 +1061,7 @@ export const Editor = () => {
       if (selectedQueries.length > 1) {
         runMultipleQueries(selectedQueries);
       } else {
-        runQuery(selectedText, 1);
+        runQuery(selectedQueries[0] || selectedText, 1);
       }
       return;
     }
@@ -2098,7 +2098,8 @@ export const Editor = () => {
         } else if (explainable.length === 1) {
           openExplainForQueryRef.current(explainable[0].query);
         } else {
-          openExplainForQueryRef.current(explainable[0].query);
+          setExplainSelectableQueries(explainable);
+          setIsExplainSelectionOpen(true);
         }
       },
     });
@@ -2529,7 +2530,7 @@ export const Editor = () => {
                         </div>
                       ) : (
                         dropdownQueries.map((q, i) => {
-                          const label = stripLeadingSqlComments(q) || q;
+                          const label = statementLabel(q);
                           return (
                           <div
                             key={i}

--- a/src/types/plugins.ts
+++ b/src/types/plugins.ts
@@ -29,6 +29,12 @@ export interface DriverCapabilities {
   readonly?: boolean;
   /** Supports listing and managing database triggers. Defaults to false. */
   triggers?: boolean;
+  /**
+   * SQL dialect for the statement splitter / classifier. Plugins that
+   * omit the field fall back to "postgres" (the dialect everyone got
+   * implicitly via the previous splitter).
+   */
+  sql_dialect?: "postgres" | "mysql" | "mssql" | "sqlite" | "oracle" | "generic";
 }
 
 export type PluginSettingType = "string" | "boolean" | "number" | "select";

--- a/src/types/plugins.ts
+++ b/src/types/plugins.ts
@@ -1,3 +1,5 @@
+import type { Dialect } from "../utils/sqlSplitter";
+
 export interface DriverCapabilities {
   schemas: boolean;
   views: boolean;
@@ -34,7 +36,7 @@ export interface DriverCapabilities {
    * omit the field fall back to "postgres" (the dialect everyone got
    * implicitly via the previous splitter).
    */
-  sql_dialect?: "postgres" | "mysql" | "mssql" | "sqlite" | "oracle" | "generic";
+  sql_dialect?: Dialect;
 }
 
 export type PluginSettingType = "string" | "boolean" | "number" | "select";

--- a/src/utils/openSourceLibraries.ts
+++ b/src/utils/openSourceLibraries.ts
@@ -33,7 +33,6 @@ export const OPEN_SOURCE_LIBRARY_SECTIONS: readonly OpenSourceLibrarySection[] =
       { name: "buffer", version: "^6.0.3" },
       { name: "clsx", version: "^2.1.1" },
       { name: "dagre", version: "^0.8.5" },
-      { name: "dbgate-query-splitter", version: "^4.12.0" },
       { name: "i18next", version: "^25.10.10" },
       { name: "i18next-browser-languagedetector", version: "^8.2.1" },
       { name: "lucide-react", version: "^0.563.0" },

--- a/src/utils/sql.ts
+++ b/src/utils/sql.ts
@@ -1,29 +1,14 @@
-import { splitQuery, postgreSplitterOptions } from 'dbgate-query-splitter';
+import { splitStatements, stripLeadingComments, isExplainable } from './sqlSplitter';
 
 export function splitQueries(sql: string): string[] {
-  return splitQuery(sql, postgreSplitterOptions).map(item => typeof item == "string" ? item : item.text);
+  return splitStatements(sql).map((s) => s.text);
 }
 
 /**
  * Strip leading SQL comments (single-line and block comments) and whitespace
  * so that the first keyword of the actual statement is at position 0.
  */
-export function stripLeadingSqlComments(query: string): string {
-  let s = query;
-  for (;;) {
-    s = s.trimStart();
-    if (s.startsWith("--")) {
-      const nl = s.indexOf("\n");
-      s = nl === -1 ? "" : s.slice(nl + 1);
-    } else if (s.startsWith("/*")) {
-      const end = s.indexOf("*/");
-      s = end === -1 ? "" : s.slice(end + 2);
-    } else {
-      break;
-    }
-  }
-  return s;
-}
+export const stripLeadingSqlComments = stripLeadingComments;
 
 /**
  * Check if a SQL statement supports EXPLAIN.
@@ -32,33 +17,21 @@ export function stripLeadingSqlComments(query: string): string {
  * and CTEs (WITH). DDL statements (CREATE, DROP, ALTER, TRUNCATE, etc.) are not supported.
  * Leading SQL comments are stripped before checking.
  */
-export function isExplainableQuery(query: string): boolean {
-  const upper = stripLeadingSqlComments(query).toUpperCase();
-  return (
-    upper.startsWith("SELECT") ||
-    upper.startsWith("INSERT") ||
-    upper.startsWith("UPDATE") ||
-    upper.startsWith("DELETE") ||
-    upper.startsWith("REPLACE") ||
-    upper.startsWith("WITH") ||
-    upper.startsWith("TABLE")
-  );
-}
+export const isExplainableQuery = isExplainable;
 
 /**
  * Splits a SQL text into individual queries and returns only those
  * that are explainable (DML: SELECT, INSERT, UPDATE, DELETE, REPLACE, WITH, TABLE).
- * Each returned entry carries its 1-based index in the original split.
+ *
+ * `index` is 1-based over emitted statements. Comment-only fragments are
+ * folded into adjacent statements (not counted), so indices line up with
+ * the run-button dropdown entries the user sees.
  */
 export function getExplainableQueries(
   sql: string,
 ): { query: string; index: number }[] {
-  return splitQueries(sql).reduce<{ query: string; index: number }[]>(
-    (acc, q, i) => {
-      if (isExplainableQuery(q)) acc.push({ query: q, index: i + 1 });
-      return acc;
-    },
-    [],
+  return splitStatements(sql).flatMap((s, i) =>
+    s.isExplainable ? [{ query: s.text, index: i + 1 }] : [],
   );
 }
 
@@ -110,7 +83,7 @@ export function extractTableName(sql: string): string | null {
   // Match FROM clause with optional quotes
   // Matches: FROM table, FROM `table`, FROM "table", FROM 'table'
   const fromMatch = cleaned.match(/\bFROM\s+([`"']?)(\w+)\1/i);
-  
+
   if (fromMatch && fromMatch[2]) {
     return fromMatch[2];
   }

--- a/src/utils/sql.ts
+++ b/src/utils/sql.ts
@@ -1,36 +1,16 @@
-import { splitStatements, stripLeadingComments, isExplainable } from './sqlSplitter';
+import {
+  type Dialect,
+  splitStatements,
+  stripLeadingComments,
+  isExplainable,
+} from './sqlSplitter';
 
-/**
- * Dialect identifier accepted by the splitter. Sourced from
- * `DriverCapabilities.sql_dialect` (Rust side); `undefined` means "use
- * the splitter default" (postgres), which matches behavior shipped
- * before the dialect was threaded through.
- */
-export type SqlDialect =
-  | 'postgres'
-  | 'mysql'
-  | 'mssql'
-  | 'sqlite'
-  | 'oracle'
-  | 'generic';
+export type SqlDialect = Dialect;
 
-export function splitQueries(sql: string, dialect?: SqlDialect): string[] {
-  return splitStatements(sql, dialect).map((s) => s.text);
-}
+export { splitQueries } from './sqlSplitter';
 
-/**
- * Strip leading SQL comments (single-line and block comments) and whitespace
- * so that the first keyword of the actual statement is at position 0.
- */
 export const stripLeadingSqlComments = stripLeadingComments;
 
-/**
- * Check if a SQL statement supports EXPLAIN.
- *
- * EXPLAIN works with DML statements (SELECT, INSERT, UPDATE, DELETE, REPLACE)
- * and CTEs (WITH). DDL statements (CREATE, DROP, ALTER, TRUNCATE, etc.) are not supported.
- * Leading SQL comments are stripped before checking.
- */
 export const isExplainableQuery = isExplainable;
 
 /**
@@ -52,6 +32,16 @@ export function getExplainableQueries(
   return splitStatements(sql, dialect).flatMap((s, i) =>
     s.isExplainable ? [{ query: s.text, index: i + 1 }] : [],
   );
+}
+
+/**
+ * Returns the user-facing label for a SQL statement in dropdowns and
+ * pickers. Strips leading comments so the first keyword surfaces, and
+ * falls back to the raw text when the statement is entirely comments
+ * (so the label is never blank).
+ */
+export function statementLabel(query: string): string {
+  return stripLeadingComments(query) || query;
 }
 
 /**

--- a/src/utils/sql.ts
+++ b/src/utils/sql.ts
@@ -1,7 +1,21 @@
 import { splitStatements, stripLeadingComments, isExplainable } from './sqlSplitter';
 
-export function splitQueries(sql: string): string[] {
-  return splitStatements(sql).map((s) => s.text);
+/**
+ * Dialect identifier accepted by the splitter. Sourced from
+ * `DriverCapabilities.sql_dialect` (Rust side); `undefined` means "use
+ * the splitter default" (postgres), which matches behavior shipped
+ * before the dialect was threaded through.
+ */
+export type SqlDialect =
+  | 'postgres'
+  | 'mysql'
+  | 'mssql'
+  | 'sqlite'
+  | 'oracle'
+  | 'generic';
+
+export function splitQueries(sql: string, dialect?: SqlDialect): string[] {
+  return splitStatements(sql, dialect).map((s) => s.text);
 }
 
 /**
@@ -29,8 +43,9 @@ export const isExplainableQuery = isExplainable;
  */
 export function getExplainableQueries(
   sql: string,
+  dialect?: SqlDialect,
 ): { query: string; index: number }[] {
-  return splitStatements(sql).flatMap((s, i) =>
+  return splitStatements(sql, dialect).flatMap((s, i) =>
     s.isExplainable ? [{ query: s.text, index: i + 1 }] : [],
   );
 }

--- a/src/utils/sql.ts
+++ b/src/utils/sql.ts
@@ -37,9 +37,13 @@ export const isExplainableQuery = isExplainable;
  * Splits a SQL text into individual queries and returns only those
  * that are explainable (DML: SELECT, INSERT, UPDATE, DELETE, REPLACE, WITH, TABLE).
  *
- * `index` is 1-based over emitted statements. Comment-only fragments are
- * folded into adjacent statements (not counted), so indices line up with
- * the run-button dropdown entries the user sees.
+ * `index` is 1-based and counts *all* statements emitted by the splitter,
+ * including non-explainable ones (DDL etc.). Example: for
+ * `CREATE TABLE t (...); SELECT * FROM t;` the SELECT gets `index: 2`,
+ * matching its position in the run-button dropdown.
+ *
+ * Comment-only fragments are folded into adjacent statements by the
+ * splitter and do not consume an index slot.
  */
 export function getExplainableQueries(
   sql: string,

--- a/src/utils/sqlSplitter/classify.ts
+++ b/src/utils/sqlSplitter/classify.ts
@@ -1,0 +1,63 @@
+// Single-statement classifiers. Mirror of
+// src-tauri/src/drivers/common/query.rs:7-84 but word-boundary aware so
+// `SELECTIVE` does not match `SELECT`.
+
+const RESULT_SET_KEYWORDS: ReadonlySet<string> = new Set([
+  'SELECT',
+  'WITH',
+  'SHOW',
+  'EXPLAIN',
+  'DESCRIBE',
+  'DESC',
+  'VALUES',
+  'TABLE',
+  'PRAGMA',
+  'CALL',
+]);
+
+const EXPLAINABLE_KEYWORDS: ReadonlySet<string> = new Set([
+  'SELECT',
+  'INSERT',
+  'UPDATE',
+  'DELETE',
+  'REPLACE',
+  'WITH',
+  'TABLE',
+]);
+
+export function stripLeadingComments(query: string): string {
+  let s = query;
+  for (;;) {
+    s = s.replace(/^\s+/, '');
+    if (s.startsWith('--')) {
+      const nl = s.indexOf('\n');
+      s = nl === -1 ? '' : s.slice(nl + 1);
+    } else if (s.startsWith('/*')) {
+      const end = s.indexOf('*/');
+      s = end === -1 ? '' : s.slice(end + 2);
+    } else {
+      break;
+    }
+  }
+  return s;
+}
+
+const LEADING_KEYWORD_RE = /^([A-Za-z_][A-Za-z0-9_]*)/;
+
+function leadingKeyword(query: string): string {
+  const stripped = stripLeadingComments(query);
+  const match = LEADING_KEYWORD_RE.exec(stripped);
+  return match ? match[1].toUpperCase() : '';
+}
+
+export function isSelect(query: string): boolean {
+  return leadingKeyword(query) === 'SELECT';
+}
+
+export function returnsResultSet(query: string): boolean {
+  return RESULT_SET_KEYWORDS.has(leadingKeyword(query));
+}
+
+export function isExplainable(query: string): boolean {
+  return EXPLAINABLE_KEYWORDS.has(leadingKeyword(query));
+}

--- a/src/utils/sqlSplitter/classify.ts
+++ b/src/utils/sqlSplitter/classify.ts
@@ -1,6 +1,15 @@
 // Single-statement classifiers. Mirror of
-// src-tauri/src/drivers/common/query.rs:7-84 but word-boundary aware so
-// `SELECTIVE` does not match `SELECT`.
+// src-tauri/src/drivers/common/query.rs:7-84.
+//
+// Deliberate divergence from the Rust side: Rust uses `starts_with` after
+// stripping leading comments, which means inputs like `SELECTIVE ...`
+// would match `SELECT`. The TS side instead extracts the leading
+// identifier and compares whole-word against a keyword set, so
+// `SELECTIVE` does not classify as a SELECT. The split-button dropdown
+// is user-facing, where the stricter rule avoids surprising false
+// positives; the Rust side is internal and the looser rule is fine
+// there. Keep these two implementations in sync semantically (same
+// keyword sets) but accept the matching strategy difference.
 
 const RESULT_SET_KEYWORDS: ReadonlySet<string> = new Set([
   'SELECT',

--- a/src/utils/sqlSplitter/classify.ts
+++ b/src/utils/sqlSplitter/classify.ts
@@ -57,10 +57,15 @@ const LEADING_KEYWORD_RE = /^([A-Za-z_][A-Za-z0-9_]*)/;
 const LEADING_PARENS_RE = /^[(\s]+/;
 
 export function leadingKeyword(query: string): string {
-  // Strip leading comments, then leading whitespace and `(` so that
-  // parenthesised queries like `(SELECT 1)` still classify by their
-  // inner keyword.
-  const body = stripLeadingComments(query).replace(LEADING_PARENS_RE, '');
+  // Comments may sit inside the parens (`(\n-- header\nSELECT 1)`),
+  // and parens may sit between leading comments (`/* x */ ( SELECT 1 )`),
+  // so we strip both in a fixed-point loop instead of one pass each.
+  let body = query;
+  for (;;) {
+    const next = stripLeadingComments(body).replace(LEADING_PARENS_RE, '');
+    if (next === body) break;
+    body = next;
+  }
   const match = LEADING_KEYWORD_RE.exec(body);
   return match ? match[1].toUpperCase() : '';
 }

--- a/src/utils/sqlSplitter/classify.ts
+++ b/src/utils/sqlSplitter/classify.ts
@@ -11,7 +11,7 @@
 // there. Keep these two implementations in sync semantically (same
 // keyword sets) but accept the matching strategy difference.
 
-const RESULT_SET_KEYWORDS: ReadonlySet<string> = new Set([
+export const RESULT_SET_KEYWORDS: ReadonlySet<string> = new Set([
   'SELECT',
   'WITH',
   'SHOW',
@@ -24,7 +24,7 @@ const RESULT_SET_KEYWORDS: ReadonlySet<string> = new Set([
   'CALL',
 ]);
 
-const EXPLAINABLE_KEYWORDS: ReadonlySet<string> = new Set([
+export const EXPLAINABLE_KEYWORDS: ReadonlySet<string> = new Set([
   'SELECT',
   'INSERT',
   'UPDATE',
@@ -32,6 +32,8 @@ const EXPLAINABLE_KEYWORDS: ReadonlySet<string> = new Set([
   'REPLACE',
   'WITH',
   'TABLE',
+  // PostgreSQL 15+ and Oracle both support EXPLAIN MERGE.
+  'MERGE',
 ]);
 
 export function stripLeadingComments(query: string): string {
@@ -52,10 +54,14 @@ export function stripLeadingComments(query: string): string {
 }
 
 const LEADING_KEYWORD_RE = /^([A-Za-z_][A-Za-z0-9_]*)/;
+const LEADING_PARENS_RE = /^[(\s]+/;
 
-function leadingKeyword(query: string): string {
-  const stripped = stripLeadingComments(query);
-  const match = LEADING_KEYWORD_RE.exec(stripped);
+export function leadingKeyword(query: string): string {
+  // Strip leading comments, then leading whitespace and `(` so that
+  // parenthesised queries like `(SELECT 1)` still classify by their
+  // inner keyword.
+  const body = stripLeadingComments(query).replace(LEADING_PARENS_RE, '');
+  const match = LEADING_KEYWORD_RE.exec(body);
   return match ? match[1].toUpperCase() : '';
 }
 

--- a/src/utils/sqlSplitter/index.ts
+++ b/src/utils/sqlSplitter/index.ts
@@ -145,20 +145,26 @@ const DIALECT_TABLE: Readonly<Record<Dialect, DialectOptions>> = {
   generic: GENERIC,
 };
 
-export function dialectOptions(dialect: Dialect): DialectOptions {
-  return DIALECT_TABLE[dialect];
+/**
+ * Look up the option preset for a dialect. Falls back to `generic` if the
+ * caller (e.g. a plugin manifest passing through serde) hands in an
+ * unknown string — the splitter stays defensive even when the type
+ * boundary is bypassed.
+ */
+export function dialectOptions(dialect: Dialect | string): DialectOptions {
+  return DIALECT_TABLE[dialect as Dialect] ?? GENERIC;
 }
 
 export function splitStatements(
   sql: string,
-  dialect: Dialect = 'postgres',
+  dialect: Dialect | string = 'postgres',
 ): Statement[] {
   return splitInto(sql, dialectOptions(dialect));
 }
 
 export function splitQueries(
   sql: string,
-  dialect: Dialect = 'postgres',
+  dialect: Dialect | string = 'postgres',
 ): string[] {
   return splitStatements(sql, dialect).map((s) => s.text);
 }

--- a/src/utils/sqlSplitter/index.ts
+++ b/src/utils/sqlSplitter/index.ts
@@ -12,6 +12,13 @@ export type Dialect =
   | 'oracle'
   | 'generic';
 
+/**
+ * Byte-offset span of the meaningful (non-comment) portion of a statement
+ * in the original source. Comments folded into `Statement.text` are NOT
+ * included in the range — only the actual SQL body. Use this for Monaco
+ * decorations / cursor positioning that should target the real statement
+ * and skip over surrounding comment whitespace.
+ */
 export interface StatementRange {
   readonly start: number;
   readonly end: number;
@@ -91,7 +98,8 @@ const MYSQL: DialectOptions = {
 const MSSQL: DialectOptions = {
   quotes: [
     { open: "'", close: "'", doubleClose: true },
-    { open: '[', close: ']', doubleClose: false },
+    // T-SQL: `]]` inside `[...]` is the literal `]` escape.
+    { open: '[', close: ']', doubleClose: true },
   ],
   eString: false,
   dollarQuoting: false,
@@ -146,25 +154,37 @@ const DIALECT_TABLE: Readonly<Record<Dialect, DialectOptions>> = {
 };
 
 /**
- * Look up the option preset for a dialect. Falls back to `generic` if the
- * caller (e.g. a plugin manifest passing through serde) hands in an
- * unknown string — the splitter stays defensive even when the type
- * boundary is bypassed.
+ * Look up the option preset for a dialect. Strictly typed — pass a
+ * `Dialect`. If you have an unvalidated string (e.g. a plugin manifest
+ * value passed through serde), normalize it at the call site or rely on
+ * the public `splitStatements` / `splitQueries` entry points which do
+ * that normalization for you.
  */
-export function dialectOptions(dialect: Dialect | string): DialectOptions {
-  return DIALECT_TABLE[dialect as Dialect] ?? GENERIC;
+export function dialectOptions(dialect: Dialect): DialectOptions {
+  return DIALECT_TABLE[dialect];
 }
 
+function normalizeDialect(dialect: Dialect | string | undefined): Dialect {
+  if (dialect === undefined) return 'postgres';
+  return dialect in DIALECT_TABLE ? (dialect as Dialect) : 'generic';
+}
+
+/**
+ * Split a SQL source into per-statement metadata. `dialect` is accepted
+ * as `Dialect | string` so plugin-manifest values can flow in without
+ * additional validation at the call site; unknown values fall back to
+ * the `generic` preset rather than throwing.
+ */
 export function splitStatements(
   sql: string,
-  dialect: Dialect | string = 'postgres',
+  dialect?: Dialect | string,
 ): Statement[] {
-  return splitInto(sql, dialectOptions(dialect));
+  return splitInto(sql, dialectOptions(normalizeDialect(dialect)));
 }
 
 export function splitQueries(
   sql: string,
-  dialect: Dialect | string = 'postgres',
+  dialect?: Dialect | string,
 ): string[] {
   return splitStatements(sql, dialect).map((s) => s.text);
 }

--- a/src/utils/sqlSplitter/index.ts
+++ b/src/utils/sqlSplitter/index.ts
@@ -65,15 +65,18 @@ export interface DialectOptions {
   readonly lineComments: boolean;
   readonly blockComments: boolean;
   /**
-   * Treat `/*! … *​/` as a meaningful statement instead of a comment.
-   * MySQL/MariaDB evaluates these "executable comments" when the
-   * embedded version directive permits; dump scripts rely on them
-   * being emitted as their own statement.
+   * Treat MySQL/MariaDB conditional comments (the ones opening with
+   * `/*!`) as meaningful statements instead of noop comments. The
+   * server evaluates them when the embedded version directive
+   * permits; dump scripts rely on them being emitted as their own
+   * statement so individual driver calls execute them.
    */
   readonly executableComments: boolean;
   /**
-   * Allow `/* … *​/` to nest. Required for PostgreSQL, which permits
-   * `/* outer /* inner *​/ outer *​/` as one comment.
+   * Allow block comments to nest, as PostgreSQL does. With this off,
+   * the first closing block-comment marker ends the comment; with it
+   * on, the scanner tracks depth and only ends at the matching
+   * outermost marker.
    */
   readonly nestedBlockComments: boolean;
 }

--- a/src/utils/sqlSplitter/index.ts
+++ b/src/utils/sqlSplitter/index.ts
@@ -79,6 +79,14 @@ export interface DialectOptions {
    * outermost marker.
    */
   readonly nestedBlockComments: boolean;
+  /**
+   * MySQL/MariaDB require `--` to be followed by whitespace (or
+   * end-of-line) to be recognised as a line comment, otherwise it is
+   * the binary subtraction operator (e.g. `SELECT 1--1` evaluates to
+   * `2`). PostgreSQL, MSSQL, SQLite and Oracle accept `--` regardless
+   * of what follows.
+   */
+  readonly lineCommentRequiresSpace: boolean;
 }
 
 const STANDARD_QUOTES: ReadonlyArray<QuoteRule> = [
@@ -96,6 +104,7 @@ const POSTGRES: DialectOptions = {
   blockComments: true,
   executableComments: false,
   nestedBlockComments: true,
+  lineCommentRequiresSpace: false,
 };
 
 const MYSQL: DialectOptions = {
@@ -112,6 +121,7 @@ const MYSQL: DialectOptions = {
   blockComments: true,
   executableComments: true,
   nestedBlockComments: false,
+  lineCommentRequiresSpace: true,
 };
 
 const MSSQL: DialectOptions = {
@@ -128,6 +138,7 @@ const MSSQL: DialectOptions = {
   blockComments: true,
   executableComments: false,
   nestedBlockComments: false,
+  lineCommentRequiresSpace: false,
 };
 
 const SQLITE: DialectOptions = {
@@ -145,6 +156,7 @@ const SQLITE: DialectOptions = {
   blockComments: true,
   executableComments: false,
   nestedBlockComments: false,
+  lineCommentRequiresSpace: false,
 };
 
 // Oracle's option shape currently matches GENERIC. They are kept as
@@ -164,6 +176,7 @@ const ORACLE: DialectOptions = {
   blockComments: true,
   executableComments: false,
   nestedBlockComments: false,
+  lineCommentRequiresSpace: false,
 };
 
 const GENERIC: DialectOptions = {
@@ -176,6 +189,7 @@ const GENERIC: DialectOptions = {
   blockComments: true,
   executableComments: false,
   nestedBlockComments: false,
+  lineCommentRequiresSpace: false,
 };
 
 const DIALECT_TABLE: Readonly<Record<Dialect, DialectOptions>> = {

--- a/src/utils/sqlSplitter/index.ts
+++ b/src/utils/sqlSplitter/index.ts
@@ -9,12 +9,18 @@ export type Dialect =
   | 'generic';
 
 /**
- * String-index span (JavaScript UTF-16 code unit offsets) of the
- * meaningful (non-comment) portion of a statement in the original
- * source. Comments folded into `Statement.text` are NOT included in
- * the range — only the actual SQL body. Use this for Monaco
- * decorations / cursor positioning that should target the real
- * statement and skip over surrounding comment whitespace.
+ * String-index span (JavaScript UTF-16 code unit offsets) of a
+ * statement in the original source. ASCII leading and trailing
+ * whitespace is excluded, and comment-only segments that were folded
+ * into adjacent statements by the splitter are NOT covered (only the
+ * meaningful segment's bounds are reported).
+ *
+ * What is still included in the range: any leading or trailing
+ * comments that live inside the meaningful segment itself, e.g. the
+ * `-- header` in `-- header\nSELECT 1;`. Consumers that need a
+ * strictly comment-free range should re-strip via
+ * `stripLeadingComments` (and a future trailing-comment helper) on
+ * the slice they get from this range.
  *
  * Note: these are JS string indices, not byte offsets. Callers that
  * need byte positions (e.g. a Rust backend) must re-encode.

--- a/src/utils/sqlSplitter/index.ts
+++ b/src/utils/sqlSplitter/index.ts
@@ -1,7 +1,3 @@
-// First-party SQL statement splitter. Replaces dbgate-query-splitter.
-// Closes #223: comment-only fragments are folded into adjacent statements,
-// never emitted as standalone entries.
-
 import { splitInto } from './splitter';
 
 export type Dialect =
@@ -13,11 +9,15 @@ export type Dialect =
   | 'generic';
 
 /**
- * Byte-offset span of the meaningful (non-comment) portion of a statement
- * in the original source. Comments folded into `Statement.text` are NOT
- * included in the range — only the actual SQL body. Use this for Monaco
- * decorations / cursor positioning that should target the real statement
- * and skip over surrounding comment whitespace.
+ * String-index span (JavaScript UTF-16 code unit offsets) of the
+ * meaningful (non-comment) portion of a statement in the original
+ * source. Comments folded into `Statement.text` are NOT included in
+ * the range — only the actual SQL body. Use this for Monaco
+ * decorations / cursor positioning that should target the real
+ * statement and skip over surrounding comment whitespace.
+ *
+ * Note: these are JS string indices, not byte offsets. Callers that
+ * need byte positions (e.g. a Rust backend) must re-encode.
  */
 export interface StatementRange {
   readonly start: number;
@@ -64,6 +64,18 @@ export interface DialectOptions {
   readonly goDelimiter: boolean;
   readonly lineComments: boolean;
   readonly blockComments: boolean;
+  /**
+   * Treat `/*! … *​/` as a meaningful statement instead of a comment.
+   * MySQL/MariaDB evaluates these "executable comments" when the
+   * embedded version directive permits; dump scripts rely on them
+   * being emitted as their own statement.
+   */
+  readonly executableComments: boolean;
+  /**
+   * Allow `/* … *​/` to nest. Required for PostgreSQL, which permits
+   * `/* outer /* inner *​/ outer *​/` as one comment.
+   */
+  readonly nestedBlockComments: boolean;
 }
 
 const STANDARD_QUOTES: ReadonlyArray<QuoteRule> = [
@@ -79,6 +91,8 @@ const POSTGRES: DialectOptions = {
   goDelimiter: false,
   lineComments: true,
   blockComments: true,
+  executableComments: false,
+  nestedBlockComments: true,
 };
 
 const MYSQL: DialectOptions = {
@@ -93,6 +107,8 @@ const MYSQL: DialectOptions = {
   goDelimiter: false,
   lineComments: true,
   blockComments: true,
+  executableComments: true,
+  nestedBlockComments: false,
 };
 
 const MSSQL: DialectOptions = {
@@ -107,6 +123,8 @@ const MSSQL: DialectOptions = {
   goDelimiter: true,
   lineComments: true,
   blockComments: true,
+  executableComments: false,
+  nestedBlockComments: false,
 };
 
 const SQLITE: DialectOptions = {
@@ -122,8 +140,17 @@ const SQLITE: DialectOptions = {
   goDelimiter: false,
   lineComments: true,
   blockComments: true,
+  executableComments: false,
+  nestedBlockComments: false,
 };
 
+// Oracle's option shape currently matches GENERIC. They are kept as
+// separate constants on purpose: once an Oracle-only feature lands
+// (e.g. `/` block terminator, nested block comments via SQLPlus, the
+// `Q'…'` quoted literal syntax), the divergence stays a one-line edit
+// rather than a search across call sites. If you find yourself
+// modifying both, prefer adding the flag to GENERIC only when it is
+// truly dialect-agnostic.
 const ORACLE: DialectOptions = {
   quotes: STANDARD_QUOTES,
   eString: false,
@@ -132,6 +159,8 @@ const ORACLE: DialectOptions = {
   goDelimiter: false,
   lineComments: true,
   blockComments: true,
+  executableComments: false,
+  nestedBlockComments: false,
 };
 
 const GENERIC: DialectOptions = {
@@ -142,6 +171,8 @@ const GENERIC: DialectOptions = {
   goDelimiter: false,
   lineComments: true,
   blockComments: true,
+  executableComments: false,
+  nestedBlockComments: false,
 };
 
 const DIALECT_TABLE: Readonly<Record<Dialect, DialectOptions>> = {

--- a/src/utils/sqlSplitter/index.ts
+++ b/src/utils/sqlSplitter/index.ts
@@ -1,0 +1,171 @@
+// First-party SQL statement splitter. Replaces dbgate-query-splitter.
+// Closes #223: comment-only fragments are folded into adjacent statements,
+// never emitted as standalone entries.
+
+import { splitInto } from './splitter';
+
+export type Dialect =
+  | 'postgres'
+  | 'mysql'
+  | 'mssql'
+  | 'sqlite'
+  | 'oracle'
+  | 'generic';
+
+export interface StatementRange {
+  readonly start: number;
+  readonly end: number;
+}
+
+export interface Statement {
+  readonly text: string;
+  readonly range: StatementRange;
+  readonly isSelect: boolean;
+  readonly returnsResultSet: boolean;
+  readonly isExplainable: boolean;
+}
+
+export type TokenKind =
+  | 'whitespace'
+  | 'eoln'
+  | 'lineComment'
+  | 'blockComment'
+  | 'string'
+  | 'delimiter'
+  | 'setDelimiter'
+  | 'goDelimiter'
+  | 'data';
+
+export interface Token {
+  readonly kind: TokenKind;
+  readonly length: number;
+  readonly value?: string;
+}
+
+export interface QuoteRule {
+  readonly open: string;
+  readonly close: string;
+  readonly escape?: string;
+  readonly doubleClose: boolean;
+}
+
+export interface DialectOptions {
+  readonly quotes: ReadonlyArray<QuoteRule>;
+  readonly eString: boolean;
+  readonly dollarQuoting: boolean;
+  readonly customDelimiter: boolean;
+  readonly goDelimiter: boolean;
+  readonly lineComments: boolean;
+  readonly blockComments: boolean;
+}
+
+const STANDARD_QUOTES: ReadonlyArray<QuoteRule> = [
+  { open: "'", close: "'", doubleClose: true },
+  { open: '"', close: '"', doubleClose: true },
+];
+
+const POSTGRES: DialectOptions = {
+  quotes: STANDARD_QUOTES,
+  eString: true,
+  dollarQuoting: true,
+  customDelimiter: false,
+  goDelimiter: false,
+  lineComments: true,
+  blockComments: true,
+};
+
+const MYSQL: DialectOptions = {
+  quotes: [
+    { open: "'", close: "'", escape: '\\', doubleClose: true },
+    { open: '"', close: '"', escape: '\\', doubleClose: true },
+    { open: '`', close: '`', doubleClose: true },
+  ],
+  eString: false,
+  dollarQuoting: false,
+  customDelimiter: true,
+  goDelimiter: false,
+  lineComments: true,
+  blockComments: true,
+};
+
+const MSSQL: DialectOptions = {
+  quotes: [
+    { open: "'", close: "'", doubleClose: true },
+    { open: '[', close: ']', doubleClose: false },
+  ],
+  eString: false,
+  dollarQuoting: false,
+  customDelimiter: false,
+  goDelimiter: true,
+  lineComments: true,
+  blockComments: true,
+};
+
+const SQLITE: DialectOptions = {
+  quotes: [
+    { open: "'", close: "'", doubleClose: true },
+    { open: '"', close: '"', doubleClose: true },
+    { open: '`', close: '`', doubleClose: true },
+    { open: '[', close: ']', doubleClose: false },
+  ],
+  eString: false,
+  dollarQuoting: false,
+  customDelimiter: false,
+  goDelimiter: false,
+  lineComments: true,
+  blockComments: true,
+};
+
+const ORACLE: DialectOptions = {
+  quotes: STANDARD_QUOTES,
+  eString: false,
+  dollarQuoting: false,
+  customDelimiter: false,
+  goDelimiter: false,
+  lineComments: true,
+  blockComments: true,
+};
+
+const GENERIC: DialectOptions = {
+  quotes: STANDARD_QUOTES,
+  eString: false,
+  dollarQuoting: false,
+  customDelimiter: false,
+  goDelimiter: false,
+  lineComments: true,
+  blockComments: true,
+};
+
+const DIALECT_TABLE: Readonly<Record<Dialect, DialectOptions>> = {
+  postgres: POSTGRES,
+  mysql: MYSQL,
+  mssql: MSSQL,
+  sqlite: SQLITE,
+  oracle: ORACLE,
+  generic: GENERIC,
+};
+
+export function dialectOptions(dialect: Dialect): DialectOptions {
+  return DIALECT_TABLE[dialect];
+}
+
+export function splitStatements(
+  sql: string,
+  dialect: Dialect = 'postgres',
+): Statement[] {
+  return splitInto(sql, dialectOptions(dialect));
+}
+
+export function splitQueries(
+  sql: string,
+  dialect: Dialect = 'postgres',
+): string[] {
+  return splitStatements(sql, dialect).map((s) => s.text);
+}
+
+export {
+  isSelect,
+  returnsResultSet,
+  isExplainable,
+  stripLeadingComments,
+} from './classify';

--- a/src/utils/sqlSplitter/splitter.ts
+++ b/src/utils/sqlSplitter/splitter.ts
@@ -1,0 +1,123 @@
+// Statement splitter. Two-pass:
+//   1. collectSegments — walk tokens, partition source by delimiter into
+//      raw segments with a hasMeaningful flag.
+//   2. foldComments — apply fold rule:
+//      (a) leading comment-only segment(s) → prepended to NEXT meaningful;
+//      (b) trailing comment-only segment(s) → appended to PREVIOUS;
+//      (c) entirely comment-only input → drop, return [].
+
+import { isExplainable, isSelect, returnsResultSet } from './classify';
+import type { DialectOptions, Statement } from './index';
+import type { TokenizerState } from './tokenizer';
+import { scanToken } from './tokenizer';
+
+interface RawSegment {
+  readonly start: number;
+  readonly end: number;
+  readonly hasMeaningful: boolean;
+}
+
+interface Span {
+  readonly start: number;
+  readonly end: number;
+}
+
+export function splitInto(sql: string, options: DialectOptions): Statement[] {
+  if (sql.length === 0) return [];
+  const segments = collectSegments(sql, options);
+  const folded = foldComments(segments);
+  return folded.map((spans) => buildStatement(sql, spans));
+}
+
+function collectSegments(sql: string, options: DialectOptions): RawSegment[] {
+  const state: TokenizerState = { delimiter: ';', lineLeading: true };
+  const segments: RawSegment[] = [];
+  let segStart = 0;
+  let hasMeaningful = false;
+  let position = 0;
+
+  const pushSegment = (end: number): void => {
+    if (end <= segStart) return;
+    segments.push({ start: segStart, end, hasMeaningful });
+  };
+
+  while (position < sql.length) {
+    const token = scanToken(sql, position, options, state);
+    if (token === null) break;
+
+    switch (token.kind) {
+      case 'delimiter':
+      case 'goDelimiter':
+        pushSegment(position);
+        position += token.length;
+        segStart = position;
+        hasMeaningful = false;
+        state.lineLeading = false;
+        break;
+      case 'setDelimiter':
+        pushSegment(position);
+        position += token.length;
+        segStart = position;
+        hasMeaningful = false;
+        if (token.value !== undefined) state.delimiter = token.value;
+        state.lineLeading = false;
+        break;
+      case 'string':
+      case 'data':
+        hasMeaningful = true;
+        position += token.length;
+        state.lineLeading = false;
+        break;
+      case 'lineComment':
+      case 'blockComment':
+        position += token.length;
+        state.lineLeading = false;
+        break;
+      case 'eoln':
+        position += token.length;
+        state.lineLeading = true;
+        break;
+      case 'whitespace':
+        position += token.length;
+        break;
+    }
+  }
+
+  pushSegment(sql.length);
+  return segments;
+}
+
+function foldComments(segments: ReadonlyArray<RawSegment>): Span[][] {
+  const output: Span[][] = [];
+  let pending: Span[] = [];
+
+  for (const seg of segments) {
+    const span: Span = { start: seg.start, end: seg.end };
+    if (seg.hasMeaningful) {
+      output.push([...pending, span]);
+      pending = [];
+    } else {
+      pending = [...pending, span];
+    }
+  }
+
+  if (pending.length > 0 && output.length > 0) {
+    const lastIndex = output.length - 1;
+    output[lastIndex] = [...output[lastIndex], ...pending];
+  }
+
+  return output;
+}
+
+function buildStatement(sql: string, spans: Span[]): Statement {
+  const text = spans.map((s) => sql.slice(s.start, s.end)).join('').trim();
+  const start = spans[0].start;
+  const end = spans[spans.length - 1].end;
+  return {
+    text,
+    range: { start, end },
+    isSelect: isSelect(text),
+    returnsResultSet: returnsResultSet(text),
+    isExplainable: isExplainable(text),
+  };
+}

--- a/src/utils/sqlSplitter/splitter.ts
+++ b/src/utils/sqlSplitter/splitter.ts
@@ -22,11 +22,16 @@ interface Span {
   readonly end: number;
 }
 
+interface FoldedGroup {
+  readonly spans: ReadonlyArray<Span>;
+  readonly meaningful: Span;
+}
+
 export function splitInto(sql: string, options: DialectOptions): Statement[] {
   if (sql.length === 0) return [];
   const segments = collectSegments(sql, options);
   const folded = foldComments(segments);
-  return folded.map((spans) => buildStatement(sql, spans));
+  return folded.map((group) => buildStatement(sql, group));
 }
 
 function collectSegments(sql: string, options: DialectOptions): RawSegment[] {
@@ -87,14 +92,14 @@ function collectSegments(sql: string, options: DialectOptions): RawSegment[] {
   return segments;
 }
 
-function foldComments(segments: ReadonlyArray<RawSegment>): Span[][] {
-  const output: Span[][] = [];
+function foldComments(segments: ReadonlyArray<RawSegment>): FoldedGroup[] {
+  const output: { spans: Span[]; meaningful: Span }[] = [];
   let pending: Span[] = [];
 
   for (const seg of segments) {
     const span: Span = { start: seg.start, end: seg.end };
     if (seg.hasMeaningful) {
-      output.push([...pending, span]);
+      output.push({ spans: [...pending, span], meaningful: span });
       pending = [];
     } else {
       pending = [...pending, span];
@@ -103,19 +108,24 @@ function foldComments(segments: ReadonlyArray<RawSegment>): Span[][] {
 
   if (pending.length > 0 && output.length > 0) {
     const lastIndex = output.length - 1;
-    output[lastIndex] = [...output[lastIndex], ...pending];
+    const last = output[lastIndex];
+    output[lastIndex] = {
+      spans: [...last.spans, ...pending],
+      meaningful: last.meaningful,
+    };
   }
 
   return output;
 }
 
-function buildStatement(sql: string, spans: Span[]): Statement {
-  const text = spans.map((s) => sql.slice(s.start, s.end)).join('').trim();
-  const start = spans[0].start;
-  const end = spans[spans.length - 1].end;
+function buildStatement(sql: string, group: FoldedGroup): Statement {
+  const text = group.spans
+    .map((s) => sql.slice(s.start, s.end))
+    .join('')
+    .trim();
   return {
     text,
-    range: { start, end },
+    range: { start: group.meaningful.start, end: group.meaningful.end },
     isSelect: isSelect(text),
     returnsResultSet: returnsResultSet(text),
     isExplainable: isExplainable(text),

--- a/src/utils/sqlSplitter/splitter.ts
+++ b/src/utils/sqlSplitter/splitter.ts
@@ -6,7 +6,11 @@
 //      (b) trailing comment-only segment(s) → appended to PREVIOUS;
 //      (c) entirely comment-only input → drop, return [].
 
-import { isExplainable, isSelect, returnsResultSet } from './classify';
+import {
+  EXPLAINABLE_KEYWORDS,
+  RESULT_SET_KEYWORDS,
+  leadingKeyword,
+} from './classify';
 import type { DialectOptions, Statement } from './index';
 import type { TokenizerState } from './tokenizer';
 import { scanToken } from './tokenizer';
@@ -123,11 +127,23 @@ function buildStatement(sql: string, group: FoldedGroup): Statement {
     .map((s) => sql.slice(s.start, s.end))
     .join('')
     .trim();
+  const keyword = leadingKeyword(text);
+  const [start, end] = trimRange(sql, group.meaningful.start, group.meaningful.end);
   return {
     text,
-    range: { start: group.meaningful.start, end: group.meaningful.end },
-    isSelect: isSelect(text),
-    returnsResultSet: returnsResultSet(text),
-    isExplainable: isExplainable(text),
+    range: { start, end },
+    isSelect: keyword === 'SELECT',
+    returnsResultSet: RESULT_SET_KEYWORDS.has(keyword),
+    isExplainable: EXPLAINABLE_KEYWORDS.has(keyword),
   };
+}
+
+function trimRange(sql: string, start: number, end: number): [number, number] {
+  while (start < end && isAsciiSpace(sql.charCodeAt(start))) start++;
+  while (end > start && isAsciiSpace(sql.charCodeAt(end - 1))) end--;
+  return [start, end];
+}
+
+function isAsciiSpace(code: number): boolean {
+  return code === 32 || code === 9 || code === 10 || code === 13;
 }

--- a/src/utils/sqlSplitter/tokenizer.ts
+++ b/src/utils/sqlSplitter/tokenizer.ts
@@ -33,6 +33,21 @@ export function scanToken(
   }
 
   if (options.lineComments && ch === '-' && source[position + 1] === '-') {
+    // MySQL/MariaDB require a whitespace (or EOF) after `--` for it to
+    // be a comment; otherwise it is the binary subtraction operator
+    // (e.g. `SELECT 1--1` → 2). Other dialects accept `--` regardless.
+    if (options.lineCommentRequiresSpace) {
+      const after = source[position + 2];
+      if (
+        after !== undefined &&
+        after !== ' ' &&
+        after !== '\t' &&
+        after !== '\n' &&
+        after !== '\r'
+      ) {
+        return { kind: 'data', length: 1 };
+      }
+    }
     let end = position + 2;
     while (end < source.length && source[end] !== '\n') end++;
     return { kind: 'lineComment', length: end - position };

--- a/src/utils/sqlSplitter/tokenizer.ts
+++ b/src/utils/sqlSplitter/tokenizer.ts
@@ -1,0 +1,195 @@
+// Pure single-token scanner. Stateless aside from the small `TokenizerState`
+// (current delimiter + lineLeading flag) that the splitter owns and mutates.
+
+import type { DialectOptions, QuoteRule, Token } from './index';
+
+export interface TokenizerState {
+  delimiter: string;
+  lineLeading: boolean;
+}
+
+const IDENT_CHAR_RE = /[A-Za-z0-9_]/;
+
+export function scanToken(
+  source: string,
+  position: number,
+  options: DialectOptions,
+  state: TokenizerState,
+): Token | null {
+  if (position >= source.length) return null;
+
+  if (
+    state.delimiter.length > 0 &&
+    source.startsWith(state.delimiter, position)
+  ) {
+    return { kind: 'delimiter', length: state.delimiter.length };
+  }
+
+  const ch = source[position];
+
+  if (ch === '\n') return { kind: 'eoln', length: 1 };
+  if (ch === ' ' || ch === '\t' || ch === '\r') {
+    return { kind: 'whitespace', length: 1 };
+  }
+
+  if (options.lineComments && ch === '-' && source[position + 1] === '-') {
+    let end = position + 2;
+    while (end < source.length && source[end] !== '\n') end++;
+    return { kind: 'lineComment', length: end - position };
+  }
+
+  if (options.blockComments && ch === '/' && source[position + 1] === '*') {
+    let end = position + 2;
+    while (end + 1 < source.length) {
+      if (source[end] === '*' && source[end + 1] === '/') {
+        return { kind: 'blockComment', length: end + 2 - position };
+      }
+      end++;
+    }
+    return { kind: 'blockComment', length: source.length - position };
+  }
+
+  if (
+    options.eString &&
+    (ch === 'E' || ch === 'e') &&
+    source[position + 1] === "'" &&
+    !isIdentBoundary(source, position - 1)
+  ) {
+    return scanEString(source, position);
+  }
+
+  if (options.dollarQuoting && ch === '$') {
+    const dollarToken = scanDollarQuoted(source, position);
+    if (dollarToken) return dollarToken;
+  }
+
+  for (const rule of options.quotes) {
+    if (source.startsWith(rule.open, position)) {
+      return scanQuoted(source, position, rule);
+    }
+  }
+
+  if (state.lineLeading) {
+    if (
+      options.customDelimiter &&
+      matchesKeyword(source, position, 'DELIMITER')
+    ) {
+      const token = readCustomDelimiter(source, position);
+      if (token) return token;
+    }
+    if (options.goDelimiter && matchesKeyword(source, position, 'GO')) {
+      const token = readGoDelimiter(source, position);
+      if (token) return token;
+    }
+  }
+
+  return { kind: 'data', length: 1 };
+}
+
+function isIdentBoundary(source: string, prevIndex: number): boolean {
+  if (prevIndex < 0) return false;
+  return IDENT_CHAR_RE.test(source[prevIndex]);
+}
+
+function scanQuoted(
+  source: string,
+  position: number,
+  rule: QuoteRule,
+): Token {
+  const start = position;
+  let p = position + rule.open.length;
+  while (p < source.length) {
+    if (
+      rule.escape !== undefined &&
+      source[p] === rule.escape &&
+      p + 1 < source.length
+    ) {
+      p += 2;
+      continue;
+    }
+    if (source.startsWith(rule.close, p)) {
+      if (
+        rule.doubleClose &&
+        source.startsWith(rule.close, p + rule.close.length)
+      ) {
+        p += rule.close.length * 2;
+        continue;
+      }
+      return { kind: 'string', length: p + rule.close.length - start };
+    }
+    p++;
+  }
+  return { kind: 'string', length: source.length - start };
+}
+
+function scanEString(source: string, position: number): Token {
+  let p = position + 2;
+  while (p < source.length) {
+    if (source[p] === '\\' && p + 1 < source.length) {
+      p += 2;
+      continue;
+    }
+    if (source[p] === "'") {
+      if (source[p + 1] === "'") {
+        p += 2;
+        continue;
+      }
+      return { kind: 'string', length: p + 1 - position };
+    }
+    p++;
+  }
+  return { kind: 'string', length: source.length - position };
+}
+
+const DOLLAR_TAG_RE = /^\$([A-Za-z0-9_]*)\$/;
+
+function scanDollarQuoted(source: string, position: number): Token | null {
+  const slice = source.slice(position);
+  const match = DOLLAR_TAG_RE.exec(slice);
+  if (!match) return null;
+  const tag = match[0];
+  let p = position + tag.length;
+  while (p < source.length) {
+    if (source.startsWith(tag, p)) {
+      return { kind: 'string', length: p + tag.length - position };
+    }
+    p++;
+  }
+  return { kind: 'string', length: source.length - position };
+}
+
+function matchesKeyword(
+  source: string,
+  position: number,
+  word: string,
+): boolean {
+  if (position + word.length > source.length) return false;
+  for (let i = 0; i < word.length; i++) {
+    const c = source[position + i];
+    if (c.toUpperCase() !== word[i]) return false;
+  }
+  const after = source[position + word.length];
+  if (after !== undefined && IDENT_CHAR_RE.test(after)) return false;
+  return true;
+}
+
+const CUSTOM_DELIM_RE = /^DELIMITER[ \t]+([^\n\r]+)/i;
+
+function readCustomDelimiter(source: string, position: number): Token | null {
+  const slice = source.slice(position);
+  const m = CUSTOM_DELIM_RE.exec(slice);
+  if (!m) return null;
+  const value = m[1].trim();
+  if (value.length === 0) return null;
+  return { kind: 'setDelimiter', length: m[0].length, value };
+}
+
+const GO_RE = /^GO[ \t\r]*(\n|$)/i;
+
+function readGoDelimiter(source: string, position: number): Token | null {
+  const slice = source.slice(position);
+  const m = GO_RE.exec(slice);
+  if (!m) return null;
+  const length = m[0].endsWith('\n') ? m[0].length - 1 : m[0].length;
+  return { kind: 'goDelimiter', length };
+}

--- a/src/utils/sqlSplitter/tokenizer.ts
+++ b/src/utils/sqlSplitter/tokenizer.ts
@@ -39,14 +39,17 @@ export function scanToken(
   }
 
   if (options.blockComments && ch === '/' && source[position + 1] === '*') {
-    let end = position + 2;
-    while (end + 1 < source.length) {
-      if (source[end] === '*' && source[end + 1] === '/') {
-        return { kind: 'blockComment', length: end + 2 - position };
-      }
-      end++;
-    }
-    return { kind: 'blockComment', length: source.length - position };
+    const length = scanBlockCommentLength(
+      source,
+      position,
+      options.nestedBlockComments,
+    );
+    // MySQL/MariaDB conditional comment `/*! ... */` is executable SQL,
+    // not a noop comment. Emit as `data` so it is treated as meaningful
+    // by the splitter and gets its own statement boundary.
+    const isExecutable =
+      options.executableComments && source[position + 2] === '!';
+    return { kind: isExecutable ? 'data' : 'blockComment', length };
   }
 
   if (
@@ -89,6 +92,30 @@ export function scanToken(
 function isIdentBoundary(source: string, prevIndex: number): boolean {
   if (prevIndex < 0) return false;
   return IDENT_CHAR_RE.test(source[prevIndex]);
+}
+
+function scanBlockCommentLength(
+  source: string,
+  position: number,
+  nested: boolean,
+): number {
+  let depth = 1;
+  let p = position + 2;
+  while (p + 1 < source.length) {
+    if (nested && source[p] === '/' && source[p + 1] === '*') {
+      depth++;
+      p += 2;
+      continue;
+    }
+    if (source[p] === '*' && source[p + 1] === '/') {
+      depth--;
+      p += 2;
+      if (depth === 0) return p - position;
+      continue;
+    }
+    p++;
+  }
+  return source.length - position;
 }
 
 function scanQuoted(
@@ -141,11 +168,11 @@ function scanEString(source: string, position: number): Token {
   return { kind: 'string', length: source.length - position };
 }
 
-const DOLLAR_TAG_RE = /^\$([A-Za-z0-9_]*)\$/;
+const DOLLAR_TAG_RE = /\$([A-Za-z0-9_]*)\$/y;
 
 function scanDollarQuoted(source: string, position: number): Token | null {
-  const slice = source.slice(position);
-  const match = DOLLAR_TAG_RE.exec(slice);
+  DOLLAR_TAG_RE.lastIndex = position;
+  const match = DOLLAR_TAG_RE.exec(source);
   if (!match) return null;
   const tag = match[0];
   let p = position + tag.length;
@@ -173,22 +200,23 @@ function matchesKeyword(
   return true;
 }
 
-const CUSTOM_DELIM_RE = /^DELIMITER[ \t]+([^\n\r]+)/i;
+// DELIMITER directive: take only the first whitespace-terminated token
+// so a trailing `-- comment` on the same line does not bleed into the
+// new delimiter string.
+const CUSTOM_DELIM_RE = /DELIMITER[ \t]+(\S+)/iy;
 
 function readCustomDelimiter(source: string, position: number): Token | null {
-  const slice = source.slice(position);
-  const m = CUSTOM_DELIM_RE.exec(slice);
+  CUSTOM_DELIM_RE.lastIndex = position;
+  const m = CUSTOM_DELIM_RE.exec(source);
   if (!m) return null;
-  const value = m[1].trim();
-  if (value.length === 0) return null;
-  return { kind: 'setDelimiter', length: m[0].length, value };
+  return { kind: 'setDelimiter', length: m[0].length, value: m[1] };
 }
 
-const GO_RE = /^GO[ \t\r]*(\n|$)/i;
+const GO_RE = /GO[ \t\r]*(\n|$)/iy;
 
 function readGoDelimiter(source: string, position: number): Token | null {
-  const slice = source.slice(position);
-  const m = GO_RE.exec(slice);
+  GO_RE.lastIndex = position;
+  const m = GO_RE.exec(source);
   if (!m) return null;
   const length = m[0].endsWith('\n') ? m[0].length - 1 : m[0].length;
   return { kind: 'goDelimiter', length };

--- a/src/utils/sqlSplitter/tokenizer.ts
+++ b/src/utils/sqlSplitter/tokenizer.ts
@@ -227,7 +227,12 @@ function readCustomDelimiter(source: string, position: number): Token | null {
   return { kind: 'setDelimiter', length: m[0].length, value: m[1] };
 }
 
-const GO_RE = /GO[ \t\r]*(\n|$)/iy;
+// `GO` with an optional repeat-count: `GO`, `GO 5`, `GO\t10`. Native
+// sqlcmd / SSMS execute the preceding batch the given number of times.
+// We treat all three as a single batch separator; the repeat count is
+// discarded at this layer (re-running the batch is a runner concern
+// outside the splitter).
+const GO_RE = /GO(?:[ \t]+\d+)?[ \t\r]*(\n|$)/iy;
 
 function readGoDelimiter(source: string, position: number): Token | null {
   GO_RE.lastIndex = position;

--- a/tests/utils/openSourceLibraries.test.ts
+++ b/tests/utils/openSourceLibraries.test.ts
@@ -8,7 +8,7 @@ import {
 describe("openSourceLibraries", () => {
   it("should expose all direct dependencies declared by the project manifests", () => {
     expect(OPEN_SOURCE_LIBRARY_SECTIONS).toHaveLength(4);
-    expect(getOpenSourceLibraryTotal()).toBe(92);
+    expect(getOpenSourceLibraryTotal()).toBe(91);
   });
 
   it("should keep section counts aligned with manifest groups", () => {
@@ -20,7 +20,7 @@ describe("openSourceLibraries", () => {
     );
 
     expect(counts).toEqual({
-      "npm-runtime": 29,
+      "npm-runtime": 28,
       "npm-tooling": 24,
       "cargo-runtime": 37,
       "cargo-tooling": 2,

--- a/tests/utils/sqlSplitter/classify.test.ts
+++ b/tests/utils/sqlSplitter/classify.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isSelect,
+  returnsResultSet,
+  isExplainable,
+  stripLeadingComments,
+} from '../../../src/utils/sqlSplitter';
+
+describe('stripLeadingComments', () => {
+  it('strips line comments', () => {
+    expect(stripLeadingComments('-- comment\nSELECT 1')).toBe('SELECT 1');
+    expect(stripLeadingComments('-- a\n-- b\nSELECT 1')).toBe('SELECT 1');
+  });
+
+  it('strips block comments', () => {
+    expect(stripLeadingComments('/* x */ SELECT 1')).toBe('SELECT 1');
+    expect(stripLeadingComments('/* a */ /* b */ SELECT 1')).toBe('SELECT 1');
+  });
+
+  it('handles mixed comments and whitespace', () => {
+    expect(stripLeadingComments('  -- a\n /* b */\n\tSELECT 1')).toBe('SELECT 1');
+  });
+
+  it('returns empty string for a comment-only input', () => {
+    expect(stripLeadingComments('-- only comment')).toBe('');
+    expect(stripLeadingComments('/* never closes')).toBe('');
+  });
+});
+
+describe('isSelect', () => {
+  it('detects bare SELECT', () => {
+    expect(isSelect('SELECT 1')).toBe(true);
+    expect(isSelect('  select * from t')).toBe(true);
+  });
+
+  it('detects SELECT after leading comments', () => {
+    expect(isSelect('-- header\nSELECT 1')).toBe(true);
+    expect(isSelect('/* x */ select 1')).toBe(true);
+  });
+
+  it('rejects words that merely start with SELECT', () => {
+    expect(isSelect('SELECTIVE 1')).toBe(false);
+  });
+
+  it('rejects non-SELECT statements', () => {
+    expect(isSelect('INSERT INTO t VALUES (1)')).toBe(false);
+    expect(isSelect('CREATE TABLE t (id INT)')).toBe(false);
+  });
+});
+
+describe('returnsResultSet', () => {
+  it('returns true for result-set producing keywords', () => {
+    expect(returnsResultSet('SELECT 1')).toBe(true);
+    expect(returnsResultSet('WITH cte AS (SELECT 1) SELECT * FROM cte')).toBe(true);
+    expect(returnsResultSet('SHOW TABLES')).toBe(true);
+    expect(returnsResultSet('EXPLAIN SELECT 1')).toBe(true);
+    expect(returnsResultSet('DESCRIBE users')).toBe(true);
+    expect(returnsResultSet('DESC users')).toBe(true);
+    expect(returnsResultSet('VALUES (1)')).toBe(true);
+    expect(returnsResultSet('TABLE users')).toBe(true);
+    expect(returnsResultSet('PRAGMA foreign_keys')).toBe(true);
+    expect(returnsResultSet('CALL proc()')).toBe(true);
+  });
+
+  it('returns false for DML that does not produce a result set', () => {
+    expect(returnsResultSet('INSERT INTO t VALUES (1)')).toBe(false);
+    expect(returnsResultSet('UPDATE t SET x = 1')).toBe(false);
+    expect(returnsResultSet('DELETE FROM t')).toBe(false);
+  });
+});
+
+describe('isExplainable', () => {
+  it('returns true for DML and CTE', () => {
+    expect(isExplainable('SELECT 1')).toBe(true);
+    expect(isExplainable('INSERT INTO t VALUES (1)')).toBe(true);
+    expect(isExplainable('UPDATE t SET x = 1')).toBe(true);
+    expect(isExplainable('DELETE FROM t')).toBe(true);
+    expect(isExplainable('REPLACE INTO t VALUES (1)')).toBe(true);
+    expect(isExplainable('WITH cte AS (SELECT 1) SELECT * FROM cte')).toBe(true);
+    expect(isExplainable('TABLE users')).toBe(true);
+  });
+
+  it('returns false for DDL', () => {
+    expect(isExplainable('CREATE TABLE t (id INT)')).toBe(false);
+    expect(isExplainable('DROP TABLE t')).toBe(false);
+    expect(isExplainable('ALTER TABLE t ADD COLUMN c INT')).toBe(false);
+    expect(isExplainable('TRUNCATE TABLE t')).toBe(false);
+  });
+
+  it('handles leading comments and whitespace', () => {
+    expect(isExplainable('-- BEFORE index: full scan\nSELECT 1')).toBe(true);
+    expect(isExplainable('/* x */ SELECT 1')).toBe(true);
+    expect(isExplainable('-- setup\nCREATE INDEX i ON t(c)')).toBe(false);
+  });
+});

--- a/tests/utils/sqlSplitter/classify.test.ts
+++ b/tests/utils/sqlSplitter/classify.test.ts
@@ -42,6 +42,12 @@ describe('isSelect', () => {
     expect(isSelect('SELECTIVE 1')).toBe(false);
   });
 
+  it('peels leading parentheses so parenthesised SELECTs still classify', () => {
+    expect(isSelect('(SELECT 1)')).toBe(true);
+    expect(isSelect('((SELECT 1))')).toBe(true);
+    expect(isSelect('-- header\n ( SELECT 1 )')).toBe(true);
+  });
+
   it('rejects non-SELECT statements', () => {
     expect(isSelect('INSERT INTO t VALUES (1)')).toBe(false);
     expect(isSelect('CREATE TABLE t (id INT)')).toBe(false);
@@ -78,6 +84,7 @@ describe('isExplainable', () => {
     expect(isExplainable('REPLACE INTO t VALUES (1)')).toBe(true);
     expect(isExplainable('WITH cte AS (SELECT 1) SELECT * FROM cte')).toBe(true);
     expect(isExplainable('TABLE users')).toBe(true);
+    expect(isExplainable('MERGE INTO target USING src ON x = y WHEN MATCHED THEN UPDATE SET a = 1')).toBe(true);
   });
 
   it('returns false for DDL', () => {

--- a/tests/utils/sqlSplitter/classify.test.ts
+++ b/tests/utils/sqlSplitter/classify.test.ts
@@ -48,6 +48,17 @@ describe('isSelect', () => {
     expect(isSelect('-- header\n ( SELECT 1 )')).toBe(true);
   });
 
+  it('peels interleaved parens and comments', () => {
+    // `(` then a comment inside the parens: previously stripLeadingComments
+    // saw `(` first and stopped, so the inner comment leaked into the
+    // keyword match. The fixed-point loop now keeps stripping until both
+    // sides give up.
+    expect(isSelect('( /* note */ SELECT 1 )')).toBe(true);
+    expect(isSelect('(\n-- comment\nSELECT 1\n)')).toBe(true);
+    expect(isSelect('(\n-- comment\n(SELECT 1)\n)')).toBe(true);
+    expect(isSelect('/* a */ ( /* b */ ( SELECT 1 ) )')).toBe(true);
+  });
+
   it('rejects non-SELECT statements', () => {
     expect(isSelect('INSERT INTO t VALUES (1)')).toBe(false);
     expect(isSelect('CREATE TABLE t (id INT)')).toBe(false);

--- a/tests/utils/sqlSplitter/dialects.test.ts
+++ b/tests/utils/sqlSplitter/dialects.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { splitQueries } from '../../../src/utils/sqlSplitter';
+
+describe('dialect canaries', () => {
+  it('postgres treats $$ as a string boundary', () => {
+    const sql = 'DO $$BEGIN PERFORM 1; END$$;';
+    expect(splitQueries(sql, 'postgres')).toHaveLength(1);
+  });
+
+  it('mysql shields semicolons inside backticked identifiers', () => {
+    const sql = 'SELECT `col;name` FROM t; SELECT 2';
+    const result = splitQueries(sql, 'mysql');
+    expect(result).toHaveLength(2);
+    expect(result[0]).toContain('`col;name`');
+  });
+
+  it('mssql shields semicolons inside [bracketed identifiers]', () => {
+    const sql = 'SELECT [col;name] FROM t; SELECT 2';
+    const result = splitQueries(sql, 'mssql');
+    expect(result).toHaveLength(2);
+    expect(result[0]).toContain('[col;name]');
+  });
+
+  it('sqlite accepts both backticks and brackets as identifier quotes', () => {
+    expect(splitQueries('SELECT `a;b` FROM t', 'sqlite')).toHaveLength(1);
+    expect(splitQueries('SELECT [a;b] FROM t', 'sqlite')).toHaveLength(1);
+  });
+
+  it('generic dialect splits a basic two-statement input', () => {
+    expect(splitQueries('SELECT 1; SELECT 2', 'generic')).toEqual([
+      'SELECT 1',
+      'SELECT 2',
+    ]);
+  });
+});

--- a/tests/utils/sqlSplitter/dialects.test.ts
+++ b/tests/utils/sqlSplitter/dialects.test.ts
@@ -32,4 +32,14 @@ describe('dialect canaries', () => {
       'SELECT 2',
     ]);
   });
+
+  it('falls back to generic when given an unknown dialect string', () => {
+    // Plugin manifests pass through serde without TS-side validation, so
+    // an unknown value may arrive at runtime. The splitter must not crash.
+    const result = splitQueries(
+      'SELECT 1; SELECT 2',
+      'unknown-driver-from-plugin',
+    );
+    expect(result).toEqual(['SELECT 1', 'SELECT 2']);
+  });
 });

--- a/tests/utils/sqlSplitter/splitter.test.ts
+++ b/tests/utils/sqlSplitter/splitter.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import { splitStatements, splitQueries } from '../../../src/utils/sqlSplitter';
+
+describe('splitStatements', () => {
+  describe('#223 — comment-only fragments fold', () => {
+    it('folds trailing inline comment into the preceding statement (the bug)', () => {
+      const sql = [
+        '-- ============================================',
+        '-- Any header comment block',
+        '-- ============================================',
+        'SELECT * FROM big_table ORDER BY id;  -- 500+ rows',
+      ].join('\n');
+      const result = splitStatements(sql);
+      expect(result).toHaveLength(1);
+      expect(result[0].text).toContain('SELECT * FROM big_table ORDER BY id');
+      expect(result[0].text).toContain('-- 500+ rows');
+      expect(result[0].text).toContain('Any header comment block');
+    });
+
+    it('folds a mid-input comment-only fragment into the NEXT statement', () => {
+      const sql = 'SELECT 1; /* mid */ ; SELECT 2;';
+      const result = splitStatements(sql);
+      expect(result).toHaveLength(2);
+      expect(result[0].text).toBe('SELECT 1');
+      expect(result[1].text).toContain('/* mid */');
+      expect(result[1].text).toContain('SELECT 2');
+    });
+
+    it('returns an empty array when the input has only comments', () => {
+      expect(splitStatements('-- only')).toEqual([]);
+      expect(splitStatements('/* only */')).toEqual([]);
+      expect(splitStatements('-- a\n/* b */\n-- c\n')).toEqual([]);
+    });
+
+    it('preserves the original behavior for leading comments', () => {
+      const sql = '-- header\nSELECT 1;';
+      const result = splitStatements(sql);
+      expect(result).toHaveLength(1);
+      expect(result[0].text).toContain('-- header');
+      expect(result[0].text).toContain('SELECT 1');
+    });
+  });
+
+  describe('basic splitting', () => {
+    it('splits two statements by semicolon', () => {
+      const result = splitQueries('SELECT 1; SELECT 2;');
+      expect(result).toEqual(['SELECT 1', 'SELECT 2']);
+    });
+
+    it('handles a single statement with no terminator', () => {
+      expect(splitQueries('SELECT 1')).toEqual(['SELECT 1']);
+    });
+
+    it('returns [] for empty input', () => {
+      expect(splitQueries('')).toEqual([]);
+      expect(splitQueries('   \n\t  ')).toEqual([]);
+    });
+
+    it('ignores semicolons inside single-quoted strings', () => {
+      const result = splitQueries("SELECT * FROM t WHERE n = 'a;b'; SELECT 2");
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe("SELECT * FROM t WHERE n = 'a;b'");
+      expect(result[1]).toBe('SELECT 2');
+    });
+
+    it('ignores semicolons inside double-quoted identifiers', () => {
+      const result = splitQueries('SELECT "a;b" FROM t; SELECT 2');
+      expect(result).toHaveLength(2);
+    });
+
+    it('ignores semicolons inside block comments', () => {
+      const result = splitQueries('SELECT 1 /* ; */; SELECT 2');
+      expect(result).toEqual(['SELECT 1 /* ; */', 'SELECT 2']);
+    });
+  });
+
+  describe('postgres dollar-quoting', () => {
+    it('treats semicolons inside $$ ... $$ as data', () => {
+      const sql = 'DO $$ BEGIN PERFORM 1; PERFORM 2; END $$;';
+      const result = splitStatements(sql);
+      expect(result).toHaveLength(1);
+      expect(result[0].text).toContain('PERFORM 1');
+      expect(result[0].text).toContain('PERFORM 2');
+    });
+
+    it('respects $tag$ ... $tag$ delimiters', () => {
+      const sql = 'DO $body$ SELECT 1; SELECT 2 $body$; SELECT 3;';
+      const result = splitQueries(sql);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toContain('$body$');
+      expect(result[1]).toBe('SELECT 3');
+    });
+  });
+
+  describe('mysql custom delimiter round-trip', () => {
+    it('handles DELIMITER // then back to ;', () => {
+      const sql = [
+        'DELIMITER //',
+        'SELECT 1//',
+        'SELECT 2//',
+        'DELIMITER ;',
+        'SELECT 3;',
+      ].join('\n');
+      const result = splitQueries(sql, 'mysql');
+      expect(result).toEqual(['SELECT 1', 'SELECT 2', 'SELECT 3']);
+    });
+  });
+
+  describe('mssql GO separator', () => {
+    it('splits on a line-leading GO', () => {
+      const sql = 'SELECT 1\nGO\nSELECT 2';
+      const result = splitQueries(sql, 'mssql');
+      expect(result).toEqual(['SELECT 1', 'SELECT 2']);
+    });
+
+    it('does not split when GO is inside a string literal', () => {
+      const sql = "SELECT 'GO' FROM t";
+      const result = splitQueries(sql, 'mssql');
+      expect(result).toEqual(["SELECT 'GO' FROM t"]);
+    });
+
+    it('does not split when GO is mid-line', () => {
+      const sql = 'SELECT 1 GO SELECT 2';
+      const result = splitQueries(sql, 'mssql');
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('statement metadata', () => {
+    it('annotates SELECT as isSelect / returnsResultSet / isExplainable', () => {
+      const [stmt] = splitStatements('SELECT 1;');
+      expect(stmt.isSelect).toBe(true);
+      expect(stmt.returnsResultSet).toBe(true);
+      expect(stmt.isExplainable).toBe(true);
+    });
+
+    it('annotates DDL as none of those', () => {
+      const [stmt] = splitStatements('CREATE TABLE t (id INT);');
+      expect(stmt.isSelect).toBe(false);
+      expect(stmt.returnsResultSet).toBe(false);
+      expect(stmt.isExplainable).toBe(false);
+    });
+
+    it('annotates UPDATE as explainable but not returning result set', () => {
+      const [stmt] = splitStatements("UPDATE t SET x = 1 WHERE id = 2;");
+      expect(stmt.isSelect).toBe(false);
+      expect(stmt.returnsResultSet).toBe(false);
+      expect(stmt.isExplainable).toBe(true);
+    });
+  });
+
+  describe('range', () => {
+    it('reports source byte offsets for the emitted statement', () => {
+      const sql = 'SELECT 1; SELECT 2';
+      const [a, b] = splitStatements(sql);
+      expect(a.range.start).toBe(0);
+      expect(a.range.end).toBe(8); // up to but excluding `;`
+      expect(b.range.start).toBe(9); // ` SELECT 2`
+      expect(b.range.end).toBe(sql.length);
+    });
+  });
+
+  describe('unterminated lenience', () => {
+    it('emits an unterminated string as part of its statement', () => {
+      const result = splitQueries("SELECT 'never closes");
+      expect(result).toHaveLength(1);
+      expect(result[0]).toContain('SELECT');
+    });
+  });
+});

--- a/tests/utils/sqlSplitter/splitter.test.ts
+++ b/tests/utils/sqlSplitter/splitter.test.ts
@@ -158,6 +158,69 @@ describe('splitStatements', () => {
       expect(b.range.start).toBe(9); // ` SELECT 2`
       expect(b.range.end).toBe(sql.length);
     });
+
+    it('excludes a folded trailing comment from range while keeping it in text', () => {
+      // Range should point at the SQL body only — `sql.slice(range)` must
+      // remain valid SQL. Display text still includes the folded comment
+      // so the run-button dropdown shows the user-visible label.
+      const sql = 'SELECT 1; -- trail';
+      const [stmt] = splitStatements(sql);
+      expect(stmt.range.start).toBe(0);
+      expect(stmt.range.end).toBe(8);
+      expect(sql.slice(stmt.range.start, stmt.range.end)).toBe('SELECT 1');
+      expect(stmt.text).toContain('-- trail');
+    });
+
+    it('range points at the meaningful body when a comment-only segment is folded into NEXT', () => {
+      const sql = 'SELECT 1; /* mid */ ; SELECT 2;';
+      const [, b] = splitStatements(sql);
+      // Meaningful for the second emitted statement is ` SELECT 2` after
+      // the second `;`. Range excludes the `/* mid */ ;` chunk that gets
+      // prepended to text.
+      expect(sql.slice(b.range.start, b.range.end).trim()).toBe('SELECT 2');
+      expect(b.text).toContain('/* mid */');
+      expect(b.text).toContain('SELECT 2');
+    });
+  });
+
+  describe('CRLF input', () => {
+    it('splits on `;` even when line endings are CRLF', () => {
+      const result = splitQueries('SELECT 1;\r\nSELECT 2;\r\n');
+      expect(result).toEqual(['SELECT 1', 'SELECT 2']);
+    });
+
+    it('treats a CRLF GO line as a separator under mssql', () => {
+      const result = splitQueries('SELECT 1\r\nGO\r\nSELECT 2', 'mssql');
+      expect(result).toEqual(['SELECT 1', 'SELECT 2']);
+    });
+  });
+
+  describe('escape-shield end-to-end', () => {
+    it('postgres E-string with an escaped semicolon does not split', () => {
+      const sql = "SELECT E'a\\;b' FROM t; SELECT 2";
+      const result = splitQueries(sql, 'postgres');
+      expect(result).toHaveLength(2);
+      expect(result[0]).toContain("E'a\\;b'");
+      expect(result[1]).toBe('SELECT 2');
+    });
+
+    it('mysql backticked identifier shields a semicolon', () => {
+      const result = splitQueries('SELECT `col;name` FROM t; SELECT 2', 'mysql');
+      expect(result).toHaveLength(2);
+      expect(result[0]).toContain('`col;name`');
+    });
+
+    it('mssql `]]` escape keeps a bracketed identifier intact across `]`', () => {
+      // T-SQL: `[col]]name]` is the identifier literally named `col]name`.
+      // Before doubleClose was wired up on the bracket rule, the first
+      // `]` closed the quote and the trailing `;` after `name]` mid-token
+      // would split incorrectly.
+      const sql = 'SELECT [col]]name] FROM t; SELECT 2';
+      const result = splitQueries(sql, 'mssql');
+      expect(result).toHaveLength(2);
+      expect(result[0]).toContain('[col]]name]');
+      expect(result[1]).toBe('SELECT 2');
+    });
   });
 
   describe('unterminated lenience', () => {

--- a/tests/utils/sqlSplitter/splitter.test.ts
+++ b/tests/utils/sqlSplitter/splitter.test.ts
@@ -175,6 +175,52 @@ describe('splitStatements', () => {
       const result = splitQueries(sql, 'mssql');
       expect(result).toHaveLength(1);
     });
+
+    it('accepts an optional repeat-count after GO (e.g. `GO 5`)', () => {
+      // sqlcmd/SSMS treat `GO 5` as "run the preceding batch 5 times".
+      // The splitter still emits a single batch boundary; the runner is
+      // responsible for any repetition.
+      const sql = 'SELECT 1\nGO 5\nSELECT 2';
+      const result = splitQueries(sql, 'mssql');
+      expect(result).toEqual(['SELECT 1', 'SELECT 2']);
+    });
+
+    it('still rejects GO followed by a non-numeric token', () => {
+      const sql = 'SELECT 1\nGO foo\nSELECT 2';
+      const result = splitQueries(sql, 'mssql');
+      // Falls through to one big statement because `GO foo` does not
+      // match the batch separator.
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('mysql `--` requires trailing whitespace', () => {
+    it('treats `1--1` as the subtraction operator, not a comment', () => {
+      // MySQL parses `--` as subtraction unless followed by whitespace,
+      // so `SELECT 1--1` is `2`, a single statement, not `SELECT 1`
+      // with a trailing comment.
+      const result = splitQueries('SELECT 1--1', 'mysql');
+      expect(result).toEqual(['SELECT 1--1']);
+    });
+
+    it('still treats `-- ` (with trailing space) as a comment', () => {
+      // The MySQL line-comment rule requires whitespace after `--`,
+      // not its absence. `-- header` followed by `\n` is a normal
+      // comment and folds into the next meaningful statement.
+      const [stmt] = splitStatements('-- header\nSELECT 1', 'mysql');
+      expect(stmt.text).toContain('-- header');
+      expect(stmt.text).toContain('SELECT 1');
+    });
+
+    it('does not apply the rule under postgres (`--` is always a comment)', () => {
+      // Sanity check: the MySQL-only rule must not regress other dialects.
+      // Postgres treats `--1` as a line comment, so the splitter keeps
+      // the source intact as one statement with the trailing comment
+      // folded in.
+      const result = splitQueries('SELECT 1--1', 'postgres');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toContain('SELECT 1');
+    });
   });
 
   describe('statement metadata', () => {

--- a/tests/utils/sqlSplitter/splitter.test.ts
+++ b/tests/utils/sqlSplitter/splitter.test.ts
@@ -104,6 +104,57 @@ describe('splitStatements', () => {
       const result = splitQueries(sql, 'mysql');
       expect(result).toEqual(['SELECT 1', 'SELECT 2', 'SELECT 3']);
     });
+
+    it('keeps an inline `-- comment` after DELIMITER out of the delimiter token', () => {
+      // Old regex pulled `[^\n\r]+`, swallowing the comment as part of
+      // the delimiter value. With the new `\S+` rule the delimiter is
+      // the bare `//`, so subsequent `SELECT 1//` actually splits. The
+      // line comment trails inside the following segment, which is the
+      // expected fold behaviour (NEXT-meaningful wins).
+      const sql = [
+        'DELIMITER //  -- switch to slashes',
+        'SELECT 1//',
+        'SELECT 2//',
+      ].join('\n');
+      const result = splitQueries(sql, 'mysql');
+      expect(result).toHaveLength(2);
+      expect(result[0]).toContain('SELECT 1');
+      expect(result[0]).toContain('-- switch to slashes');
+      expect(result[1]).toBe('SELECT 2');
+    });
+  });
+
+  describe('mysql executable conditional comments', () => {
+    it('emits `/*! ... */` as a standalone statement', () => {
+      const sql = '/*!40101 SET NAMES utf8 */;\nSELECT * FROM users;';
+      const result = splitQueries(sql, 'mysql');
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe('/*!40101 SET NAMES utf8 */');
+      expect(result[1]).toBe('SELECT * FROM users');
+    });
+
+    it('treats a plain block comment normally on mysql', () => {
+      const sql = '/* plain */\nSELECT 1;';
+      const [stmt] = splitStatements(sql, 'mysql');
+      expect(stmt.text).toContain('/* plain */');
+      expect(stmt.text).toContain('SELECT 1');
+    });
+  });
+
+  describe('postgres nested block comments', () => {
+    it('does not split on `;` inside a nested block comment', () => {
+      const sql = '/* outer /* inner ; */ outer */ SELECT 1;';
+      const result = splitQueries(sql, 'postgres');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toContain('SELECT 1');
+    });
+
+    it('mysql still terminates at the first `*/`', () => {
+      // MySQL block comments do not nest; the first `*/` closes.
+      const sql = '/* outer /* inner */ trailing */ SELECT 1';
+      const result = splitQueries(sql, 'mysql');
+      expect(result[0]).toContain('SELECT 1');
+    });
   });
 
   describe('mssql GO separator', () => {
@@ -150,13 +201,17 @@ describe('splitStatements', () => {
   });
 
   describe('range', () => {
-    it('reports source byte offsets for the emitted statement', () => {
+    it('reports source string indices for the emitted statement', () => {
       const sql = 'SELECT 1; SELECT 2';
       const [a, b] = splitStatements(sql);
       expect(a.range.start).toBe(0);
       expect(a.range.end).toBe(8); // up to but excluding `;`
-      expect(b.range.start).toBe(9); // ` SELECT 2`
+      // The space between `;` and `SELECT 2` is whitespace, not part of
+      // the SQL body. range should point at the first non-space char so
+      // sql.slice(range.start, range.end) returns clean SQL.
+      expect(b.range.start).toBe(10);
       expect(b.range.end).toBe(sql.length);
+      expect(sql.slice(b.range.start, b.range.end)).toBe('SELECT 2');
     });
 
     it('excludes a folded trailing comment from range while keeping it in text', () => {

--- a/tests/utils/sqlSplitter/tokenizer.test.ts
+++ b/tests/utils/sqlSplitter/tokenizer.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import { scanToken, type TokenizerState } from '../../../src/utils/sqlSplitter/tokenizer';
+import { dialectOptions } from '../../../src/utils/sqlSplitter';
+
+const PG = dialectOptions('postgres');
+const MY = dialectOptions('mysql');
+const MS = dialectOptions('mssql');
+
+const freshState = (): TokenizerState => ({ delimiter: ';', lineLeading: true });
+
+describe('scanToken', () => {
+  describe('basic kinds', () => {
+    it('emits whitespace for spaces', () => {
+      const t = scanToken('   ', 0, PG, freshState());
+      expect(t).toEqual({ kind: 'whitespace', length: 1 });
+    });
+
+    it('emits eoln for newline', () => {
+      const t = scanToken('\n', 0, PG, freshState());
+      expect(t).toEqual({ kind: 'eoln', length: 1 });
+    });
+
+    it('emits data for letters', () => {
+      const t = scanToken('SELECT', 0, PG, freshState());
+      expect(t).toEqual({ kind: 'data', length: 1 });
+    });
+
+    it('emits delimiter when current delimiter matches', () => {
+      const t = scanToken(';', 0, PG, freshState());
+      expect(t).toEqual({ kind: 'delimiter', length: 1 });
+    });
+  });
+
+  describe('comments', () => {
+    it('consumes line comments until newline', () => {
+      const t = scanToken('-- hello\nrest', 0, PG, freshState());
+      expect(t).toEqual({ kind: 'lineComment', length: 8 });
+    });
+
+    it('consumes line comments to EOF when no newline', () => {
+      const src = '-- trailing';
+      const t = scanToken(src, 0, PG, freshState());
+      expect(t).toEqual({ kind: 'lineComment', length: src.length });
+    });
+
+    it('consumes block comments', () => {
+      const t = scanToken('/* foo */ rest', 0, PG, freshState());
+      expect(t).toEqual({ kind: 'blockComment', length: 9 });
+    });
+
+    it('consumes unterminated block comments to EOF', () => {
+      const src = '/* never closes';
+      const t = scanToken(src, 0, PG, freshState());
+      expect(t).toEqual({ kind: 'blockComment', length: src.length });
+    });
+  });
+
+  describe('strings (postgres)', () => {
+    it('consumes single-quoted string with doubled-quote escape', () => {
+      const src = "'It''s fine'";
+      const t = scanToken(src, 0, PG, freshState());
+      expect(t).toEqual({ kind: 'string', length: src.length });
+    });
+
+    it('consumes double-quoted identifier', () => {
+      const src = '"my ident"';
+      const t = scanToken(src, 0, PG, freshState());
+      expect(t).toEqual({ kind: 'string', length: src.length });
+    });
+
+    it('consumes dollar-quoted string with empty tag', () => {
+      const src = '$$body with ; inside$$';
+      const t = scanToken(src, 0, PG, freshState());
+      expect(t).toEqual({ kind: 'string', length: src.length });
+    });
+
+    it('consumes dollar-quoted string with named tag', () => {
+      const src = '$tag$body$tag$';
+      const t = scanToken(src, 0, PG, freshState());
+      expect(t).toEqual({ kind: 'string', length: src.length });
+    });
+
+    it('consumes E-string with backslash escape', () => {
+      const src = "E'a\\'b'";
+      const t = scanToken(src, 0, PG, freshState());
+      expect(t).toEqual({ kind: 'string', length: src.length });
+    });
+
+    it('does not start an E-string after an identifier character', () => {
+      // `valE'foo'` — E follows a letter, so not an E-string. Just `data`.
+      const src = "valE'foo'";
+      const t = scanToken(src, 3, PG, freshState()); // position at 'E'
+      expect(t).toEqual({ kind: 'data', length: 1 });
+    });
+  });
+
+  describe('mysql identifiers and escape', () => {
+    it('consumes backtick identifier', () => {
+      const src = '`my col`';
+      const t = scanToken(src, 0, MY, freshState());
+      expect(t).toEqual({ kind: 'string', length: src.length });
+    });
+
+    it("treats `\\'` as escaped quote inside string (mysql)", () => {
+      const src = "'It\\'s ok'";
+      const t = scanToken(src, 0, MY, freshState());
+      expect(t).toEqual({ kind: 'string', length: src.length });
+    });
+  });
+
+  describe('mssql brackets', () => {
+    it('consumes [bracketed identifier]', () => {
+      const src = '[col;name]';
+      const t = scanToken(src, 0, MS, freshState());
+      expect(t).toEqual({ kind: 'string', length: src.length });
+    });
+  });
+
+  describe('line-leading directives', () => {
+    it('recognises GO when line-leading (mssql)', () => {
+      const src = 'GO\nSELECT 1';
+      const t = scanToken(src, 0, MS, freshState());
+      expect(t?.kind).toBe('goDelimiter');
+      // length excludes the trailing newline
+      expect(t?.length).toBe(2);
+    });
+
+    it('does not recognise GO when not line-leading', () => {
+      const src = 'GO';
+      const state: TokenizerState = { delimiter: ';', lineLeading: false };
+      const t = scanToken(src, 0, MS, state);
+      expect(t?.kind).toBe('data');
+    });
+
+    it('recognises DELIMITER directive (mysql)', () => {
+      const src = 'DELIMITER //\nSELECT';
+      const t = scanToken(src, 0, MY, freshState());
+      expect(t?.kind).toBe('setDelimiter');
+      expect(t?.value).toBe('//');
+    });
+
+    it('does not recognise DELIMITER mid-line', () => {
+      const state: TokenizerState = { delimiter: ';', lineLeading: false };
+      const t = scanToken('DELIMITER //', 0, MY, state);
+      expect(t?.kind).toBe('data');
+    });
+  });
+});


### PR DESCRIPTION
Closes #223.

## Summary

Replace `dbgate-query-splitter` with a first-party module under `src/utils/sqlSplitter/`. Comment-only fragments are now folded into the adjacent meaningful statement instead of surfacing as their own dropdown entry, which is the #223 bug. Per-driver SQL dialect is declared on `DriverCapabilities` and threaded through to the splitter so MySQL backticks, MSSQL `[...]`, PG dollar-quoting, etc. are honoured at split time (option B from the issue discussion, suggested by @debba).

## What landed

- `src/utils/sqlSplitter/` (index, tokenizer, splitter, classify): full first-party splitter
  - Strings (`''` / `\'` / `E'...'` / dollar-quoted / backtick / bracket), `--` and `/* */` comments (with PG nested-comment support), `;` / `DELIMITER` / `GO` delimiters
  - MySQL conditional `/*! ... */` emitted as its own statement so dump scripts execute correctly
  - Classifier mirror of `src-tauri/src/drivers/common/query.rs`: `isSelect`, `returnsResultSet`, `isExplainable`, `stripLeadingComments`, plus `MERGE` on both sides
- `DriverCapabilities.sql_dialect` (Rust enum, serde-validated at install) with built-in postgres / mysql / sqlite presets and a defensive `generic` fallback for unknown plugin manifests
- `src/utils/sql.ts` is a thin façade so existing call sites compile unchanged; old `splitQueries(sql)` calls keep working
- Editor wiring: `activeConnection.capabilities.sql_dialect` flows into every run / explain / dropdown path
- `dbgate-query-splitter` removed from dependencies and the open-source-libraries list

## Comment-fold rule

1. Leading comment-only span: folded into the NEXT meaningful statement (matches the previous splitter for header comments).
2. Trailing comment-only span: folded into the PREVIOUS meaningful statement. This is the #223 fix.
3. Entire input is comments: empty array. Callers already had a `queries[0] || fullText` fallback.

`Statement.range` points at the meaningful SQL body only, excluding any folded comments and any leading whitespace, so `sql.slice(range.start, range.end)` is always valid SQL.

## Test plan

- `pnpm vitest tests/utils/sqlSplitter tests/utils/sql.test.ts`: 104 passing
- `pnpm typecheck`: clean
- `cargo test drivers::common::tests::test_is_explainable_query`: 4 passing (covers `MERGE`)
- `pnpm test` full TS suite: 2376 / 2377 passing. The one failure is a pre-existing date-dependent test on `main`.
- Manual: pasted the #223 repro into a Console tab and confirmed one dropdown entry.

## Out of scope (follow-ups)

- Oracle `/` block terminator, Firebird PSQL `BEGIN...END`, MSSQL `adaptiveGoSplit`
- Postgres `COPY FROM stdin`
- Unifying `extractTableName` on the new tokenizer (still regex-based, pre-existing)