### PR TITLE
Fix filters for case-sensitive column names on PostgreSQL

### DIFF
--- a/src/components/ui/TableToolbar.tsx
+++ b/src/components/ui/TableToolbar.tsx
@@ -18,6 +18,8 @@ import {
   createEmptyFilter,
 } from "../../utils/filterBar";
 import type { StructuredFilter } from "../../utils/filterBar";
+import { formatSqlIdentifier } from "../../utils/identifiers";
+import { formatSortClause } from "../../utils/tableToolbar";
 import { FilterRow } from "./FilterRow";
 import { SlotAnchor } from "./SlotAnchor";
 import { useDatabase } from "../../hooks/useDatabase";
@@ -104,13 +106,14 @@ const TableToolbarInternal = ({
     (filter: string, sort: string, limit: string) => {
       const limitVal = getLimitVal(limit);
       const filterChanged = (filter || "") !== (initialFilter || "");
-      const sortChanged = (sort || "") !== (initialSort || "");
+      const formattedSort = formatSortClause(sort, activeDriver);
+      const sortChanged = (formattedSort || "") !== (initialSort || "");
       const limitChanged = limitVal !== initialLimit;
       if (filterChanged || sortChanged || limitChanged) {
-        onUpdate(filter, sort, limitVal);
+        onUpdate(filter, formattedSort, limitVal);
       }
     },
-    [getLimitVal, initialFilter, initialSort, initialLimit, onUpdate]
+    [getLimitVal, initialFilter, initialSort, initialLimit, onUpdate, activeDriver]
   );
 
   // ── click outside to close panel ─────────────────────────────────────────────
@@ -149,7 +152,7 @@ const TableToolbarInternal = ({
     const clause = buildStructuredFilterClause(structuredFilters, activeDriver);
     setFilterInput(clause);
     onPanelOpenChange(false);
-    onUpdate(clause, sortInput, getLimitVal(limitInput));
+    onUpdate(clause, formatSortClause(sortInput, activeDriver), getLimitVal(limitInput));
   }, [structuredFilters, sortInput, limitInput, getLimitVal, onUpdate, onPanelOpenChange, activeDriver]);
 
   const togglePanel = () => {
@@ -165,7 +168,7 @@ const TableToolbarInternal = ({
   // Applies all enabled filters — does NOT close panel
   const handleApplyAll = useCallback(() => {
     const clause = buildStructuredFilterClause(structuredFilters, activeDriver);
-    onUpdate(clause, sortInput, getLimitVal(limitInput));
+    onUpdate(clause, formatSortClause(sortInput, activeDriver), getLimitVal(limitInput));
     structuredFilters.forEach((f) => {
       if (f.enabled !== false) {
         onTriggerApplied(f.id);
@@ -178,7 +181,11 @@ const TableToolbarInternal = ({
   // Applies only that single row's filter — resets Applied on all others
   const handleApplySingle = useCallback(
     (filter: StructuredFilter) => {
-      onUpdate(buildSingleFilterClause(filter, activeDriver), sortInput, getLimitVal(limitInput));
+      onUpdate(
+        buildSingleFilterClause(filter, activeDriver),
+        formatSortClause(sortInput, activeDriver),
+        getLimitVal(limitInput),
+      );
       onResetAllApplied();
       onTriggerApplied(filter.id);
     },
@@ -187,7 +194,7 @@ const TableToolbarInternal = ({
 
   const handleUnset = () => {
     onStructuredFiltersChange([]);
-    onUpdate("", sortInput, getLimitVal(limitInput));
+    onUpdate("", formatSortClause(sortInput, activeDriver), getLimitVal(limitInput));
   };
 
   const handleAddFilter = () => {
@@ -258,7 +265,8 @@ const TableToolbarInternal = ({
   const acceptSuggestion = (col: TableColumn) => {
     const input = filterInputRef.current;
     const cursorPos = input?.selectionStart ?? filterInput.length;
-    const newValue = replaceCurrentWord(filterInput, cursorPos, col.name);
+    const replacement = formatSqlIdentifier(col.name, activeDriver);
+    const newValue = replaceCurrentWord(filterInput, cursorPos, replacement);
     setFilterInput(newValue);
     setAutocompleteOpen(false);
 
@@ -268,7 +276,7 @@ const TableToolbarInternal = ({
         const before = filterInput.slice(0, cursorPos);
         const wordMatch = before.match(/[a-zA-Z0-9_]+$/);
         const wordStart = wordMatch ? cursorPos - wordMatch[0].length : cursorPos;
-        input.setSelectionRange(wordStart + col.name.length, wordStart + col.name.length);
+        input.setSelectionRange(wordStart + replacement.length, wordStart + replacement.length);
       }
     }, 0);
   };
@@ -327,7 +335,8 @@ const TableToolbarInternal = ({
   const acceptSortSuggestion = (col: TableColumn) => {
     const input = sortInputRef.current;
     const cursorPos = input?.selectionStart ?? sortInput.length;
-    const newValue = replaceCurrentWord(sortInput, cursorPos, col.name);
+    const replacement = formatSqlIdentifier(col.name, activeDriver);
+    const newValue = replaceCurrentWord(sortInput, cursorPos, replacement);
     setSortInput(newValue);
     setSortAcOpen(false);
     setTimeout(() => {
@@ -336,7 +345,7 @@ const TableToolbarInternal = ({
         const before = sortInput.slice(0, cursorPos);
         const wordMatch = before.match(/[a-zA-Z0-9_]+$/);
         const wordStart = wordMatch ? cursorPos - wordMatch[0].length : cursorPos;
-        input.setSelectionRange(wordStart + col.name.length, wordStart + col.name.length);
+        input.setSelectionRange(wordStart + replacement.length, wordStart + replacement.length);
       }
     }, 0);
   };
@@ -361,7 +370,11 @@ const TableToolbarInternal = ({
     if (!panelOpen) {
       commitSql(filterInput, sortInput, limitInput);
     } else {
-      onUpdate(buildStructuredFilterClause(structuredFilters, activeDriver), sortInput, getLimitVal(limitInput));
+      onUpdate(
+        buildStructuredFilterClause(structuredFilters, activeDriver),
+        formatSortClause(sortInput, activeDriver),
+        getLimitVal(limitInput),
+      );
     }
   };
 
@@ -369,7 +382,11 @@ const TableToolbarInternal = ({
     if (!panelOpen) {
       commitSql(filterInput, sortInput, limitInput);
     } else {
-      onUpdate(buildStructuredFilterClause(structuredFilters, activeDriver), sortInput, getLimitVal(limitInput));
+      onUpdate(
+        buildStructuredFilterClause(structuredFilters, activeDriver),
+        formatSortClause(sortInput, activeDriver),
+        getLimitVal(limitInput),
+      );
     }
   };
 

--- a/src/components/ui/TableToolbar.tsx
+++ b/src/components/ui/TableToolbar.tsx
@@ -30,6 +30,7 @@ interface TableToolbarProps {
   defaultLimit: number;
   columnMetadata?: TableColumn[];
   onUpdate: (filter: string, sort: string, limit: number | undefined) => void;
+  driver?: string | null;
 }
 
 interface TableToolbarInternalProps extends TableToolbarProps {
@@ -62,6 +63,7 @@ const TableToolbarInternal = ({
   onResetApplied,
   onResetAllApplied,
   onUpdate,
+  driver,
 }: TableToolbarInternalProps) => {
   const { t } = useTranslation();
   const [filterInput, setFilterInput] = useState(initialFilter || "");
@@ -144,11 +146,11 @@ const TableToolbarInternal = ({
   };
 
   const closePanel = useCallback(() => {
-    const clause = buildStructuredFilterClause(structuredFilters);
+    const clause = buildStructuredFilterClause(structuredFilters, driver);
     setFilterInput(clause);
     onPanelOpenChange(false);
     onUpdate(clause, sortInput, getLimitVal(limitInput));
-  }, [structuredFilters, sortInput, limitInput, getLimitVal, onUpdate, onPanelOpenChange]);
+  }, [structuredFilters, sortInput, limitInput, getLimitVal, onUpdate, onPanelOpenChange, driver]);
 
   const togglePanel = () => {
     if (panelOpen) {
@@ -162,7 +164,7 @@ const TableToolbarInternal = ({
 
   // Applies all enabled filters — does NOT close panel
   const handleApplyAll = useCallback(() => {
-    const clause = buildStructuredFilterClause(structuredFilters);
+    const clause = buildStructuredFilterClause(structuredFilters, driver);
     onUpdate(clause, sortInput, getLimitVal(limitInput));
     structuredFilters.forEach((f) => {
       if (f.enabled !== false) {
@@ -171,16 +173,16 @@ const TableToolbarInternal = ({
         onResetApplied(f.id);
       }
     });
-  }, [structuredFilters, sortInput, limitInput, getLimitVal, onUpdate, onTriggerApplied, onResetApplied]);
+  }, [structuredFilters, sortInput, limitInput, getLimitVal, onUpdate, onTriggerApplied, onResetApplied, driver]);
 
   // Applies only that single row's filter — resets Applied on all others
   const handleApplySingle = useCallback(
     (filter: StructuredFilter) => {
-      onUpdate(buildSingleFilterClause(filter), sortInput, getLimitVal(limitInput));
+      onUpdate(buildSingleFilterClause(filter, driver), sortInput, getLimitVal(limitInput));
       onResetAllApplied();
       onTriggerApplied(filter.id);
     },
-    [sortInput, limitInput, getLimitVal, onUpdate, onResetAllApplied, onTriggerApplied]
+    [sortInput, limitInput, getLimitVal, onUpdate, onResetAllApplied, onTriggerApplied, driver]
   );
 
   const handleUnset = () => {
@@ -359,7 +361,7 @@ const TableToolbarInternal = ({
     if (!panelOpen) {
       commitSql(filterInput, sortInput, limitInput);
     } else {
-      onUpdate(buildStructuredFilterClause(structuredFilters), sortInput, getLimitVal(limitInput));
+      onUpdate(buildStructuredFilterClause(structuredFilters, driver), sortInput, getLimitVal(limitInput));
     }
   };
 
@@ -367,7 +369,7 @@ const TableToolbarInternal = ({
     if (!panelOpen) {
       commitSql(filterInput, sortInput, limitInput);
     } else {
-      onUpdate(buildStructuredFilterClause(structuredFilters), sortInput, getLimitVal(limitInput));
+      onUpdate(buildStructuredFilterClause(structuredFilters, driver), sortInput, getLimitVal(limitInput));
     }
   };
 
@@ -455,7 +457,7 @@ const TableToolbarInternal = ({
           <div className="flex items-center gap-1.5 flex-1 px-2 py-1 min-w-0">
             <Filter size={12} className="text-muted shrink-0" />
             <span className="text-xs text-muted font-mono truncate">
-              {buildStructuredFilterClause(structuredFilters) || (
+              {buildStructuredFilterClause(structuredFilters, driver) || (
                 <em className="not-italic opacity-50">{t("toolbar.noActiveFilters")}</em>
               )}
             </span>

--- a/src/components/ui/TableToolbar.tsx
+++ b/src/components/ui/TableToolbar.tsx
@@ -20,6 +20,7 @@ import {
 import type { StructuredFilter } from "../../utils/filterBar";
 import { FilterRow } from "./FilterRow";
 import { SlotAnchor } from "./SlotAnchor";
+import { useDatabase } from "../../hooks/useDatabase";
 
 interface TableToolbarProps {
   initialFilter?: string;
@@ -30,7 +31,6 @@ interface TableToolbarProps {
   defaultLimit: number;
   columnMetadata?: TableColumn[];
   onUpdate: (filter: string, sort: string, limit: number | undefined) => void;
-  driver?: string | null;
 }
 
 interface TableToolbarInternalProps extends TableToolbarProps {
@@ -63,9 +63,9 @@ const TableToolbarInternal = ({
   onResetApplied,
   onResetAllApplied,
   onUpdate,
-  driver,
 }: TableToolbarInternalProps) => {
   const { t } = useTranslation();
+  const { activeDriver } = useDatabase();
   const [filterInput, setFilterInput] = useState(initialFilter || "");
   const [sortInput, setSortInput] = useState(initialSort || "");
   const [limitInput, setLimitInput] = useState(
@@ -146,11 +146,11 @@ const TableToolbarInternal = ({
   };
 
   const closePanel = useCallback(() => {
-    const clause = buildStructuredFilterClause(structuredFilters, driver);
+    const clause = buildStructuredFilterClause(structuredFilters, activeDriver);
     setFilterInput(clause);
     onPanelOpenChange(false);
     onUpdate(clause, sortInput, getLimitVal(limitInput));
-  }, [structuredFilters, sortInput, limitInput, getLimitVal, onUpdate, onPanelOpenChange, driver]);
+  }, [structuredFilters, sortInput, limitInput, getLimitVal, onUpdate, onPanelOpenChange, activeDriver]);
 
   const togglePanel = () => {
     if (panelOpen) {
@@ -164,7 +164,7 @@ const TableToolbarInternal = ({
 
   // Applies all enabled filters — does NOT close panel
   const handleApplyAll = useCallback(() => {
-    const clause = buildStructuredFilterClause(structuredFilters, driver);
+    const clause = buildStructuredFilterClause(structuredFilters, activeDriver);
     onUpdate(clause, sortInput, getLimitVal(limitInput));
     structuredFilters.forEach((f) => {
       if (f.enabled !== false) {
@@ -173,16 +173,16 @@ const TableToolbarInternal = ({
         onResetApplied(f.id);
       }
     });
-  }, [structuredFilters, sortInput, limitInput, getLimitVal, onUpdate, onTriggerApplied, onResetApplied, driver]);
+  }, [structuredFilters, sortInput, limitInput, getLimitVal, onUpdate, onTriggerApplied, onResetApplied, activeDriver]);
 
   // Applies only that single row's filter — resets Applied on all others
   const handleApplySingle = useCallback(
     (filter: StructuredFilter) => {
-      onUpdate(buildSingleFilterClause(filter, driver), sortInput, getLimitVal(limitInput));
+      onUpdate(buildSingleFilterClause(filter, activeDriver), sortInput, getLimitVal(limitInput));
       onResetAllApplied();
       onTriggerApplied(filter.id);
     },
-    [sortInput, limitInput, getLimitVal, onUpdate, onResetAllApplied, onTriggerApplied, driver]
+    [sortInput, limitInput, getLimitVal, onUpdate, onResetAllApplied, onTriggerApplied, activeDriver]
   );
 
   const handleUnset = () => {
@@ -361,7 +361,7 @@ const TableToolbarInternal = ({
     if (!panelOpen) {
       commitSql(filterInput, sortInput, limitInput);
     } else {
-      onUpdate(buildStructuredFilterClause(structuredFilters, driver), sortInput, getLimitVal(limitInput));
+      onUpdate(buildStructuredFilterClause(structuredFilters, activeDriver), sortInput, getLimitVal(limitInput));
     }
   };
 
@@ -369,7 +369,7 @@ const TableToolbarInternal = ({
     if (!panelOpen) {
       commitSql(filterInput, sortInput, limitInput);
     } else {
-      onUpdate(buildStructuredFilterClause(structuredFilters, driver), sortInput, getLimitVal(limitInput));
+      onUpdate(buildStructuredFilterClause(structuredFilters, activeDriver), sortInput, getLimitVal(limitInput));
     }
   };
 
@@ -457,7 +457,7 @@ const TableToolbarInternal = ({
           <div className="flex items-center gap-1.5 flex-1 px-2 py-1 min-w-0">
             <Filter size={12} className="text-muted shrink-0" />
             <span className="text-xs text-muted font-mono truncate">
-              {buildStructuredFilterClause(structuredFilters, driver) || (
+              {buildStructuredFilterClause(structuredFilters, activeDriver) || (
                 <em className="not-italic opacity-50">{t("toolbar.noActiveFilters")}</em>
               )}
             </span>

--- a/src/components/ui/TableToolbar.tsx
+++ b/src/components/ui/TableToolbar.tsx
@@ -106,11 +106,10 @@ const TableToolbarInternal = ({
     (filter: string, sort: string, limit: string) => {
       const limitVal = getLimitVal(limit);
       const filterChanged = (filter || "") !== (initialFilter || "");
-      const formattedSort = formatSortClause(sort, activeDriver);
-      const sortChanged = (formattedSort || "") !== (initialSort || "");
+      const sortChanged = (sort || "") !== (initialSort || "");
       const limitChanged = limitVal !== initialLimit;
       if (filterChanged || sortChanged || limitChanged) {
-        onUpdate(filter, formattedSort, limitVal);
+        onUpdate(filter, formatSortClause(sort, activeDriver), limitVal);
       }
     },
     [getLimitVal, initialFilter, initialSort, initialLimit, onUpdate, activeDriver]

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -102,6 +102,7 @@ import type {
   ForeignKey,
 } from "../types/editor";
 import { buildForeignKeyFilterClause } from "../utils/foreignKeys";
+import { formatSqlIdentifier } from "../utils/identifiers";
 import {
   getTabScrollState,
   getAdjacentTabIndex,
@@ -1293,21 +1294,22 @@ export const Editor = () => {
 
       let newSort = "";
 
+      const sortCol = parts[0]?.replace(/^["`]|["`]$/g, "") ?? "";
+
       // Check if we are currently sorting by this column
-      if (parts[0] === colName && parts.length <= 2) {
-        // Toggle logic
+      if (sortCol === colName && parts.length <= 2) {
         const currentDir = parts[1]?.toUpperCase();
 
         if (!currentDir || currentDir === "ASC") {
           // ASC -> DESC
-          newSort = `${colName} DESC`;
+          newSort = `${formatSqlIdentifier(colName, activeDriver)} DESC`;
         } else {
           // DESC -> None (Clear)
           newSort = "";
         }
       } else {
         // New column -> ASC
-        newSort = `${colName} ASC`;
+        newSort = `${formatSqlIdentifier(colName, activeDriver)} ASC`;
       }
 
       handleToolbarUpdate(
@@ -1316,7 +1318,7 @@ export const Editor = () => {
         activeTab.limitClause,
       );
     },
-    [activeTab, handleToolbarUpdate],
+    [activeTab, activeDriver, handleToolbarUpdate],
   );
 
   const handlePendingChange = useCallback(

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -2789,6 +2789,7 @@ export const Editor = () => {
               defaultLimit={settings.resultPageSize || 100}
               columnMetadata={activeTab?.columnMetadata}
               onUpdate={handleToolbarUpdate}
+              driver={activeDriver}
             />
           ) : (
             <div

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -2789,7 +2789,6 @@ export const Editor = () => {
               defaultLimit={settings.resultPageSize || 100}
               columnMetadata={activeTab?.columnMetadata}
               onUpdate={handleToolbarUpdate}
-              driver={activeDriver}
             />
           ) : (
             <div

--- a/src/utils/dataGrid.ts
+++ b/src/utils/dataGrid.ts
@@ -95,12 +95,13 @@ export function getColumnSortState(
 ): SortDirection {
   if (!sortClause) return null;
 
-  // Normalize for case-insensitive comparison
-  const normalizedClause = sortClause.toLowerCase();
+  // Strip identifier quotes so postgres clauses like "Status" DESC match column names
+  const clauseForMatch = sortClause
+    .replace(/"([^"]*)"/g, "$1")
+    .replace(/`([^`]*)`/g, "$1");
+  const normalizedClause = clauseForMatch.toLowerCase();
   const normalizedCol = columnName.toLowerCase();
 
-  // Check if column appears in sort clause
-  // Handle patterns like: "name ASC", "name asc", "table.name ASC", etc.
   const patterns = [
     new RegExp(`\\b${escapeRegExp(normalizedCol)}\\s+(asc|desc)\\b`),
     new RegExp(`\\b${escapeRegExp(normalizedCol)}\\b`),
@@ -109,17 +110,16 @@ export function getColumnSortState(
   for (const pattern of patterns) {
     const match = normalizedClause.match(pattern);
     if (match) {
-      // Check if explicit ASC/DESC was captured
       if (match[1]) {
         return match[1] === "asc" ? "asc" : "desc";
       }
-      // Default to ASC if no direction specified
       return "asc";
     }
   }
 
   return null;
 }
+
 
 /**
  * Calculates a range of indices for shift-click selection

--- a/src/utils/filterBar.ts
+++ b/src/utils/filterBar.ts
@@ -1,5 +1,5 @@
 import type { TableColumn } from "../types/editor";
-import { quoteIdentifier } from "./identifiers";
+import { formatSqlIdentifier } from "./identifiers";
 
 
 export type FilterOperator =
@@ -153,10 +153,7 @@ export function buildSingleFilterClause(
   filter: StructuredFilter,
   driver?: string | null
 ): string {
-  const col =
-    driver === 'postgres'
-      ? quoteIdentifier(filter.column, driver)
-      : filter.column;
+  const col = formatSqlIdentifier(filter.column, driver);
     const op = filter.operator;
 
   if (op === "IS NULL") {

--- a/src/utils/filterBar.ts
+++ b/src/utils/filterBar.ts
@@ -1,4 +1,6 @@
 import type { TableColumn } from "../types/editor";
+import { quoteIdentifier } from "./identifiers";
+
 
 export type FilterOperator =
   | "="
@@ -147,9 +149,15 @@ export function getOperatorsForType(dataType: string): FilterOperator[] {
  * String values are single-quoted. IS NULL / IS NOT NULL ignore the value.
  * BETWEEN uses value AND value2. IN/NOT IN parse comma-separated values.
  */
-export function buildSingleFilterClause(filter: StructuredFilter): string {
-  const col = filter.column;
-  const op = filter.operator;
+export function buildSingleFilterClause(
+  filter: StructuredFilter,
+  driver?: string | null
+): string {
+  const col =
+    driver === 'postgres'
+      ? quoteIdentifier(filter.column, driver)
+      : filter.column;
+    const op = filter.operator;
 
   if (op === "IS NULL") {
     return `${col} IS NULL`;
@@ -198,11 +206,12 @@ function quoteIfNeeded(value: string): string {
  * Returns empty string if filters array is empty.
  */
 export function buildStructuredFilterClause(
-  filters: StructuredFilter[]
+  filters: StructuredFilter[],
+  driver?: string | null
 ): string {
   const clauses = filters
     .filter((f) => f.column && f.enabled !== false)
-    .map(buildSingleFilterClause);
+    .map((f) => buildSingleFilterClause(f, driver));
   return clauses.join(" AND ");
 }
 

--- a/src/utils/identifiers.ts
+++ b/src/utils/identifiers.ts
@@ -29,6 +29,26 @@ export function getQuoteChar(
  * quoteIdentifier("my table", "mysql") // returns: `my table`
  * quoteIdentifier("my_table", "postgres") // returns: "my_table"
  */
+/** True when identifiers in generated SQL fragments should be double-quoted (PostgreSQL). */
+export function shouldQuoteIdentifiers(
+  driver: string | null | undefined,
+): boolean {
+  return driver === "postgres";
+}
+
+/**
+ * Formats a SQL identifier for WHERE / ORDER BY fragments.
+ * Quotes only when required (PostgreSQL); otherwise returns the name unchanged.
+ */
+export function formatSqlIdentifier(
+  identifier: string,
+  driver: string | null | undefined,
+): string {
+  return shouldQuoteIdentifiers(driver)
+    ? quoteIdentifier(identifier, driver)
+    : identifier;
+}
+
 export function quoteIdentifier(
   identifier: string,
   driver: string | null | undefined,

--- a/src/utils/tableToolbar.ts
+++ b/src/utils/tableToolbar.ts
@@ -3,6 +3,8 @@
  * Pure functions for managing toolbar state and changes
  */
 
+import { formatSqlIdentifier } from "./identifiers";
+
 export interface TableToolbarState {
   filterInput: string;
   sortInput: string;
@@ -91,4 +93,36 @@ export function generateWherePlaceholder(column: string): string {
  */
 export function generateOrderByPlaceholder(column: string): string {
   return `${column} DESC`;
+}
+
+/**
+ * Quotes column names in ORDER BY input for PostgreSQL (e.g. `Status DESC` → `"Status" DESC`).
+ */
+export function formatSortClause(
+  clause: string,
+  driver?: string | null,
+): string {
+  if (!clause.trim() || driver !== "postgres") {
+    return clause;
+  }
+
+  return clause
+    .split(",")
+    .map((term) => {
+      const parts = term.trim().split(/\s+/);
+
+      // Skip empty terms
+      if (!parts[0]) return term.trim();
+
+      // Already quoted, no need to format
+      if (parts[0].startsWith('"') || parts[0].startsWith("`")) {
+        return term.trim();
+      }
+
+      // Format the column identifier and preserve the direction (ASC/DESC) if present
+      const col = formatSqlIdentifier(parts[0], driver);
+      const dir = parts[1]?.toUpperCase();
+      return dir ? `${col} ${dir}` : col;
+    })
+    .join(", ");
 }

--- a/src/utils/visualQuery.ts
+++ b/src/utils/visualQuery.ts
@@ -3,6 +3,8 @@
  * Pure functions for generating SQL from visual query state
  */
 
+import { formatSqlIdentifier } from "./identifiers";
+
 export interface TableNodeData {
   label: string;
   columns: { name: string; type: string }[];
@@ -292,10 +294,15 @@ export function generateHavingClause(conditions: WhereCondition[]): string {
 /**
  * Generates ORDER BY clause
  */
-export function generateOrderByClause(orderBy: OrderByClause[]): string {
+export function generateOrderByClause(
+  orderBy: OrderByClause[],
+  driver?: string | null,
+): string {
   if (orderBy.length === 0) return '';
 
-  const clauses = orderBy.map((o) => `${o.column} ${o.direction}`);
+  const clauses = orderBy.map(
+    (o) => `${formatSqlIdentifier(o.column, driver)} ${o.direction}`,
+  );
   return '\nORDER BY\n  ' + clauses.join(',\n  ');
 }
 
@@ -316,7 +323,8 @@ export function generateVisualQuerySQL(
   whereConditions: WhereCondition[],
   orderBy: OrderByClause[],
   groupBy: string[],
-  limit: string
+  limit: string,
+  driver?: string | null,
 ): string {
   if (nodes.length === 0) return '';
 
@@ -329,7 +337,7 @@ export function generateVisualQuerySQL(
   sql += generateWhereClause(whereConditions);
   sql += generateGroupByClause(hasAggregation, nonAggregatedCols, groupBy);
   sql += generateHavingClause(whereConditions);
-  sql += generateOrderByClause(orderBy);
+  sql += generateOrderByClause(orderBy, driver);
   sql += generateLimitClause(limit);
 
   return sql;

--- a/tests/components/ui/TableToolbar.test.tsx
+++ b/tests/components/ui/TableToolbar.test.tsx
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { TableToolbar } from '../../../src/components/ui/TableToolbar';
+import { useDatabase } from '../../../src/hooks/useDatabase';
+
+vi.mock('../../../src/hooks/useDatabase', () => ({
+  useDatabase: vi.fn(),
+}));
 
 describe('TableToolbar', () => {
   const mockOnUpdate = vi.fn();
@@ -13,6 +18,9 @@ describe('TableToolbar', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useDatabase).mockReturnValue({
+      activeDriver: null,
+    } as ReturnType<typeof useDatabase>);
   });
 
   it('renders with default state', () => {

--- a/tests/components/ui/TableToolbar.test.tsx
+++ b/tests/components/ui/TableToolbar.test.tsx
@@ -103,6 +103,20 @@ describe('TableToolbar', () => {
     expect(mockOnUpdate).toHaveBeenCalledWith('', 'name DESC', undefined);
   });
 
+  it('quotes sort column on commit for postgres driver', () => {
+    vi.mocked(useDatabase).mockReturnValue({
+      activeDriver: 'postgres',
+    } as ReturnType<typeof useDatabase>);
+
+    render(<TableToolbar {...defaultProps} />);
+
+    const sortInput = screen.getByPlaceholderText('created_at DESC');
+    fireEvent.change(sortInput, { target: { value: 'Status DESC' } });
+    fireEvent.keyDown(sortInput, { key: 'Enter' });
+
+    expect(mockOnUpdate).toHaveBeenCalledWith('', '"Status" DESC', undefined);
+  });
+
   it('calls onUpdate when pressing Enter in limit input', () => {
     render(<TableToolbar {...defaultProps} />);
 

--- a/tests/components/ui/TableToolbar.test.tsx
+++ b/tests/components/ui/TableToolbar.test.tsx
@@ -151,6 +151,24 @@ describe('TableToolbar', () => {
     expect(mockOnUpdate).not.toHaveBeenCalled();
   });
 
+  it('does not call onUpdate on sort blur when clause only differs by postgres quoting', () => {
+    vi.mocked(useDatabase).mockReturnValue({
+      activeDriver: 'postgres',
+    } as ReturnType<typeof useDatabase>);
+
+    render(
+      <TableToolbar
+        {...defaultProps}
+        initialSort="Status DESC"
+      />
+    );
+
+    const sortInput = screen.getByDisplayValue('Status DESC');
+    fireEvent.blur(sortInput);
+
+    expect(mockOnUpdate).not.toHaveBeenCalled();
+  });
+
   it('resets component when key changes', () => {
     const { rerender } = render(
       <TableToolbar

--- a/tests/utils/dataGrid.test.ts
+++ b/tests/utils/dataGrid.test.ts
@@ -189,6 +189,12 @@ describe('dataGrid utils', () => {
       expect(getColumnSortState('name', 'name   ASC')).toBe('asc');
       expect(getColumnSortState('name', 'name  desc')).toBe('desc');
     });
+
+    it('should detect sort for quoted postgres column names', () => {
+      expect(getColumnSortState('Status', '"Status" DESC')).toBe('desc');
+      expect(getColumnSortState('Status', '"Status" ASC')).toBe('asc');
+      expect(getColumnSortState('UserName', '"Status" ASC, "UserName" DESC')).toBe('desc');
+    });
   });
 
   describe('calculateSelectionRange', () => {

--- a/tests/utils/filterBar.test.ts
+++ b/tests/utils/filterBar.test.ts
@@ -296,6 +296,26 @@ describe("filterBar utils", () => {
       };
       expect(buildSingleFilterClause(filter)).toBe("price >= 9.99");
     });
+
+    it("should quote the column name with double quotes for postgres driver", () => {
+      const filter: StructuredFilter = {
+        id: "1",
+        column: "user_status",
+        operator: "=",
+        value: "active",
+      };
+      expect(buildSingleFilterClause(filter, "postgres")).toBe('"user_status" = \'active\'');
+    });
+
+    it("should not quote the column name for mysql driver", () => {
+      const filter: StructuredFilter = {
+        id: "1",
+        column: "user_status",
+        operator: "=",
+        value: "active",
+      };
+      expect(buildSingleFilterClause(filter, "mysql")).toBe("user_status = 'active'");
+    });
   });
 
   describe("buildStructuredFilterClause", () => {
@@ -317,6 +337,16 @@ describe("filterBar utils", () => {
       ];
       expect(buildStructuredFilterClause(filters)).toBe(
         "status = 'active' AND age > 18"
+      );
+    });
+
+    it("should quote columns for postgres in structured filters", () => {
+      const filters: StructuredFilter[] = [
+        { id: "1", column: "status", operator: "=", value: "active" },
+        { id: "2", column: "age", operator: ">", value: "18" },
+      ];
+      expect(buildStructuredFilterClause(filters, "postgres")).toBe(
+        '"status" = \'active\' AND "age" > 18'
       );
     });
 

--- a/tests/utils/identifiers.test.ts
+++ b/tests/utils/identifiers.test.ts
@@ -3,6 +3,7 @@ import {
   getQuoteChar,
   quoteIdentifier,
   quoteTableRef,
+  formatSqlIdentifier,
 } from '../../src/utils/identifiers';
 
 describe('getQuoteChar', () => {
@@ -98,5 +99,22 @@ describe('quoteTableRef', () => {
 
   it('should escape special chars in both schema and table', () => {
     expect(quoteTableRef('my"table', 'postgres', 'my"schema')).toBe('"my""schema"."my""table"');
+  });
+});
+
+describe('formatSqlIdentifier', () => {
+  it('should quote identifiers for postgres', () => {
+    expect(formatSqlIdentifier('Status', 'postgres')).toBe('"Status"');
+    expect(formatSqlIdentifier('user_status', 'postgres')).toBe('"user_status"');
+  });
+
+  it('should leave identifiers unchanged for mysql', () => {
+    expect(formatSqlIdentifier('Status', 'mysql')).toBe('Status');
+    expect(formatSqlIdentifier('user_status', 'mariadb')).toBe('user_status');
+  });
+
+  it('should leave identifiers unchanged for sqlite and unknown drivers', () => {
+    expect(formatSqlIdentifier('Status', 'sqlite')).toBe('Status');
+    expect(formatSqlIdentifier('Status', null)).toBe('Status');
   });
 });

--- a/tests/utils/tableToolbar.test.ts
+++ b/tests/utils/tableToolbar.test.ts
@@ -7,6 +7,7 @@ import {
   formatLimitInput,
   generateWherePlaceholder,
   generateOrderByPlaceholder,
+  formatSortClause,
 } from '../../src/utils/tableToolbar';
 
 describe('tableToolbar utils', () => {
@@ -204,6 +205,32 @@ describe('tableToolbar utils', () => {
     it('should generate placeholder with column name', () => {
       expect(generateOrderByPlaceholder('id')).toBe('id DESC');
       expect(generateOrderByPlaceholder('created_at')).toBe('created_at DESC');
+    });
+  });
+
+  describe('formatSortClause', () => {
+    it('should quote column names for postgres', () => {
+      expect(formatSortClause('Status DESC', 'postgres')).toBe('"Status" DESC');
+    });
+
+    it('should quote multiple comma-separated terms for postgres', () => {
+      expect(formatSortClause('Status ASC, UserName DESC', 'postgres')).toBe(
+        '"Status" ASC, "UserName" DESC',
+      );
+    });
+
+    it('should leave already-quoted terms unchanged for postgres', () => {
+      expect(formatSortClause('"Status" DESC', 'postgres')).toBe('"Status" DESC');
+    });
+
+    it('should leave clause unchanged for non-postgres drivers', () => {
+      expect(formatSortClause('Status DESC', 'mysql')).toBe('Status DESC');
+      expect(formatSortClause('Status DESC', null)).toBe('Status DESC');
+    });
+
+    it('should return empty clause unchanged', () => {
+      expect(formatSortClause('', 'postgres')).toBe('');
+      expect(formatSortClause('   ', 'postgres')).toBe('   ');
     });
   });
 

--- a/tests/utils/visualQuery.test.ts
+++ b/tests/utils/visualQuery.test.ts
@@ -538,6 +538,16 @@ describe('visualQuery utils', () => {
     it('should return empty string for empty orderBy', () => {
       expect(generateOrderByClause([])).toBe('');
     });
+
+    it('should quote column names for postgres driver', () => {
+      const orderBy: OrderByClause[] = [
+        { id: '1', column: 'Status', direction: 'DESC' },
+      ];
+
+      expect(generateOrderByClause(orderBy, 'postgres')).toBe(
+        '\nORDER BY\n  "Status" DESC',
+      );
+    });
   });
 
   describe('generateLimitClause', () => {


### PR DESCRIPTION
**Fix: quote Postgres column names in structured filters**

Postgres is case-sensitive: `userId` was becoming `userid` and filters failed.
Now when driver = postgres, columns get double quotes via `quoteIdentifier` (MySQL/SQLite unchanged).

Closes #231