### PR TITLE
fix: Ctrl+Enter always runs query in the last opened console tab

### DIFF
--- a/src/components/ui/SqlEditorWrapper.tsx
+++ b/src/components/ui/SqlEditorWrapper.tsx
@@ -29,6 +29,8 @@ const SqlEditorInternal = ({
   const updateTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
   const monacoRef = useRef<typeof Monaco | null>(null);
+  const onRunRef = useRef(onRun);
+  onRunRef.current = onRun;
   const { currentTheme, allThemes } = useTheme();
   const { settings } = useSettings();
 
@@ -135,11 +137,11 @@ const SqlEditorInternal = ({
         }
       }
 
-      // Bind Ctrl+Enter to Run
+      // Bind Ctrl+Enter to Run — use ref so the closure never goes stale
       editor.addCommand(
         monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
         () => {
-            onRun();
+          onRunRef.current();
         }
       );
 

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -2097,10 +2097,6 @@ export const Editor = () => {
         }
       },
     });
-    editor.addCommand(
-      monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
-      handleRunButton,
-    );
   };
 
   useEffect(() => {


### PR DESCRIPTION
### Problem

  When multiple Console tabs are open, `Ctrl+Enter` always executed the query of the **last opened
  tab** instead of the tab currently in the foreground.

  #### Root cause

  Monaco's `editor.addCommand()` registers keybindings in a **global registry** — last registration
   wins across all editor instances on the page. Two compounding issues caused this:

  1. **`Editor.tsx` – stale closure + global override**
     `handleEditorMount` called `editor.addCommand(CtrlCmd+Enter, handleRunButton)`, where
  `handleRunButton` is a `useCallback` that closes over `activeTab` at the time of registration.
  Because `onMount` is only passed for the *active* tab, this command was registered anew every
  time a tab was opened — each time globally overriding the binding for *all* editors with a
  handler still pointing to the newly opened tab.

  2. **`SqlEditorWrapper.tsx` – stale closure**
     The `addCommand` closure captured `onRun` once at editor mount time. Even when the parent
  re-rendered with a fresh `handleRunButton`, the Monaco command kept calling the original stale
  reference.

  ### Fix

  **`SqlEditorWrapper.tsx`** — introduce `onRunRef` updated synchronously on every render. The
  `addCommand` closure reads `onRunRef.current` so it always dispatches to the current handler
  regardless of when the editor mounted.

  **`Editor.tsx`** — remove the duplicate `addCommand(CtrlCmd+Enter, handleRunButton)` from
  `handleEditorMount`. `SqlEditorWrapper` already owns this binding; the `Editor.tsx` call existed
  only to override it with a stale closure on each new tab open.

  ### Behaviour after fix

  - `Ctrl+Enter` (and `Cmd+Enter` on macOS) executes the query in whichever Console tab is
  currently active, regardless of how many tabs are open or the order in which they were opened.
  - The `run-selection` and `explain-selection` context-menu actions are unaffected (they already
  used stable refs via `addAction`).