### PR TITLE
Fix table list refresh after creating tables

### DIFF
--- a/src/components/layout/ExplorerSidebar.tsx
+++ b/src/components/layout/ExplorerSidebar.tsx
@@ -75,6 +75,11 @@ import { SqlHighlight } from "../ui/SqlHighlight";
 import { isMultiDatabaseCapable } from "../../utils/database";
 import { supportsManageTables } from "../../utils/driverCapabilities";
 import { newConsoleForDatabase, newConsoleForTable } from "../../utils/newConsole";
+import {
+  DEFAULT_CREATE_TABLE_TARGET,
+  getCreateTableRefreshPlan,
+  type CreateTableTarget,
+} from "../../utils/createTable";
 
 export type SidebarTab = "structure" | "favorites" | "history";
 
@@ -139,6 +144,7 @@ export const ExplorerSidebar = ({ sidebarWidth, startResize, onCollapse, sidebar
   } | null>(null);
   const [schemaModal, setSchemaModal] = useState<{ tableName: string; schema?: string } | null>(null);
   const [isCreateTableModalOpen, setIsCreateTableModalOpen] = useState(false);
+  const [createTableTarget, setCreateTableTarget] = useState<CreateTableTarget>(DEFAULT_CREATE_TABLE_TARGET);
   const [isClipboardImportOpen, setIsClipboardImportOpen] = useState(false);
   const [modifyColumnModal, setModifyColumnModal] = useState<{
     isOpen: boolean;
@@ -203,6 +209,24 @@ export const ExplorerSidebar = ({ sidebarWidth, startResize, onCollapse, sidebar
   }>({ isOpen: false });
 
   const groupedRoutines = routines ? groupRoutinesByType(routines) : { procedures: [], functions: [] };
+
+  const openCreateTableModal = (target: CreateTableTarget) => {
+    setCreateTableTarget(target);
+    setIsCreateTableModalOpen(true);
+  };
+
+  const refreshAfterCreateTable = async () => {
+    const refreshPlan = getCreateTableRefreshPlan(createTableTarget);
+
+    if (refreshPlan.scope === "schema") {
+      await refreshSchemaData(refreshPlan.schema);
+    } else if (refreshPlan.scope === "database") {
+      await refreshDatabaseData(refreshPlan.schema);
+    } else if (refreshTables) {
+      await refreshTables();
+    }
+    setSchemaVersion((v) => v + 1);
+  };
 
   const runQuery = (sql: string, queryName?: string, tableName?: string, preventAutoRun: boolean = false, schema?: string, readOnly?: boolean) => {
     navigate("/editor", {
@@ -912,7 +936,7 @@ export const ExplorerSidebar = ({ sidebarWidth, startResize, onCollapse, sidebar
                               }
                             }
                           }}
-                          onCreateTable={() => setIsCreateTableModalOpen(true)}
+                          onCreateTable={() => openCreateTableModal({ kind: "schema", schema: schemaName })}
                           onCreateView={() =>
                             setViewEditorModal({ isOpen: true, isNewView: true })
                           }
@@ -1139,7 +1163,7 @@ export const ExplorerSidebar = ({ sidebarWidth, startResize, onCollapse, sidebar
                         }
                       }}
                       capabilities={activeCapabilities}
-                      onCreateTable={() => setIsCreateTableModalOpen(true)}
+                      onCreateTable={() => openCreateTableModal({ kind: "database", schema: dbName })}
                       onCreateView={() =>
                         setViewEditorModal({ isOpen: true, isNewView: true })
                       }
@@ -1208,7 +1232,7 @@ export const ExplorerSidebar = ({ sidebarWidth, startResize, onCollapse, sidebar
                         <button
                           onClick={(e) => {
                             e.stopPropagation();
-                            setIsCreateTableModalOpen(true);
+                            openCreateTableModal({ kind: "connection", schema: null });
                           }}
                           className="p-1 rounded hover:bg-surface-secondary text-muted hover:text-primary transition-colors"
                           title="Create New Table"
@@ -2053,10 +2077,8 @@ export const ExplorerSidebar = ({ sidebarWidth, startResize, onCollapse, sidebar
         <CreateTableModal
           isOpen={isCreateTableModalOpen}
           onClose={() => setIsCreateTableModalOpen(false)}
-          onSuccess={() => {
-            if (refreshTables) refreshTables();
-            setSchemaVersion((v) => v + 1);
-          }}
+          onSuccess={refreshAfterCreateTable}
+          schema={createTableTarget.schema}
         />
       )}
 

--- a/src/components/modals/CreateTableModal.tsx
+++ b/src/components/modals/CreateTableModal.tsx
@@ -8,6 +8,7 @@ import { useDataTypes } from '../../hooks/useDataTypes';
 import { Modal } from '../ui/Modal';
 import { Select } from '../ui/Select';
 import { getRequiredExtensions } from '../../utils/columnTypes';
+import { resolveCreateTableSchema } from '../../utils/createTable';
 
 interface ColumnDef {
   id: string; // Internal ID for React keys
@@ -23,12 +24,14 @@ interface ColumnDef {
 interface CreateTableModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSuccess: () => void;
+  onSuccess: () => void | Promise<void>;
+  schema?: string | null;
 }
 
-export const CreateTableModal = ({ isOpen, onClose, onSuccess }: CreateTableModalProps) => {
+export const CreateTableModal = ({ isOpen, onClose, onSuccess, schema }: CreateTableModalProps) => {
   const { t } = useTranslation();
   const { activeConnectionId, activeDriver, activeSchema } = useDatabase();
+  const targetSchema = resolveCreateTableSchema(schema, activeSchema);
   const currentDriver = activeDriver || "sqlite";
   const { dataTypes } = useDataTypes(currentDriver);
 
@@ -70,13 +73,13 @@ export const CreateTableModal = ({ isOpen, onClose, onSuccess }: CreateTableModa
         connectionId: activeConnectionId,
         tableName,
         columns: colDefs,
-        ...(activeSchema ? { schema: activeSchema } : {}),
+        ...(targetSchema ? { schema: targetSchema } : {}),
       });
       setSqlPreview(stmts.map(s => s + ';').join('\n'));
     } catch (e) {
       setSqlPreview('-- ' + String(e));
     }
-  }, [tableName, columns, activeConnectionId, activeSchema, t]);
+  }, [tableName, columns, activeConnectionId, targetSchema, t]);
 
   useEffect(() => {
     const timer = setTimeout(generatePreview, 300);
@@ -129,18 +132,18 @@ export const CreateTableModal = ({ isOpen, onClose, onSuccess }: CreateTableModa
           connectionId: activeConnectionId,
           tableName,
           columns: colDefs,
-          ...(activeSchema ? { schema: activeSchema } : {}),
+          ...(targetSchema ? { schema: targetSchema } : {}),
         });
 
         for (const sql of stmts) {
           await invoke('execute_query', {
             connectionId: activeConnectionId,
             query: sql,
-            ...(activeSchema ? { schema: activeSchema } : {}),
+            ...(targetSchema ? { schema: targetSchema } : {}),
           });
         }
 
-        onSuccess();
+        await onSuccess();
         onClose();
         setTableName('');
         setColumns([{ id: '1', name: 'id', type: 'INTEGER', length: '', isPk: true, isNullable: false, isAutoInc: true, defaultValue: '' }]);

--- a/src/utils/createTable.ts
+++ b/src/utils/createTable.ts
@@ -1,0 +1,30 @@
+export type CreateTableTarget =
+  | { kind: "connection"; schema: null }
+  | { kind: "schema"; schema: string }
+  | { kind: "database"; schema: string };
+
+export type CreateTableRefreshPlan =
+  | { scope: "connection"; schema: null }
+  | { scope: "schema"; schema: string }
+  | { scope: "database"; schema: string };
+
+export const DEFAULT_CREATE_TABLE_TARGET: CreateTableTarget = { kind: "connection", schema: null };
+
+export function getCreateTableRefreshPlan(target: CreateTableTarget): CreateTableRefreshPlan {
+  if (target.kind === "schema") {
+    return { scope: "schema", schema: target.schema };
+  }
+
+  if (target.kind === "database") {
+    return { scope: "database", schema: target.schema };
+  }
+
+  return { scope: "connection", schema: null };
+}
+
+export function resolveCreateTableSchema(
+  schemaOverride: string | null | undefined,
+  activeSchema: string | null,
+): string | null {
+  return schemaOverride === undefined ? activeSchema : schemaOverride;
+}

--- a/tests/utils/createTable.test.ts
+++ b/tests/utils/createTable.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_CREATE_TABLE_TARGET,
+  getCreateTableRefreshPlan,
+  resolveCreateTableSchema,
+  type CreateTableTarget,
+} from "../../src/utils/createTable";
+
+describe("createTable", () => {
+  describe("getCreateTableRefreshPlan", () => {
+    it("refreshes the flat connection table list for the default target", () => {
+      expect(getCreateTableRefreshPlan(DEFAULT_CREATE_TABLE_TARGET)).toEqual({
+        scope: "connection",
+        schema: null,
+      });
+    });
+
+    it("refreshes schema data for schema-scoped table creation", () => {
+      const target: CreateTableTarget = { kind: "schema", schema: "public" };
+
+      expect(getCreateTableRefreshPlan(target)).toEqual({
+        scope: "schema",
+        schema: "public",
+      });
+    });
+
+    it("refreshes database data for multi-database table creation", () => {
+      const target: CreateTableTarget = { kind: "database", schema: "analytics" };
+
+      expect(getCreateTableRefreshPlan(target)).toEqual({
+        scope: "database",
+        schema: "analytics",
+      });
+    });
+  });
+
+  describe("resolveCreateTableSchema", () => {
+    it("uses the active schema when no override is provided", () => {
+      expect(resolveCreateTableSchema(undefined, "public")).toBe("public");
+    });
+
+    it("uses an explicit schema override", () => {
+      expect(resolveCreateTableSchema("analytics", "public")).toBe("analytics");
+    });
+
+    it("uses null override to create without a schema", () => {
+      expect(resolveCreateTableSchema(null, "public")).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Refresh the table list that owns the create action, including schema and multi-database sidebar sections.
- Pass the selected schema/database into create-table SQL preview and execution.
- Add unit coverage for create-table target resolution.

## Testing
- pnpm typecheck
- pnpm lint
- pnpm exec vitest run tests/utils/createTable.test.ts

Closes #238