### PR TITLE
feat(sqlserver): data type registry + CREATE TABLE DDL

### DIFF
--- a/src-tauri/src/drivers/sqlserver/mod.rs
+++ b/src-tauri/src/drivers/sqlserver/mod.rs
@@ -9,6 +9,7 @@ pub mod extract;
 pub mod helpers;
 pub mod introspection;
 pub mod pool;
+pub mod types;
 pub mod version;
 
 use std::collections::HashMap;
@@ -19,11 +20,11 @@ use crate::drivers::driver_trait::{
     DatabaseDriver, DriverCapabilities, PluginManifest,
 };
 use crate::drivers::sqlserver::helpers::{
-    build_delete_composite_sql, build_update_composite_sql,
+    bracket_quote, build_delete_composite_sql, build_update_composite_sql, qualify,
 };
 use crate::models::{
-    ConnectionParams, DataTypeInfo, ForeignKey, Index, Pagination, QueryResult, RoutineInfo,
-    RoutineParameter, TableColumn, TableInfo, TableSchema, ViewInfo,
+    ColumnDefinition, ConnectionParams, DataTypeInfo, ForeignKey, Index, Pagination, QueryResult,
+    RoutineInfo, RoutineParameter, TableColumn, TableInfo, TableSchema, ViewInfo,
 };
 use crate::pool_manager::get_sqlserver_pool;
 use mssql_tiberius_bridge::ToSql;
@@ -95,9 +96,7 @@ impl DatabaseDriver for SqlServerDriver {
     }
 
     fn get_data_types(&self) -> Vec<DataTypeInfo> {
-        // Populated in Phase 1 Day 5+; empty vec keeps clipboard-import UI
-        // inert for now (the readonly flag already hides editing surfaces).
-        Vec::new()
+        types::get_data_types()
     }
 
     fn map_inferred_type(&self, kind: &str) -> String {
@@ -512,6 +511,46 @@ impl DatabaseDriver for SqlServerDriver {
 
     // --- ER diagram batch ---------------------------------------------------
 
+    async fn get_create_table_sql(
+        &self,
+        table_name: &str,
+        columns: Vec<ColumnDefinition>,
+        schema: Option<&str>,
+    ) -> Result<Vec<String>, String> {
+        let mut col_defs = Vec::new();
+        let mut pk_cols = Vec::new();
+
+        for col in &columns {
+            let mut def = format!("{} {}", bracket_quote(&col.name), col.data_type);
+            if col.is_auto_increment {
+                def.push_str(" IDENTITY(1,1)");
+            }
+            if col.is_nullable {
+                def.push_str(" NULL");
+            } else {
+                def.push_str(" NOT NULL");
+            }
+            if let Some(default) = &col.default_value {
+                def.push_str(&format!(" DEFAULT {}", default));
+            }
+            col_defs.push(def);
+            if col.is_pk {
+                pk_cols.push(bracket_quote(&col.name));
+            }
+        }
+
+        if !pk_cols.is_empty() {
+            col_defs.push(format!("PRIMARY KEY ({})", pk_cols.join(", ")));
+        }
+
+        let table_ref = qualify(schema, table_name);
+        Ok(vec![format!(
+            "CREATE TABLE {} (\n  {}\n)",
+            table_ref,
+            col_defs.join(",\n  ")
+        )])
+    }
+
     async fn get_schema_snapshot(
         &self,
         params: &ConnectionParams,
@@ -635,10 +674,14 @@ mod tests {
     }
 
     #[test]
-    fn get_data_types_empty_in_phase1() {
-        // Phase 1 is read-only; clipboard-import types are populated in Phase 2.
+    fn get_data_types_includes_core_types() {
         let drv = SqlServerDriver::new();
-        assert!(drv.get_data_types().is_empty());
+        let types = drv.get_data_types();
+        assert!(!types.is_empty());
+        assert!(types.iter().any(|t| t.name == "INT"));
+        assert!(types.iter().any(|t| t.name == "NVARCHAR"));
+        assert!(types.iter().any(|t| t.name == "DATETIME2"));
+        assert!(types.iter().any(|t| t.name == "UNIQUEIDENTIFIER"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/drivers/sqlserver/types.rs
+++ b/src-tauri/src/drivers/sqlserver/types.rs
@@ -1,0 +1,379 @@
+use crate::models::DataTypeInfo;
+
+/// Returns the list of data types supported by SQL Server.
+pub fn get_data_types() -> Vec<DataTypeInfo> {
+    vec![
+        // Exact numeric
+        DataTypeInfo {
+            name: "TINYINT".to_string(),
+            category: "numeric".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: true,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "SMALLINT".to_string(),
+            category: "numeric".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: true,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "INT".to_string(),
+            category: "numeric".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: true,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "BIGINT".to_string(),
+            category: "numeric".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: true,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "DECIMAL".to_string(),
+            category: "numeric".to_string(),
+            requires_length: false,
+            requires_precision: true,
+            default_length: Some("18,2".to_string()),
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "NUMERIC".to_string(),
+            category: "numeric".to_string(),
+            requires_length: false,
+            requires_precision: true,
+            default_length: Some("18,2".to_string()),
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "SMALLMONEY".to_string(),
+            category: "numeric".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "MONEY".to_string(),
+            category: "numeric".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        // Approximate numeric
+        DataTypeInfo {
+            name: "FLOAT".to_string(),
+            category: "numeric".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "REAL".to_string(),
+            category: "numeric".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        // Character strings
+        DataTypeInfo {
+            name: "CHAR".to_string(),
+            category: "text".to_string(),
+            requires_length: true,
+            requires_precision: false,
+            default_length: Some("1".to_string()),
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "VARCHAR".to_string(),
+            category: "text".to_string(),
+            requires_length: true,
+            requires_precision: false,
+            default_length: Some("255".to_string()),
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "VARCHAR(MAX)".to_string(),
+            category: "text".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "TEXT".to_string(),
+            category: "text".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        // Unicode strings
+        DataTypeInfo {
+            name: "NCHAR".to_string(),
+            category: "text".to_string(),
+            requires_length: true,
+            requires_precision: false,
+            default_length: Some("1".to_string()),
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "NVARCHAR".to_string(),
+            category: "text".to_string(),
+            requires_length: true,
+            requires_precision: false,
+            default_length: Some("255".to_string()),
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "NVARCHAR(MAX)".to_string(),
+            category: "text".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "NTEXT".to_string(),
+            category: "text".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        // Binary
+        DataTypeInfo {
+            name: "BINARY".to_string(),
+            category: "binary".to_string(),
+            requires_length: true,
+            requires_precision: false,
+            default_length: Some("1".to_string()),
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "VARBINARY".to_string(),
+            category: "binary".to_string(),
+            requires_length: true,
+            requires_precision: false,
+            default_length: Some("255".to_string()),
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "VARBINARY(MAX)".to_string(),
+            category: "binary".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "IMAGE".to_string(),
+            category: "binary".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        // Date / time
+        DataTypeInfo {
+            name: "DATE".to_string(),
+            category: "datetime".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "TIME".to_string(),
+            category: "datetime".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "DATETIME".to_string(),
+            category: "datetime".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "DATETIME2".to_string(),
+            category: "datetime".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "SMALLDATETIME".to_string(),
+            category: "datetime".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "DATETIMEOFFSET".to_string(),
+            category: "datetime".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        // Other
+        DataTypeInfo {
+            name: "BIT".to_string(),
+            category: "boolean".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "UNIQUEIDENTIFIER".to_string(),
+            category: "other".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "XML".to_string(),
+            category: "other".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "SQL_VARIANT".to_string(),
+            category: "other".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "ROWVERSION".to_string(),
+            category: "other".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "TIMESTAMP".to_string(),
+            category: "other".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "HIERARCHYID".to_string(),
+            category: "other".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "GEOGRAPHY".to_string(),
+            category: "spatial".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+        DataTypeInfo {
+            name: "GEOMETRY".to_string(),
+            category: "spatial".to_string(),
+            requires_length: false,
+            requires_precision: false,
+            default_length: None,
+            supports_auto_increment: false,
+            requires_extension: None,
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn types_list_is_non_empty() {
+        let types = get_data_types();
+        assert!(!types.is_empty());
+    }
+
+    #[test]
+    fn int_supports_auto_increment() {
+        let types = get_data_types();
+        let int_type = types.iter().find(|t| t.name == "INT").expect("INT must be present");
+        assert!(int_type.supports_auto_increment);
+    }
+
+    #[test]
+    fn varchar_requires_length() {
+        let types = get_data_types();
+        let t = types.iter().find(|t| t.name == "VARCHAR").expect("VARCHAR must be present");
+        assert!(t.requires_length);
+    }
+
+    #[test]
+    fn decimal_requires_precision() {
+        let types = get_data_types();
+        let t = types.iter().find(|t| t.name == "DECIMAL").expect("DECIMAL must be present");
+        assert!(t.requires_precision);
+    }
+}


### PR DESCRIPTION
## Summary

Populates the SQL Server data-type registry so the column-type dropdown in the table designer is functional, and implements \get_create_table_sql\ so table creation works for SQL Server.

## Changes

### \src-tauri/src/drivers/sqlserver/types.rs\ (new file)
34 SQL Server data types across 7 categories:
- **numeric**: TINYINT, SMALLINT, INT, BIGINT, DECIMAL, NUMERIC, SMALLMONEY, MONEY, FLOAT, REAL
- **text**: CHAR, VARCHAR, VARCHAR(MAX), TEXT
- **unicode**: NCHAR, NVARCHAR, NVARCHAR(MAX), NTEXT
- **binary**: BINARY, VARBINARY, VARBINARY(MAX), IMAGE
- **datetime**: DATE, TIME, DATETIME, DATETIME2, SMALLDATETIME, DATETIMEOFFSET
- **boolean/other**: BIT, UNIQUEIDENTIFIER, XML, SQL_VARIANT, ROWVERSION, TIMESTAMP, HIERARCHYID
- **spatial**: GEOGRAPHY, GEOMETRY

INT/BIGINT/SMALLINT/TINYINT marked \supports_auto_increment: true\ (IDENTITY). DECIMAL/NUMERIC marked \equires_precision: true\. VARCHAR/NVARCHAR/CHAR/NCHAR marked \equires_length: true\.

### \src-tauri/src/drivers/sqlserver/mod.rs\
- Declares \pub mod types\
- Wires \get_data_types()\ → \	ypes::get_data_types()\
- Implements \get_create_table_sql\ using \racket_quote()\ + \qualify()\ from helpers.rs; IDENTITY(1,1) for auto-increment; separate PRIMARY KEY clause (\inline_pk = false\)
- Adds \racket_quote\ + \qualify\ to the helpers import
- Adds \ColumnDefinition\ to the models import
- Replaces the Phase 1 \get_data_types_empty_in_phase1\ test with \get_data_types_includes_core_types\

## Test results

\\\
cargo test --lib drivers::sqlserver
test result: ok. 123 passed; 0 failed; 0 ignored
\\\

(Was 119 before; 4 new unit tests in \	ypes.rs\.)

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>