### PR TITLE
test(updater): gate Linux-only installation source tests

### DIFF
--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -401,10 +401,12 @@ mod tests {
     }
 
     // Mutex to serialize env var mutations across parallel tests
+    #[cfg(target_os = "linux")]
     static ENV_MUTEX: std::sync::LazyLock<std::sync::Mutex<()>> =
         std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
 
     // Installation source detection tests
+    #[cfg(target_os = "linux")]
     #[test]
     fn test_detect_installation_source_snap() {
         let _lock = ENV_MUTEX.lock().unwrap();
@@ -415,6 +417,7 @@ mod tests {
         assert_eq!(source.as_deref(), Some("snap"));
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn test_detect_installation_source_flatpak() {
         let _lock = ENV_MUTEX.lock().unwrap();
@@ -425,6 +428,7 @@ mod tests {
         assert_eq!(source.as_deref(), Some("flatpak"));
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn test_detect_installation_source_direct() {
         let _lock = ENV_MUTEX.lock().unwrap();


### PR DESCRIPTION
## Why

The `test_detect_installation_source_*` tests in `src-tauri/src/updater.rs` poke at `SNAP` / `FLATPAK_ID` / `APPIMAGE` env vars to verify the heuristic that maps an installation to a packaging source. The heuristic itself is only meaningful on Linux, and on macOS/Windows two things go wrong:

1. The shared `ENV_MUTEX` and the three tests are dead code on non-Linux targets, which trips dead-code lints when the workspace is built outside Linux.
2. The tests can interact with whatever environment the host machine happens to have, instead of cleanly testing the Linux-specific code path.

Easiest fix: gate them behind `#[cfg(target_os = "linux")]` so they only compile and run where they actually mean something.

## What changed

Four `#[cfg(target_os = "linux")]` attributes added in `src-tauri/src/updater.rs`:

- One on `ENV_MUTEX` (the lock that serializes env-var mutations across the three tests).
- One on each of `test_detect_installation_source_snap`, `test_detect_installation_source_flatpak`, `test_detect_installation_source_direct`.

No production code touched. No test logic changed. Linux CI still runs the three tests; macOS/Windows simply skip them.

## Test plan

- [ ] Linux: `cargo test -p tabularis updater::tests` — the three `test_detect_installation_source_*` tests still run and pass.
- [ ] macOS / Windows: `cargo build` and `cargo test` on `src-tauri/` — no dead-code or unused-item warnings on `ENV_MUTEX` or the three tests.