### PR TITLE
feat(sqlserver): flip driver manifest to editing-ready (#149)

### DIFF
--- a/src-tauri/src/drivers/sqlserver/mod.rs
+++ b/src-tauri/src/drivers/sqlserver/mod.rs
@@ -1,9 +1,10 @@
 //! Microsoft SQL Server driver (built-in).
 //!
-//! Phase 1 scope: read-only preview. `DriverCapabilities.readonly = true`
-//! keeps the UI from calling CRUD routes; the trait still requires the methods
-//! to exist, so the unimplemented ones return a descriptive error until later
-//! days fill them in.
+//! Phase 2 scope: editing-ready. `DriverCapabilities.readonly = false` and
+//! `manage_tables = true` so the UI exposes INSERT / UPDATE / DELETE routes
+//! for tables (single-PK, composite-PK, and IDENTITY-PK shapes). DDL for
+//! `alter_column` / `create_foreign_keys` is still gated off — that lands in
+//! Phase 3.
 
 pub mod extract;
 pub mod helpers;
@@ -39,8 +40,8 @@ impl SqlServerDriver {
             manifest: PluginManifest {
                 id: "sqlserver".to_string(),
                 name: "SQL Server".to_string(),
-                version: "0.1.0".to_string(),
-                description: "Microsoft SQL Server (read-only preview)".to_string(),
+                version: "0.2.0".to_string(),
+                description: "Microsoft SQL Server".to_string(),
                 default_port: Some(1433),
                 capabilities: DriverCapabilities {
                     schemas: true,
@@ -60,8 +61,8 @@ impl SqlServerDriver {
                     alter_column: false,
                     create_foreign_keys: false,
                     no_connection_required: false,
-                    manage_tables: false,
-                    readonly: true,
+                    manage_tables: true,
+                    readonly: false,
                 },
                 is_builtin: true,
                 default_username: "sa".to_string(),
@@ -572,16 +573,28 @@ mod tests {
     }
 
     #[test]
-    fn manifest_has_phase1_capabilities() {
+    fn manifest_has_phase2_capabilities() {
         let drv = SqlServerDriver::new();
         let m = drv.manifest();
         assert_eq!(m.id, "sqlserver");
+        assert_eq!(m.version, "0.2.0", "Phase 2 bumps the driver version");
         assert_eq!(m.default_port, Some(1433));
         assert!(m.is_builtin);
-        assert!(m.capabilities.readonly, "Phase 1 must ship readonly");
         assert!(
-            !m.capabilities.manage_tables,
-            "Phase 1 must hide CREATE TABLE UI"
+            !m.capabilities.readonly,
+            "Phase 2 enables editing (readonly = false)"
+        );
+        assert!(
+            m.capabilities.manage_tables,
+            "Phase 2 exposes CREATE TABLE UI (manage_tables = true)"
+        );
+        assert!(
+            !m.capabilities.alter_column,
+            "Phase 3 owns ALTER COLUMN — keep gated off"
+        );
+        assert!(
+            !m.capabilities.create_foreign_keys,
+            "Phase 3 owns CREATE FOREIGN KEY — keep gated off"
         );
         assert!(m.capabilities.schemas);
         assert!(m.capabilities.views);

--- a/src/hooks/useDrivers.ts
+++ b/src/hooks/useDrivers.ts
@@ -118,8 +118,8 @@ const FALLBACK_DRIVERS: PluginManifest[] = [
   {
     id: "sqlserver",
     name: "SQL Server",
-    version: "0.1.0",
-    description: "Microsoft SQL Server (read-only preview)",
+    version: "0.2.0",
+    description: "Microsoft SQL Server",
     default_port: 1433,
     is_builtin: true,
     default_username: "sa",
@@ -141,8 +141,8 @@ const FALLBACK_DRIVERS: PluginManifest[] = [
       inline_pk: false,
       alter_column: false,
       create_foreign_keys: false,
-      manage_tables: false,
-      readonly: true,
+      manage_tables: true,
+      readonly: false,
     },
   },
 ];


### PR DESCRIPTION
# [Phase 2] Flip driver manifest to editing-ready (closes Phase 2)

Closes #149. Final Phase 2 PR — once #215 (insert) and #222 (composite UPDATE/DELETE) merge into `feat/sql-server`, this one flips the capability bits so the UI actually exposes those editing surfaces.

## What changes

### Backend — `src-tauri/src/drivers/sqlserver/mod.rs`

| field | before | after |
|---|---|---|
| `version` | `"0.1.0"` | `"0.2.0"` |
| `description` | `"Microsoft SQL Server (read-only preview)"` | `"Microsoft SQL Server"` |
| `capabilities.manage_tables` | `false` | `true` |
| `capabilities.readonly` | `true` | `false` |
| `capabilities.alter_column` | `false` | `false` *(Phase 3)* |
| `capabilities.create_foreign_keys` | `false` | `false` *(Phase 3)* |

Module doc comment updated to describe Phase 2 scope.

`manifest_has_phase1_capabilities` test renamed to `manifest_has_phase2_capabilities`, assertions inverted, and added explicit pins that `alter_column` / `create_foreign_keys` stay off (Phase 3).

### Frontend — `src/hooks/useDrivers.ts`

Mirrors the Rust manifest in `FALLBACK_DRIVERS` (`version`, `description`, `manage_tables`, `readonly`). This is the offline fallback shown before the Tauri command returns; the real manifest comes from the driver itself, but keeping the fallback in sync avoids a flicker.

## What does NOT change

- `alter_column` and `create_foreign_keys` stay `false` — DDL generation is Phase 3.
- Single-key `update_record` / `delete_record` on the driver still return a "Phase 1 read-only preview" error; the editing entry points are the **composite** variants (`update_record_composite` / `delete_record_composite`) introduced in #146 / #222, which handle any arity including length-1 keys. The frontend in #222 routes through those.
- View create / alter / drop also still return Phase-1 errors; Phase 2 was about row-level CRUD on tables, not view DDL.

## Manual QA

Marked done out-of-band against:

- INSERT / UPDATE / DELETE via the UI on a table with single-column PK
- Same on a table with composite PK
- INSERT into an IDENTITY-PK table, with and without supplying the identity value (exercises the `SET IDENTITY_INSERT` TRY/CATCH wrap from #215)
- TLS off / on / strict against a local SQL Server 2022 container and Azure SQL
- Regression: MySQL / Postgres / SQLite editable flows unchanged (no shared code touched)

## Sequencing

This PR is the close-out of Phase 2 and is intentionally **last**. It depends on:

- #145 — driver scaffold (already in `feat/sql-server`)
- #146 — composite FK aggregation (already in `feat/sql-server`)
- #147 / PR #215 — `insert_record` + `IDENTITY_INSERT`
- #148 / PR #222 — frontend composite-PK plumbing

Once those are in, this flip is a one-commit close-out and the whole `feat/sql-server` branch can be squashed onto `main`.

## Test results

```
cargo test --lib drivers::sqlserver
test result: ok. 119 passed; 0 failed; 0 ignored
```

ESLint clean on `src/hooks/useDrivers.ts`.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
