### PR TITLE
feat(sqlserver): add Encrypt dropdown to connection dialog

### DIFF
--- a/src/components/modals/NewConnectionModal.tsx
+++ b/src/components/modals/NewConnectionModal.tsx
@@ -129,7 +129,7 @@ export const NewConnectionModal = ({
     username: "",
     database: "",
     ssl_mode: "",
-    encrypt: "",
+    encrypt: undefined,
     ssh_enabled: false,
     ssh_port: 22,
   });
@@ -369,7 +369,7 @@ export const NewConnectionModal = ({
       password: "",
       database: "",
       ssl_mode: "",
-      encrypt: "",
+      encrypt: undefined,
       ssh_enabled: false,
       ssh_connection_id: undefined,
       ssh_host: undefined,
@@ -485,6 +485,7 @@ export const NewConnectionModal = ({
       if (initialConnection) {
         if (!params.password?.trim()) delete params.password;
         if (!params.ssh_password?.trim()) delete params.ssh_password;
+        if (!params.encrypt?.trim()) delete params.encrypt;
         await invoke("update_connection", {
           id: initialConnection.id,
           name,

--- a/src/components/modals/NewConnectionModal.tsx
+++ b/src/components/modals/NewConnectionModal.tsx
@@ -45,6 +45,9 @@ interface ConnectionParams {
   ssl_ca?: string;
   ssl_cert?: string;
   ssl_key?: string;
+  // SQL Server
+  encrypt?: string;
+  trust_server_certificate?: boolean;
   // SSH
   ssh_enabled?: boolean;
   ssh_connection_id?: string;
@@ -126,6 +129,7 @@ export const NewConnectionModal = ({
     username: "",
     database: "",
     ssl_mode: "",
+    encrypt: "",
     ssh_enabled: false,
     ssh_port: 22,
   });
@@ -365,6 +369,7 @@ export const NewConnectionModal = ({
       password: "",
       database: "",
       ssl_mode: "",
+      encrypt: "",
       ssh_enabled: false,
       ssh_connection_id: undefined,
       ssh_host: undefined,
@@ -693,6 +698,26 @@ export const NewConnectionModal = ({
               placeholder={driver === "mysql" ? "3306" : "5432"}
             />
           </div>
+
+          {/* Encrypt (SQL Server only) */}
+          {driver === "sqlserver" && (
+            <div className="flex flex-col gap-1">
+              <label className="text-[10px] uppercase font-semibold tracking-wider text-muted">
+                {t("newConnection.encrypt", { defaultValue: "Encrypt" })}
+              </label>
+              <Select
+                value={formData.encrypt || "yes"}
+                options={["yes", "no", "strict"]}
+                labels={{
+                  yes: t("newConnection.encryptModes.yes", { defaultValue: "Yes" }),
+                  no: t("newConnection.encryptModes.no", { defaultValue: "No" }),
+                  strict: t("newConnection.encryptModes.strict", { defaultValue: "Strict" }),
+                }}
+                onChange={(v) => updateField("encrypt", v)}
+                searchable={false}
+              />
+            </div>
+          )}
 
           {/* User + Password */}
           <div className="grid grid-cols-2 gap-3">

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -617,6 +617,12 @@
       "allow": "Allow",
       "prefer": "Prefer",
       "require": "Require"
+    },
+    "encrypt": "Encrypt",
+    "encryptModes": {
+      "yes": "Yes",
+      "no": "No",
+      "strict": "Strict"
     }
   },
   "sshConnections": {

--- a/src/utils/connections.ts
+++ b/src/utils/connections.ts
@@ -19,6 +19,11 @@ export interface ConnectionParams {
   port?: number;
   username?: string;
   password?: string;
+  ssl_mode?: string;
+  // SQL Server
+  encrypt?: string;
+  trust_server_certificate?: boolean;
+  auth_mode?: string;
   ssh_enabled?: boolean;
   ssh_connection_id?: string;
   // Legacy fields (for backward compatibility)

--- a/src/utils/credentials.ts
+++ b/src/utils/credentials.ts
@@ -8,6 +8,10 @@ interface ConnectionParams {
   password?: string;
   database: string | string[];
   ssl_mode?: string;
+  // SQL Server
+  encrypt?: string;
+  trust_server_certificate?: boolean;
+  auth_mode?: string;
   ssh_enabled?: boolean;
   ssh_connection_id?: string;
   ssh_host?: string;


### PR DESCRIPTION
## Summary

Adds an **Encrypt** dropdown to the New Connection modal when the driver is **SQL Server**. Three options: **Yes** (default), **No**, **Strict**.

The backend already accepts the `encrypt` field on `ConnectionParams` and maps it correctly in `pool.rs::build_config` (`strict` → `Required`, `no` → `NotSupported`, default → `On`). This PR only adds the missing UI control.

## Changes

- `src/components/modals/NewConnectionModal.tsx` — local interface field, formData seed, driver-change reset, and conditional `<Select>` rendered for `driver === "sqlserver"` between the host/port grid and credentials block.
- `src/i18n/locales/en.json` — `newConnection.encrypt` label + `encryptModes.{yes,no,strict}` option labels (mirroring the existing `sslModes` pattern).

## Why draft

The new `encrypt` value is not yet threaded into the connection **save/load** path (i.e., the `Config` mapping where saved connections are reloaded into the dialog). Marking draft until that round-trip is wired so a saved connection re-opens with the previously chosen Encrypt setting.

## Manual test

1. Open New Connection → choose SQL Server → confirm the Encrypt dropdown appears between Host/Port and User/Password.
2. Switch driver away from SQL Server → confirm the dropdown disappears and `encrypt` is reset.
3. Pick **Strict** → connect to a server requiring TLS → confirms the value reaches the backend (existing `build_config` test coverage already validates the mapping).

## Out of scope

- `trust_server_certificate` UI control (field exists on the interface, no surface yet).
- Persisting encrypt on saved connections (the "why draft" item above).
- Other locale files; English-only for now, falls back via `defaultValue`.
