### PR TITLE
feat: Kubernetes port-forward tunnel support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ devdiary
 coverage
 plugins/**/target
 .gitnexus
+.pi/

--- a/src-tauri/src/clipboard_import.rs
+++ b/src-tauri/src/clipboard_import.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 use crate::{
-    commands::{expand_ssh_connection_params, find_connection_by_id, resolve_connection_params_with_id},
+    commands::{
+        expand_k8s_connection_params, expand_ssh_connection_params, find_connection_by_id,
+        resolve_connection_params_with_id,
+    },
     drivers::{driver_trait::DatabaseDriver, registry::get_driver},
     models::ColumnDefinition,
 };
@@ -77,6 +80,7 @@ pub async fn execute_clipboard_import<R: Runtime>(
 
     let saved_conn = find_connection_by_id(&app, &req.connection_id)?;
     let expanded = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded = expand_k8s_connection_params(&app, &expanded).await?;
     let params = resolve_connection_params_with_id(&expanded, &req.connection_id)?;
     let drv: Arc<dyn DatabaseDriver> = get_driver(&saved_conn.params.driver)
         .await

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -11,9 +11,9 @@ use crate::credential_cache;
 use crate::keychain_utils;
 use crate::models::{
     BatchStatementResult, ColumnDefinition, ConnectionGroup, ConnectionParams, ConnectionsFile,
-    ExplainPlan, ExportPayload, ForeignKey, Index, QueryResult, RoutineInfo, RoutineParameter,
-    SavedConnection, SshConnection, SshConnectionInput, SshTestParams, TableColumn, TableInfo,
-    TestConnectionRequest, TriggerInfo,
+    ExplainPlan, ExportPayload, ForeignKey, Index, K8sConnection, K8sConnectionInput, QueryResult,
+    RoutineInfo, RoutineParameter, SavedConnection, SshConnection, SshConnectionInput, SshTestParams,
+    TableColumn, TableInfo, TestConnectionRequest, TriggerInfo,
 };
 use crate::persistence;
 use crate::ssh_tunnel::{get_tunnels, SshTunnel};
@@ -219,7 +219,83 @@ fn build_tunnel_map_key(
     crate::ssh_tunnel::build_tunnel_key(ssh_user, ssh_host, ssh_port, remote_host, remote_port)
 }
 
+/// Resolve K8s tunnel params synchronously (no saved-connection lookup; uses inline fields only).
+fn resolve_k8s_params(params: &ConnectionParams) -> Result<ConnectionParams, String> {
+    let context = params
+        .k8s_context
+        .as_deref()
+        .ok_or("Missing K8s context")?;
+    let namespace = params
+        .k8s_namespace
+        .as_deref()
+        .ok_or("Missing K8s namespace")?;
+    let resource_type = params
+        .k8s_resource_type
+        .as_deref()
+        .ok_or("Missing K8s resource type")?;
+    let resource_name = params
+        .k8s_resource_name
+        .as_deref()
+        .ok_or("Missing K8s resource name")?;
+    let port = params.k8s_port.ok_or("Missing K8s port")?;
+
+    let map_key = crate::k8s_tunnel::build_tunnel_key(
+        context, namespace, resource_type, resource_name, port,
+    );
+
+    // Check for existing tunnel
+    {
+        let tunnels = crate::k8s_tunnel::get_tunnels().lock().unwrap();
+        if let Some(tunnel) = tunnels.get(&map_key) {
+            log::debug!("Reusing existing K8s tunnel on port {}", tunnel.local_port);
+            let mut new_params = params.clone();
+            new_params.host = Some("127.0.0.1".to_string());
+            new_params.port = Some(tunnel.local_port);
+            return Ok(new_params);
+        }
+    }
+
+    log::info!(
+        "Creating new K8s tunnel for {}/{} in {}:{} (context: {})",
+        resource_type, resource_name, namespace, port, context
+    );
+
+    let tunnel = crate::k8s_tunnel::K8sTunnel::new(
+        context, namespace, resource_type, resource_name, port,
+    )
+    .map_err(|e| {
+        eprintln!("[Connection Error] K8s Tunnel setup failed: {}", e);
+        e
+    })?;
+
+    let local_port = tunnel.local_port;
+    log::info!("K8s tunnel created successfully on port {}", local_port);
+
+    {
+        let mut tunnels = crate::k8s_tunnel::get_tunnels().lock().unwrap();
+        tunnels.insert(map_key, tunnel);
+    }
+
+    let mut new_params = params.clone();
+    new_params.host = Some("127.0.0.1".to_string());
+    new_params.port = Some(local_port);
+    Ok(new_params)
+}
+
 pub fn resolve_connection_params(params: &ConnectionParams) -> Result<ConnectionParams, String> {
+    // K8s and SSH are mutually exclusive
+    if params.k8s_enabled.unwrap_or(false) && params.ssh_enabled.unwrap_or(false) {
+        return Err(
+            "Kubernetes and SSH tunnel cannot both be enabled for the same connection".to_string()
+        );
+    }
+
+    // Handle K8s tunnel
+    if params.k8s_enabled.unwrap_or(false) {
+        return resolve_k8s_params(params);
+    }
+
+    // Handle SSH tunnel (existing logic)
     if !params.ssh_enabled.unwrap_or(false) {
         return Ok(params.clone());
     }
@@ -1220,6 +1296,301 @@ pub async fn test_ssh_connection<R: Runtime>(
     )
 }
 
+// ---------------------------------------------------------------------------
+// Kubernetes Connections
+// ---------------------------------------------------------------------------
+
+/// Load K8s connections synchronously from the config file.
+fn load_k8s_connections_sync<R: Runtime>(
+    app: &AppHandle<R>,
+) -> Result<Vec<K8sConnection>, String> {
+    let path = get_k8s_config_path(app)?;
+    if !path.exists() {
+        return Ok(vec![]);
+    }
+    let content = fs::read_to_string(&path).map_err(|e| e.to_string())?;
+    Ok(serde_json::from_str(&content).unwrap_or_default())
+}
+
+/// Get the path to the k8s_connections.json file.
+fn get_k8s_config_path<R: Runtime>(app: &AppHandle<R>) -> Result<PathBuf, String> {
+    let config_dir = app
+        .path()
+        .app_config_dir()
+        .map_err(|e| format!("Failed to get config dir: {}", e))?;
+    Ok(config_dir.join("k8s_connections.json"))
+}
+
+#[tauri::command]
+pub async fn get_k8s_connections<R: Runtime>(
+    app: AppHandle<R>,
+) -> Result<Vec<K8sConnection>, String> {
+    let path = get_k8s_config_path(&app)?;
+    if !path.exists() {
+        return Ok(vec![]);
+    }
+    let content = fs::read_to_string(&path).map_err(|e| e.to_string())?;
+    let connections: Vec<K8sConnection> =
+        serde_json::from_str(&content).unwrap_or_default();
+    Ok(connections)
+}
+
+#[tauri::command]
+pub async fn save_k8s_connection<R: Runtime>(
+    app: AppHandle<R>,
+    k8s: K8sConnectionInput,
+) -> Result<K8sConnection, String> {
+    let path = get_k8s_config_path(&app)?;
+    let mut connections: Vec<K8sConnection> = if path.exists() {
+        let content = fs::read_to_string(&path).map_err(|e| e.to_string())?;
+        serde_json::from_str(&content).unwrap_or_default()
+    } else {
+        vec![]
+    };
+
+    let id = Uuid::new_v4().to_string();
+    let connection = K8sConnection {
+        id: id.clone(),
+        name: k8s.name,
+        context: k8s.context,
+        namespace: k8s.namespace,
+        resource_type: k8s.resource_type,
+        resource_name: k8s.resource_name,
+        port: k8s.port,
+    };
+
+    connections.push(connection.clone());
+    let json =
+        serde_json::to_string_pretty(&connections).map_err(|e| e.to_string())?;
+    fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    Ok(connection)
+}
+
+#[tauri::command]
+pub async fn update_k8s_connection<R: Runtime>(
+    app: AppHandle<R>,
+    id: String,
+    k8s: K8sConnectionInput,
+) -> Result<K8sConnection, String> {
+    let path = get_k8s_config_path(&app)?;
+    let mut connections: Vec<K8sConnection> = if path.exists() {
+        let content = fs::read_to_string(&path).map_err(|e| e.to_string())?;
+        serde_json::from_str(&content).unwrap_or_default()
+    } else {
+        return Err("No K8s connections file found".to_string());
+    };
+
+    let idx = connections
+        .iter()
+        .position(|c| c.id == id)
+        .ok_or_else(|| format!("K8s connection with ID {} not found", id))?;
+
+    let connection = K8sConnection {
+        id: id.clone(),
+        name: k8s.name,
+        context: k8s.context,
+        namespace: k8s.namespace,
+        resource_type: k8s.resource_type,
+        resource_name: k8s.resource_name,
+        port: k8s.port,
+    };
+
+    connections[idx] = connection.clone();
+    let json =
+        serde_json::to_string_pretty(&connections).map_err(|e| e.to_string())?;
+    fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    Ok(connection)
+}
+
+#[tauri::command]
+pub async fn delete_k8s_connection<R: Runtime>(
+    app: AppHandle<R>,
+    id: String,
+) -> Result<(), String> {
+    let path = get_k8s_config_path(&app)?;
+    let mut connections: Vec<K8sConnection> = if path.exists() {
+        let content = fs::read_to_string(&path).map_err(|e| e.to_string())?;
+        serde_json::from_str(&content).unwrap_or_default()
+    } else {
+        return Ok(());
+    };
+
+    connections.retain(|c| c.id != id);
+    let json =
+        serde_json::to_string_pretty(&connections).map_err(|e| e.to_string())?;
+    fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn test_k8s_connection_cmd<R: Runtime>(
+    _app: AppHandle<R>,
+    context: String,
+    namespace: String,
+) -> Result<String, String> {
+    crate::k8s_tunnel::test_k8s_connection(&context, &namespace)
+}
+
+#[tauri::command]
+pub async fn get_k8s_contexts_cmd<R: Runtime>(
+    _app: AppHandle<R>,
+) -> Result<Vec<String>, String> {
+    crate::k8s_tunnel::get_k8s_contexts()
+}
+
+#[tauri::command]
+pub async fn get_k8s_namespaces_cmd<R: Runtime>(
+    _app: AppHandle<R>,
+    context: String,
+) -> Result<Vec<String>, String> {
+    crate::k8s_tunnel::get_k8s_namespaces(&context)
+}
+
+#[tauri::command]
+pub async fn get_k8s_resources_cmd<R: Runtime>(
+    _app: AppHandle<R>,
+    context: String,
+    namespace: String,
+    resource_type: String,
+) -> Result<Vec<String>, String> {
+    crate::k8s_tunnel::get_k8s_resources(&context, &namespace, &resource_type)
+}
+
+/// Expand K8s connection params by loading saved config and creating/reusing a tunnel.
+pub async fn expand_k8s_connection_params<R: Runtime>(
+    app: &AppHandle<R>,
+    params: &ConnectionParams,
+) -> Result<ConnectionParams, String> {
+    if !params.k8s_enabled.unwrap_or(false) {
+        return Ok(params.clone());
+    }
+
+    // Mutual exclusion: K8s and SSH cannot both be active
+    if params.ssh_enabled.unwrap_or(false) {
+        return Err(
+            "Kubernetes and SSH tunnel cannot both be enabled for the same connection".to_string()
+        );
+    }
+
+    // Resolve K8s params from saved connection if using connection_id
+    let (context, namespace, resource_type, resource_name, port) =
+        if let Some(k8s_id) = &params.k8s_connection_id {
+            let k8s_conn = get_k8s_connection_by_id(app, k8s_id).await?;
+            (
+                k8s_conn.context,
+                k8s_conn.namespace,
+                k8s_conn.resource_type,
+                k8s_conn.resource_name,
+                k8s_conn.port,
+            )
+        } else {
+            let ctx = params
+                .k8s_context
+                .as_deref()
+                .ok_or("Missing K8s context")?
+                .to_string();
+            let ns = params
+                .k8s_namespace
+                .as_deref()
+                .ok_or("Missing K8s namespace")?
+                .to_string();
+            let rt = params
+                .k8s_resource_type
+                .as_deref()
+                .ok_or("Missing K8s resource type")?
+                .to_string();
+            let rn = params
+                .k8s_resource_name
+                .as_deref()
+                .ok_or("Missing K8s resource name")?
+                .to_string();
+            let p = params.k8s_port.ok_or("Missing K8s port")?;
+            (ctx, ns, rt, rn, p)
+        };
+
+    let _remote_host = params.host.as_deref().unwrap_or("localhost");
+    let _remote_port = params.port.unwrap_or(DEFAULT_MYSQL_PORT);
+
+    let map_key = crate::k8s_tunnel::build_tunnel_key(
+        &context,
+        &namespace,
+        &resource_type,
+        &resource_name,
+        port,
+    );
+
+    // Check for existing tunnel
+    {
+        let tunnels = crate::k8s_tunnel::get_tunnels().lock().unwrap();
+        if let Some(tunnel) = tunnels.get(&map_key) {
+            log::debug!(
+                "Reusing existing K8s tunnel on port {}",
+                tunnel.local_port
+            );
+            let mut new_params = params.clone();
+            new_params.host = Some("127.0.0.1".to_string());
+            new_params.port = Some(tunnel.local_port);
+            return Ok(new_params);
+        }
+    }
+
+    // Create new tunnel
+    log::info!(
+        "Creating new K8s tunnel for {}/{} in {}:{} (context: {})",
+        resource_type,
+        resource_name,
+        namespace,
+        port,
+        context
+    );
+
+    let tunnel = crate::k8s_tunnel::K8sTunnel::new(
+        &context,
+        &namespace,
+        &resource_type,
+        &resource_name,
+        port,
+    )
+    .map_err(|e| {
+        eprintln!("[Connection Error] K8s Tunnel setup failed: {}", e);
+        e
+    })?;
+
+    let local_port = tunnel.local_port;
+    log::info!("K8s tunnel created successfully on port {}", local_port);
+
+    {
+        let mut tunnels = crate::k8s_tunnel::get_tunnels().lock().unwrap();
+        tunnels.insert(map_key, tunnel);
+    }
+
+    let mut new_params = params.clone();
+    new_params.host = Some("127.0.0.1".to_string());
+    new_params.port = Some(local_port);
+    Ok(new_params)
+}
+
+/// Load a K8s connection by ID from the config file.
+async fn get_k8s_connection_by_id<R: Runtime>(
+    app: &AppHandle<R>,
+    k8s_id: &str,
+) -> Result<K8sConnection, String> {
+    let path = get_k8s_config_path(app)?;
+    if !path.exists() {
+        return Err(format!("K8s connection with ID {} not found", k8s_id));
+    }
+    let content = fs::read_to_string(&path).map_err(|e| e.to_string())?;
+    let connections: Vec<K8sConnection> =
+        serde_json::from_str(&content).unwrap_or_default();
+    connections
+        .into_iter()
+        .find(|c| c.id == k8s_id)
+        .ok_or_else(|| format!("K8s connection with ID {} not found", k8s_id))
+}
+
 #[tauri::command]
 pub async fn test_connection<R: Runtime>(
     app: AppHandle<R>,
@@ -1231,6 +1602,7 @@ pub async fn test_connection<R: Runtime>(
     );
 
     let mut expanded_params = expand_ssh_connection_params(&app, &request.params).await?;
+    expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
 
     if request.params.password.is_none() && expanded_params.password.is_none() {
         let saved_conn = match &request.connection_id {
@@ -1287,22 +1659,8 @@ mod tests {
             host: Some("localhost".to_string()),
             port: Some(3306),
             username: Some("root".to_string()),
-            password: None,
             database: DatabaseSelection::Single("testdb".to_string()),
-            ssl_mode: None,
-            ssl_ca: None,
-            ssl_cert: None,
-            ssl_key: None,
-            ssh_enabled: None,
-            ssh_connection_id: None,
-            ssh_host: None,
-            ssh_port: None,
-            ssh_user: None,
-            ssh_password: None,
-            ssh_key_file: None,
-            ssh_key_passphrase: None,
-            save_in_keychain: None,
-            connection_id: None,
+            ..Default::default()
         }
     }
 
@@ -1374,20 +1732,7 @@ mod tests {
                 username: Some(username.to_string()),
                 password: password.map(|p| p.to_string()),
                 database: DatabaseSelection::Single(database.to_string()),
-                ssl_mode: None,
-                ssl_ca: None,
-                ssl_cert: None,
-                ssl_key: None,
-                ssh_enabled: None,
-                ssh_connection_id: None,
-                ssh_host: None,
-                ssh_port: None,
-                ssh_user: None,
-                ssh_password: None,
-                ssh_key_file: None,
-                ssh_key_passphrase: None,
-                save_in_keychain: None,
-                connection_id: None,
+                ..Default::default()
             }
         }
 
@@ -1655,20 +2000,12 @@ mod tests {
                 username: Some("dbuser".to_string()),
                 password: Some("dbpass".to_string()),
                 database: DatabaseSelection::Single("testdb".to_string()),
-                ssl_mode: None,
-                ssl_ca: None,
-                ssl_cert: None,
-                ssl_key: None,
                 ssh_enabled: Some(true),
-                ssh_connection_id: None,
                 ssh_host: Some(ssh_host.to_string()),
                 ssh_port: Some(ssh_port),
                 ssh_user: Some(ssh_user.to_string()),
-                ssh_password: None,
                 ssh_key_file: Some("/home/user/.ssh/id_rsa".to_string()),
-                ssh_key_passphrase: None,
-                save_in_keychain: None,
-                connection_id: None,
+                ..Default::default()
             }
         }
 
@@ -1696,6 +2033,88 @@ mod tests {
             let result = resolve_connection_params(&params);
             assert!(result.is_err());
             assert!(result.unwrap_err().contains("SSH User"));
+        }
+    }
+
+    mod resolve_k8s_params_tests {
+        use super::*;
+
+        fn create_k8s_params(
+            context: &str,
+            namespace: &str,
+            resource_type: &str,
+            resource_name: &str,
+            port: u16,
+        ) -> ConnectionParams {
+            ConnectionParams {
+                driver: "mysql".to_string(),
+                host: Some("localhost".to_string()),
+                port: Some(3306),
+                username: Some("root".to_string()),
+                database: DatabaseSelection::Single("testdb".to_string()),
+                k8s_enabled: Some(true),
+                k8s_context: Some(context.to_string()),
+                k8s_namespace: Some(namespace.to_string()),
+                k8s_resource_type: Some(resource_type.to_string()),
+                k8s_resource_name: Some(resource_name.to_string()),
+                k8s_port: Some(port),
+                ..Default::default()
+            }
+        }
+
+        #[test]
+        fn test_k8s_and_ssh_mutual_exclusion() {
+            let mut params = create_k8s_params("my-ctx", "default", "service", "my-db", 3306);
+            params.ssh_enabled = Some(true);
+            params.ssh_host = Some("jump.host".to_string());
+            let result = resolve_connection_params(&params);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains("cannot both be enabled"));
+        }
+
+        #[test]
+        fn test_k8s_requires_context() {
+            let mut params = create_k8s_params("my-ctx", "default", "service", "my-db", 3306);
+            params.k8s_context = None;
+            let result = resolve_k8s_params(&params);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains("K8s context"));
+        }
+
+        #[test]
+        fn test_k8s_requires_namespace() {
+            let mut params = create_k8s_params("my-ctx", "default", "service", "my-db", 3306);
+            params.k8s_namespace = None;
+            let result = resolve_k8s_params(&params);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains("K8s namespace"));
+        }
+
+        #[test]
+        fn test_k8s_requires_resource_type() {
+            let mut params = create_k8s_params("my-ctx", "default", "service", "my-db", 3306);
+            params.k8s_resource_type = None;
+            let result = resolve_k8s_params(&params);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains("K8s resource type"));
+        }
+
+        #[test]
+        fn test_k8s_requires_resource_name() {
+            let mut params = create_k8s_params("my-ctx", "default", "service", "my-db", 3306);
+            params.k8s_resource_name = None;
+            let result = resolve_k8s_params(&params);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains("K8s resource name"));
+        }
+
+        #[test]
+        fn test_k8s_requires_port() {
+            let mut params = create_k8s_params("my-ctx", "default", "service", "my-db", 3306);
+            params.k8s_port = None;
+            let result = resolve_k8s_params(&params);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains("K8s port"));
         }
     }
 
@@ -3568,6 +3987,7 @@ pub async fn export_connections_payload<R: Runtime>(
         groups: conn_file.groups,
         connections: conn_file.connections,
         ssh_connections,
+        k8s_connections: load_k8s_connections_sync(&app)?,
     })
 }
 
@@ -3667,6 +4087,19 @@ pub async fn import_connections_payload<R: Runtime>(
     save_connections_and_invalidate(&app, &conn_path, &current_file)?;
     let ssh_json = serde_json::to_string_pretty(&current_ssh).map_err(|e| e.to_string())?;
     fs::write(ssh_path, ssh_json).map_err(|e| e.to_string())?;
+
+    // Merge K8s connections
+    let k8s_path = get_k8s_config_path(&app)?;
+    let mut current_k8s = load_k8s_connections_sync(&app)?;
+    for new_k8s in payload.k8s_connections {
+        if let Some(existing) = current_k8s.iter_mut().find(|k| k.id == new_k8s.id) {
+            *existing = new_k8s;
+        } else {
+            current_k8s.push(new_k8s);
+        }
+    }
+    let k8s_json = serde_json::to_string_pretty(&current_k8s).map_err(|e| e.to_string())?;
+    fs::write(k8s_path, k8s_json).map_err(|e| e.to_string())?;
 
     Ok(())
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -469,6 +469,7 @@ pub async fn get_schemas<R: Runtime>(
 
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
     let drv = driver_for(&saved_conn.params.driver).await?;
@@ -487,6 +488,7 @@ pub async fn get_available_databases<R: Runtime>(
 
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
     let drv = driver_for(&saved_conn.params.driver).await?;
@@ -503,6 +505,7 @@ pub async fn get_routines<R: Runtime>(
 
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
     let drv = driver_for(&saved_conn.params.driver).await?;
@@ -524,6 +527,7 @@ pub async fn get_routine_parameters<R: Runtime>(
 
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
     let drv = driver_for(&saved_conn.params.driver).await?;
@@ -548,6 +552,7 @@ pub async fn get_routine_definition<R: Runtime>(
 
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
     let drv = driver_for(&saved_conn.params.driver).await?;
@@ -563,6 +568,7 @@ pub async fn get_schema_snapshot<R: Runtime>(
 ) -> Result<Vec<crate::models::TableSchema>, String> {
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
     let drv = driver_for(&saved_conn.params.driver).await?;
     drv.get_schema_snapshot(&params, schema.as_deref()).await
@@ -2365,6 +2371,7 @@ pub async fn list_databases<R: Runtime>(
     request: TestConnectionRequest,
 ) -> Result<Vec<String>, String> {
     let mut expanded_params = expand_ssh_connection_params(&app, &request.params).await?;
+    expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
 
     if request.params.password.is_none() && expanded_params.password.is_none() {
         let saved_conn = match &request.connection_id {
@@ -2405,6 +2412,7 @@ pub async fn get_tables<R: Runtime>(
 
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
     log::debug!(
@@ -2433,6 +2441,7 @@ pub async fn get_columns<R: Runtime>(
 ) -> Result<Vec<TableColumn>, String> {
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
     let drv = driver_for(&saved_conn.params.driver).await?;
     drv.get_columns(&params, &table_name, schema.as_deref())
@@ -2448,6 +2457,7 @@ pub async fn get_foreign_keys<R: Runtime>(
 ) -> Result<Vec<ForeignKey>, String> {
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
     let drv = driver_for(&saved_conn.params.driver).await?;
     drv.get_foreign_keys(&params, &table_name, schema.as_deref())
@@ -2463,6 +2473,7 @@ pub async fn get_indexes<R: Runtime>(
 ) -> Result<Vec<Index>, String> {
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
     let drv = driver_for(&saved_conn.params.driver).await?;
     drv.get_indexes(&params, &table_name, schema.as_deref())
@@ -2488,6 +2499,7 @@ pub async fn delete_record<R: Runtime>(
     );
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let mut params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
     if let Some(db) = database {
         params.database = crate::models::DatabaseSelection::Single(db);
@@ -2520,6 +2532,7 @@ pub async fn update_record<R: Runtime>(
     );
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let mut params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
     if let Some(db) = database {
         params.database = crate::models::DatabaseSelection::Single(db);
@@ -2552,6 +2565,7 @@ pub async fn save_blob_to_file<R: Runtime>(
 ) -> Result<(), String> {
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
     let drv = driver_for(&saved_conn.params.driver).await?;
     drv.save_blob_to_file(
@@ -2580,6 +2594,7 @@ pub async fn fetch_blob_as_data_url<R: Runtime>(
 ) -> Result<String, String> {
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
     let drv = driver_for(&saved_conn.params.driver).await?;
     let wire = drv
@@ -2775,6 +2790,7 @@ pub async fn insert_record<R: Runtime>(
     );
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let mut params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
     if let Some(db) = database {
         params.database = crate::models::DatabaseSelection::Single(db);
@@ -2830,6 +2846,7 @@ pub async fn execute_query<R: Runtime>(
 
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
     let drv = driver_for(&saved_conn.params.driver).await?;
@@ -2898,6 +2915,7 @@ pub async fn execute_query_batch<R: Runtime>(
 
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
     let drv = driver_for(&saved_conn.params.driver).await?;
@@ -2970,6 +2988,7 @@ pub async fn explain_query_plan<R: Runtime>(
 
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
     let drv = driver_for(&saved_conn.params.driver).await?;
@@ -3012,6 +3031,7 @@ pub async fn count_query<R: Runtime>(
 ) -> Result<u64, String> {
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
     let sanitized = query.trim().trim_end_matches(';').to_string();
@@ -3255,6 +3275,7 @@ pub async fn get_views<R: Runtime>(
 
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
     log::debug!(
@@ -3289,6 +3310,7 @@ pub async fn get_view_definition<R: Runtime>(
 
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
     let drv = driver_for(&saved_conn.params.driver).await?;
@@ -3320,6 +3342,7 @@ pub async fn create_view<R: Runtime>(
 
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
     let drv = driver_for(&saved_conn.params.driver).await?;
@@ -3351,6 +3374,7 @@ pub async fn alter_view<R: Runtime>(
 
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
     let drv = driver_for(&saved_conn.params.driver).await?;
@@ -3381,6 +3405,7 @@ pub async fn drop_view<R: Runtime>(
 
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
     let drv = driver_for(&saved_conn.params.driver).await?;
@@ -3409,6 +3434,7 @@ pub async fn get_view_columns<R: Runtime>(
 
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
     let drv = driver_for(&saved_conn.params.driver).await?;
@@ -3434,6 +3460,7 @@ pub async fn get_triggers<R: Runtime>(
 
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
     let drv = driver_for(&saved_conn.params.driver).await?;
@@ -3463,6 +3490,7 @@ pub async fn get_trigger_definition<R: Runtime>(
 
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
     let drv = driver_for(&saved_conn.params.driver).await?;
@@ -3481,6 +3509,7 @@ pub async fn create_trigger<R: Runtime>(
 
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
     let drv = driver_for(&saved_conn.params.driver).await?;
@@ -3512,6 +3541,7 @@ pub async fn drop_trigger<R: Runtime>(
 
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
     let drv = driver_for(&saved_conn.params.driver).await?;
@@ -3546,6 +3576,7 @@ pub async fn disconnect_connection<R: Runtime>(
 
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
     // Close the connection pool
@@ -3680,6 +3711,7 @@ pub async fn drop_index_action<R: Runtime>(
 ) -> Result<(), String> {
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
     let drv = driver_for(&saved_conn.params.driver).await?;
     drv.drop_index(&params, &table, &index_name, schema.as_deref())
@@ -3696,6 +3728,7 @@ pub async fn drop_foreign_key_action<R: Runtime>(
 ) -> Result<(), String> {
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
     let drv = driver_for(&saved_conn.params.driver).await?;
     drv.drop_foreign_key(&params, &table, &fk_name, schema.as_deref())
@@ -3909,6 +3942,7 @@ pub async fn get_server_now<R: Runtime>(
 ) -> Result<String, String> {
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
     let query = match saved_conn.params.driver.as_str() {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -249,6 +249,7 @@ fn resolve_k8s_params(params: &ConnectionParams) -> Result<ConnectionParams, Str
         if let Some(tunnel) = tunnels.get(&map_key) {
             log::debug!("Reusing existing K8s tunnel on port {}", tunnel.local_port);
             let mut new_params = params.clone();
+            new_params.k8s_enabled = Some(false);
             new_params.host = Some("127.0.0.1".to_string());
             new_params.port = Some(tunnel.local_port);
             return Ok(new_params);
@@ -277,6 +278,7 @@ fn resolve_k8s_params(params: &ConnectionParams) -> Result<ConnectionParams, Str
     }
 
     let mut new_params = params.clone();
+    new_params.k8s_enabled = Some(false);
     new_params.host = Some("127.0.0.1".to_string());
     new_params.port = Some(local_port);
     Ok(new_params)
@@ -1324,6 +1326,9 @@ fn get_k8s_config_path<R: Runtime>(app: &AppHandle<R>) -> Result<PathBuf, String
         .path()
         .app_config_dir()
         .map_err(|e| format!("Failed to get config dir: {}", e))?;
+    if !config_dir.exists() {
+        fs::create_dir_all(&config_dir).map_err(|e| e.to_string())?;
+    }
     Ok(config_dir.join("k8s_connections.json"))
 }
 
@@ -1537,6 +1542,7 @@ pub async fn expand_k8s_connection_params<R: Runtime>(
                 tunnel.local_port
             );
             let mut new_params = params.clone();
+            new_params.k8s_enabled = Some(false);
             new_params.host = Some("127.0.0.1".to_string());
             new_params.port = Some(tunnel.local_port);
             return Ok(new_params);
@@ -1574,6 +1580,7 @@ pub async fn expand_k8s_connection_params<R: Runtime>(
     }
 
     let mut new_params = params.clone();
+    new_params.k8s_enabled = Some(false);
     new_params.host = Some("127.0.0.1".to_string());
     new_params.port = Some(local_port);
     Ok(new_params)

--- a/src-tauri/src/drivers/sqlite/tests.rs
+++ b/src-tauri/src/drivers/sqlite/tests.rs
@@ -15,24 +15,7 @@ async fn setup_test_db() -> (ConnectionParams, NamedTempFile) {
     let params = ConnectionParams {
         driver: "sqlite".to_string(),
         database: DatabaseSelection::Single(path.clone()),
-        host: None,
-        port: None,
-        username: None,
-        password: None,
-        ssl_mode: None,
-        ssl_ca: None,
-        ssl_cert: None,
-        ssl_key: None,
-        ssh_enabled: None,
-        ssh_connection_id: None,
-        ssh_host: None,
-        ssh_port: None,
-        ssh_user: None,
-        ssh_password: None,
-        ssh_key_file: None,
-        ssh_key_passphrase: None,
-        save_in_keychain: None,
-        connection_id: None,
+        ..Default::default()
     };
 
     // Initialize DB with a table

--- a/src-tauri/src/dump_commands.rs
+++ b/src-tauri/src/dump_commands.rs
@@ -1,6 +1,7 @@
 use crate::commands::{
-    expand_ssh_connection_params, find_connection_by_id, register_abort_handle,
-    resolve_connection_params_with_id, unregister_abort_handle, AbortHandleMap,
+    expand_k8s_connection_params, expand_ssh_connection_params, find_connection_by_id,
+    register_abort_handle, resolve_connection_params_with_id, unregister_abort_handle,
+    AbortHandleMap,
 };
 use crate::drivers::{mysql, postgres, sqlite};
 use crate::dump_utils::{drop_table_if_exists, format_table_ref, insert_into_statement};
@@ -63,6 +64,7 @@ pub async fn dump_database<R: Runtime>(
 ) -> Result<(), String> {
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
     let driver = saved_conn.params.driver.clone();
     let schema = schema.unwrap_or_else(|| "public".to_string());
@@ -436,6 +438,7 @@ pub async fn import_database<R: Runtime>(
 ) -> Result<(), String> {
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
     let driver = saved_conn.params.driver.clone();
     let pg_schema = schema.unwrap_or_else(|| "public".to_string());

--- a/src-tauri/src/export.rs
+++ b/src-tauri/src/export.rs
@@ -19,8 +19,9 @@ use serde_json::Value;
 use tauri::{AppHandle, Emitter, Runtime, State};
 
 use crate::commands::{
-    expand_ssh_connection_params, find_connection_by_id, register_abort_handle,
-    resolve_connection_params_with_id, unregister_abort_handle, AbortHandleMap,
+    expand_k8s_connection_params, expand_ssh_connection_params, find_connection_by_id,
+    register_abort_handle, resolve_connection_params_with_id, unregister_abort_handle,
+    AbortHandleMap,
 };
 use crate::drivers::{mysql, postgres, sqlite};
 use crate::models::ConnectionParams;
@@ -76,6 +77,7 @@ pub async fn export_query_to_file<R: Runtime>(
     let sanitized_query = sanitize_query(&query);
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
     let driver = saved_conn.params.driver.clone();
 

--- a/src-tauri/src/export_import_tests.rs
+++ b/src-tauri/src/export_import_tests.rs
@@ -22,20 +22,9 @@ mod tests {
                     username: Some("root".to_string()),
                     password: Some("password".to_string()),
                     database: DatabaseSelection::Single("test".to_string()),
-                    ssl_mode: None,
-                    ssl_ca: None,
-                    ssl_cert: None,
-                    ssl_key: None,
                     ssh_enabled: Some(false),
-                    ssh_connection_id: None,
-                    ssh_host: None,
-                    ssh_port: None,
-                    ssh_user: None,
-                    ssh_password: None,
-                    ssh_key_file: None,
-                    ssh_key_passphrase: None,
                     save_in_keychain: Some(true),
-                    connection_id: None,
+                    ..Default::default()
                 },
                 group_id: Some("group1".to_string()),
                 sort_order: Some(0),
@@ -53,6 +42,7 @@ mod tests {
                 key_passphrase: None,
                 save_in_keychain: Some(true),
             }],
+            k8s_connections: vec![],
         };
 
         let json = serde_json::to_string(&payload).unwrap();

--- a/src-tauri/src/health_check.rs
+++ b/src-tauri/src/health_check.rs
@@ -142,6 +142,8 @@ async fn ping_single_connection(app: &tauri::AppHandle, connection_id: &str) -> 
 
     let expanded_params =
         crate::commands::expand_ssh_connection_params(app, &saved_conn.params).await?;
+    let expanded_params =
+        crate::commands::expand_k8s_connection_params(app, &expanded_params).await?;
     let params =
         crate::commands::resolve_connection_params_with_id(&expanded_params, connection_id)?;
 
@@ -171,9 +173,10 @@ async fn handle_connection_failure(app: &tauri::AppHandle, connection_id: &str, 
         if let Ok(expanded) =
             crate::commands::expand_ssh_connection_params(app, &saved_conn.params).await
         {
-            if let Ok(params) =
-                crate::commands::resolve_connection_params_with_id(&expanded, connection_id)
-            {
+            let expanded = crate::commands::expand_k8s_connection_params(app, &expanded).await;
+            if let Ok(params) = expanded.and_then(|params| {
+                crate::commands::resolve_connection_params_with_id(&params, connection_id)
+            }) {
                 crate::pool_manager::close_pool_with_id(&params, Some(connection_id)).await;
             }
         }

--- a/src-tauri/src/k8s_tunnel.rs
+++ b/src-tauri/src/k8s_tunnel.rs
@@ -1,0 +1,504 @@
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader};
+use std::net::{TcpListener, TcpStream};
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+// Constants for timeouts and configuration
+const K8S_TUNNEL_TIMEOUT_SECS: u64 = 15;
+const K8S_CONNECT_RETRY_MS: u64 = 200;
+const LOG_BUFFER_INITIAL_CAPACITY: usize = 64;
+
+#[derive(Clone)]
+pub struct K8sTunnel {
+    pub local_port: u16,
+    child: Arc<Mutex<Child>>,
+}
+
+pub static TUNNELS: OnceLock<Mutex<HashMap<String, K8sTunnel>>> = OnceLock::new();
+
+pub fn get_tunnels() -> &'static Mutex<HashMap<String, K8sTunnel>> {
+    TUNNELS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+impl K8sTunnel {
+    /// Create a new kubectl port-forward tunnel.
+    ///
+    /// Spawns `kubectl port-forward --context <ctx> -n <ns> <res_type>/<res_name> <local_port>:<remote_port>`
+    /// and waits for the local port to become connectable.
+    pub fn new(
+        context: &str,
+        namespace: &str,
+        resource_type: &str,
+        resource_name: &str,
+        remote_port: u16,
+    ) -> Result<Self, String> {
+        println!(
+            "[K8s Tunnel] New request: context={}, namespace={}, {}/{}:{}",
+            context, namespace, resource_type, resource_name, remote_port
+        );
+
+        // Verify kubectl is available
+        Self::verify_kubectl()?;
+
+        // Allocate a free local port
+        let local_port = {
+            let listener = TcpListener::bind("127.0.0.1:0").map_err(|e| {
+                let err = format!("Failed to find free local port: {}", e);
+                eprintln!("[K8s Tunnel Error] {}", err);
+                err
+            })?;
+            listener.local_addr().unwrap().port()
+        };
+        println!("[K8s Tunnel] Assigned local port: {}", local_port);
+
+        // Build the kubectl port-forward command
+        let port_forward_spec = format!("{}:{}", local_port, remote_port);
+        let resource = format!("{}/{}", resource_type, resource_name);
+
+        let mut args = Vec::with_capacity(10);
+        args.extend([
+            "port-forward",
+            "--context",
+            context,
+            "--namespace",
+            namespace,
+            &resource,
+            &port_forward_spec,
+        ]);
+
+        println!("[K8s Tunnel] Executing: kubectl {:?}", args);
+
+        let mut child = Command::new("kubectl")
+            .args(&args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| {
+                let err = format!(
+                    "Failed to launch kubectl: {}. Ensure 'kubectl' is in PATH.",
+                    e
+                );
+                eprintln!("[K8s Tunnel Error] {}", err);
+                err
+            })?;
+
+        // Capture stdout/stderr in background threads
+        let stdout_log = Arc::new(Mutex::new(Vec::with_capacity(LOG_BUFFER_INITIAL_CAPACITY)));
+        let stderr_log = Arc::new(Mutex::new(Vec::with_capacity(LOG_BUFFER_INITIAL_CAPACITY)));
+
+        if let Some(stdout) = child.stdout.take() {
+            let log = stdout_log.clone();
+            thread::spawn(move || {
+                let reader = BufReader::new(stdout);
+                for line in reader.lines() {
+                    if let Ok(l) = line {
+                        #[cfg(debug_assertions)]
+                        println!("[K8s kubectl Out] {}", l);
+                        if let Ok(mut g) = log.lock() {
+                            g.push(l);
+                        }
+                    }
+                }
+            });
+        }
+
+        if let Some(stderr) = child.stderr.take() {
+            let log = stderr_log.clone();
+            thread::spawn(move || {
+                let reader = BufReader::new(stderr);
+                for line in reader.lines() {
+                    if let Ok(l) = line {
+                        #[cfg(debug_assertions)]
+                        eprintln!("[K8s kubectl Err] {}", l);
+                        if let Ok(mut g) = log.lock() {
+                            g.push(l);
+                        }
+                    }
+                }
+            });
+        }
+
+        let child_arc = Arc::new(Mutex::new(child));
+
+        // Wait for the tunnel to become ready
+        let start = Instant::now();
+        let timeout = Duration::from_secs(K8S_TUNNEL_TIMEOUT_SECS);
+        let mut ready = false;
+
+        while start.elapsed() < timeout {
+            // Check if process is still alive
+            {
+                let mut c = child_arc.lock().unwrap();
+                if let Ok(Some(status)) = c.try_wait() {
+                    let stdout_content = stdout_log.lock().unwrap().join("\n");
+                    let stderr_content = stderr_log.lock().unwrap().join("\n");
+                    let err_msg = format!(
+                        "kubectl port-forward exited prematurely with status: {}.\nStderr: {}\nStdout: {}",
+                        status, stderr_content, stdout_content
+                    );
+                    eprintln!("[K8s Tunnel Error] {}", err_msg);
+                    return Err(err_msg);
+                }
+            }
+
+            // Try connecting to the local port
+            match TcpStream::connect(format!("127.0.0.1:{}", local_port)) {
+                Ok(_) => {
+                    println!(
+                        "[K8s Tunnel] Tunnel established successfully on port {}",
+                        local_port
+                    );
+                    ready = true;
+                    break;
+                }
+                Err(_) => {
+                    thread::sleep(Duration::from_millis(K8S_CONNECT_RETRY_MS));
+                }
+            }
+        }
+
+        if !ready {
+            if let Ok(mut c) = child_arc.lock() {
+                let _ = c.kill();
+            }
+            let err = format!(
+                "Timed out waiting for kubectl port-forward to establish ({}s)",
+                K8S_TUNNEL_TIMEOUT_SECS
+            );
+            eprintln!("[K8s Tunnel Error] {}", err);
+            return Err(err);
+        }
+
+        Ok(Self {
+            local_port,
+            child: child_arc,
+        })
+    }
+
+    /// Stop the tunnel by killing the kubectl child process.
+    pub fn stop(&self) {
+        if let Ok(mut c) = self.child.lock() {
+            let _ = c.kill();
+            println!(
+                "[K8s Tunnel] Stopped tunnel on port {}",
+                self.local_port
+            );
+        }
+    }
+
+    /// Check that kubectl is available in PATH.
+    fn verify_kubectl() -> Result<(), String> {
+        let output = Command::new("kubectl")
+            .arg("version")
+            .arg("--client")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .map_err(|e| {
+                format!(
+                    "kubectl not found: {}. Please install kubectl and ensure it is in PATH.",
+                    e
+                )
+            })?;
+
+        if !output.status.success() {
+            return Err("kubectl version check failed. Please verify your kubectl installation.".to_string());
+        }
+
+        Ok(())
+    }
+}
+
+/// Build a deterministic tunnel map key from K8s parameters.
+#[inline]
+pub fn build_tunnel_key(
+    context: &str,
+    namespace: &str,
+    resource_type: &str,
+    resource_name: &str,
+    port: u16,
+) -> String {
+    format!(
+        "{}:{}:{}/{}:{}",
+        context, namespace, resource_type, resource_name, port
+    )
+}
+
+/// Test a K8s connection by verifying context and namespace reachability.
+pub fn test_k8s_connection(
+    context: &str,
+    namespace: &str,
+) -> Result<String, String> {
+    println!(
+        "[K8s Test] Testing connection: context={}, namespace={}",
+        context, namespace
+    );
+
+    K8sTunnel::verify_kubectl()?;
+
+    let output = Command::new("kubectl")
+        .args(["--context", context, "get", "namespace", namespace, "-o", "name"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("Failed to execute kubectl: {}", e))?;
+
+    if output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        println!("[K8s Test] Connection successful: {}", stdout);
+        Ok(format!(
+            "Kubernetes connection to context '{}' namespace '{}' verified successfully!",
+            context, namespace
+        ))
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let err = format!("K8s connection test failed: {}", stderr.trim());
+        eprintln!("[K8s Test Error] {}", err);
+        Err(err)
+    }
+}
+
+/// List available kubectl contexts from kubeconfig.
+pub fn get_k8s_contexts() -> Result<Vec<String>, String> {
+    let output = Command::new("kubectl")
+        .args(["config", "get-contexts", "-o", "name"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("Failed to execute kubectl: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Failed to list K8s contexts: {}", stderr.trim()));
+    }
+
+    let contexts = parse_lines(&String::from_utf8_lossy(&output.stdout));
+    println!("[K8s Discovery] Found {} contexts", contexts.len());
+    Ok(contexts)
+}
+
+/// List namespaces in a given kubectl context.
+pub fn get_k8s_namespaces(context: &str) -> Result<Vec<String>, String> {
+    let output = Command::new("kubectl")
+        .args([
+            "--context",
+            context,
+            "get",
+            "namespaces",
+            "-o",
+            "name",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("Failed to execute kubectl: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "Failed to list namespaces in context '{}': {}",
+            context,
+            stderr.trim()
+        ));
+    }
+
+    let namespaces = parse_lines_with_prefix(&String::from_utf8_lossy(&output.stdout), "namespace/");
+    println!(
+        "[K8s Discovery] Found {} namespaces in context '{}'",
+        namespaces.len(),
+        context
+    );
+    Ok(namespaces)
+}
+
+/// List resources (services or pods) in a given context and namespace.
+pub fn get_k8s_resources(
+    context: &str,
+    namespace: &str,
+    resource_type: &str,
+) -> Result<Vec<String>, String> {
+    // Validate resource type
+    if resource_type != "service" && resource_type != "pod" {
+        return Err(format!(
+            "Unsupported resource type '{}'. Only 'service' and 'pod' are supported.",
+            resource_type
+        ));
+    }
+
+    let output = Command::new("kubectl")
+        .args([
+            "--context",
+            context,
+            "--namespace",
+            namespace,
+            "get",
+            resource_type,
+            "-o",
+            "name",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("Failed to execute kubectl: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "Failed to list {} in context '{}' namespace '{}': {}",
+            resource_type,
+            context,
+            namespace,
+            stderr.trim()
+        ));
+    }
+
+    let prefix = format!("{}/", resource_type);
+    let resources = parse_lines_with_prefix(&String::from_utf8_lossy(&output.stdout), &prefix);
+    println!(
+        "[K8s Discovery] Found {} {} in context '{}' namespace '{}'",
+        resources.len(),
+        resource_type,
+        context,
+        namespace
+    );
+    Ok(resources)
+}
+
+/// Parse newline-separated output into a list of trimmed, non-empty strings.
+fn parse_lines(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty())
+        .map(String::from)
+        .collect()
+}
+
+/// Parse newline-separated output, stripping a prefix from each line.
+fn parse_lines_with_prefix(output: &str, prefix: &str) -> Vec<String> {
+    output
+        .lines()
+        .map(|l| l.trim().strip_prefix(prefix).unwrap_or(l.trim()))
+        .filter(|l| !l.is_empty())
+        .map(String::from)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod build_tunnel_key_tests {
+        use super::*;
+
+        #[test]
+        fn test_basic_key_format() {
+            let key = build_tunnel_key(
+                "my-cluster",
+                "default",
+                "service",
+                "my-db",
+                3306,
+            );
+            assert_eq!(key, "my-cluster:default:service/my-db:3306");
+        }
+
+        #[test]
+        fn test_pod_resource_type() {
+            let key = build_tunnel_key(
+                "prod-cluster",
+                "database",
+                "pod",
+                "mysql-0",
+                5432,
+            );
+            assert_eq!(key, "prod-cluster:database:pod/mysql-0:5432");
+        }
+
+        #[test]
+        fn test_empty_context() {
+            let key = build_tunnel_key("", "default", "service", "db", 80);
+            assert_eq!(key, ":default:service/db:80");
+        }
+
+        #[test]
+        fn test_special_characters() {
+            let key = build_tunnel_key(
+                "gke_project_us-central1_cluster",
+                "my-namespace",
+                "service",
+                "my-db-svc",
+                3306,
+            );
+            assert_eq!(
+                key,
+                "gke_project_us-central1_cluster:my-namespace:service/my-db-svc:3306"
+            );
+        }
+    }
+
+    mod parse_lines_tests {
+        use super::*;
+
+        #[test]
+        fn test_basic_lines() {
+            let output = "line1\nline2\nline3\n";
+            let result = parse_lines(output);
+            assert_eq!(result, vec!["line1", "line2", "line3"]);
+        }
+
+        #[test]
+        fn test_empty_output() {
+            let result = parse_lines("");
+            assert!(result.is_empty());
+        }
+
+        #[test]
+        fn test_whitespace_handling() {
+            let output = "  line1  \n\n  line2  \n";
+            let result = parse_lines(output);
+            assert_eq!(result, vec!["line1", "line2"]);
+        }
+    }
+
+    mod parse_lines_with_prefix_tests {
+        use super::*;
+
+        #[test]
+        fn test_namespace_prefix() {
+            let output = "namespace/default\nnamespace/kube-system\nnamespace/my-ns\n";
+            let result = parse_lines_with_prefix(output, "namespace/");
+            assert_eq!(result, vec!["default", "kube-system", "my-ns"]);
+        }
+
+        #[test]
+        fn test_service_prefix() {
+            let output = "service/my-db\nservice/api-gateway\n";
+            let result = parse_lines_with_prefix(output, "service/");
+            assert_eq!(result, vec!["my-db", "api-gateway"]);
+        }
+
+        #[test]
+        fn test_pod_prefix() {
+            let output = "pod/mysql-0\npod/mysql-1\n";
+            let result = parse_lines_with_prefix(output, "pod/");
+            assert_eq!(result, vec!["mysql-0", "mysql-1"]);
+        }
+
+        #[test]
+        fn test_no_match_returns_full_line() {
+            let output = "something/else\n";
+            let result = parse_lines_with_prefix(output, "namespace/");
+            assert_eq!(result, vec!["something/else"]);
+        }
+
+        #[test]
+        fn test_empty_output() {
+            let result = parse_lines_with_prefix("", "namespace/");
+            assert!(result.is_empty());
+        }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -34,6 +34,7 @@ pub mod heartbeat;
 pub mod heartbeat_tests;
 pub mod json_viewer;
 pub mod keychain_utils;
+pub mod k8s_tunnel;
 pub mod log_commands;
 pub mod logger;
 pub mod mcp;
@@ -260,6 +261,15 @@ pub fn run() {
             commands::update_ssh_connection,
             commands::delete_ssh_connection,
             commands::test_ssh_connection,
+            // K8s Connections
+            commands::get_k8s_connections,
+            commands::save_k8s_connection,
+            commands::update_k8s_connection,
+            commands::delete_k8s_connection,
+            commands::test_k8s_connection_cmd,
+            commands::get_k8s_contexts_cmd,
+            commands::get_k8s_namespaces_cmd,
+            commands::get_k8s_resources_cmd,
             // Connection Groups
             commands::get_connection_groups,
             commands::get_connections_with_groups,

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -9,7 +9,7 @@ use crate::config::{
 use crate::credential_cache;
 use crate::drivers::{mysql, postgres, sqlite};
 use crate::heartbeat;
-use crate::models::{ConnectionParams, SshConnection};
+use crate::models::{ConnectionParams, K8sConnection, SshConnection};
 use crate::paths;
 use crate::persistence;
 use serde_json::{json, Value};
@@ -153,6 +153,65 @@ async fn expand_ssh_params_for_mcp(
     Ok(expanded)
 }
 
+/// MCP-mode equivalent of K8s saved-connection expansion.
+async fn expand_k8s_params_for_mcp(
+    params: &ConnectionParams,
+) -> Result<ConnectionParams, JsonRpcError> {
+    let mut expanded = params.clone();
+
+    if !params.k8s_enabled.unwrap_or(false) {
+        return Ok(expanded);
+    }
+
+    let k8s_id = match &params.k8s_connection_id {
+        Some(id) => id.clone(),
+        None => return Ok(expanded),
+    };
+
+    let k8s_path = paths::get_app_config_dir().join("k8s_connections.json");
+    if !k8s_path.exists() {
+        return Err(JsonRpcError {
+            code: -32000,
+            message: format!("K8s connection {} not found", k8s_id),
+            data: None,
+        });
+    }
+
+    let content = tokio::task::spawn_blocking({
+        let p = k8s_path.clone();
+        move || std::fs::read_to_string(p).map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| JsonRpcError {
+        code: -32000,
+        message: e.to_string(),
+        data: None,
+    })?
+    .map_err(|e| JsonRpcError {
+        code: -32000,
+        message: e,
+        data: None,
+    })?;
+
+    let k8s: K8sConnection = serde_json::from_str::<Vec<K8sConnection>>(&content)
+        .unwrap_or_default()
+        .into_iter()
+        .find(|k| k.id == k8s_id)
+        .ok_or_else(|| JsonRpcError {
+            code: -32000,
+            message: format!("K8s connection {} not found", k8s_id),
+            data: None,
+        })?;
+
+    expanded.k8s_context = Some(k8s.context);
+    expanded.k8s_namespace = Some(k8s.namespace);
+    expanded.k8s_resource_type = Some(k8s.resource_type);
+    expanded.k8s_resource_name = Some(k8s.resource_name);
+    expanded.k8s_port = Some(k8s.port);
+
+    Ok(expanded)
+}
+
 fn find_connection(conn_id: &str) -> Result<crate::models::SavedConnection, JsonRpcError> {
     let config_path = paths::get_app_config_dir().join("connections.json");
     let connections = persistence::load_connections(&config_path).map_err(|e| JsonRpcError {
@@ -199,6 +258,7 @@ async fn resolve_db_params(
     }
 
     let expanded = expand_ssh_params_for_mcp(&conn.params).await?;
+    let expanded = expand_k8s_params_for_mcp(&expanded).await?;
     let db_params = commands::resolve_connection_params(&expanded).map_err(|e| JsonRpcError {
         code: -32000,
         message: e,
@@ -425,12 +485,13 @@ async fn handle_read_resource(params: Option<Value>) -> Result<Value, JsonRpcErr
                 data: None,
             })?;
 
-        let params =
-            commands::resolve_connection_params(&conn.params).map_err(|e| JsonRpcError {
-                code: -32000,
-                message: e,
-                data: None,
-            })?;
+        let expanded = expand_ssh_params_for_mcp(&conn.params).await?;
+        let expanded = expand_k8s_params_for_mcp(&expanded).await?;
+        let params = commands::resolve_connection_params(&expanded).map_err(|e| JsonRpcError {
+            code: -32000,
+            message: e,
+            data: None,
+        })?;
 
         let tables = match conn.params.driver.as_str() {
             "mysql" => mysql::get_tables(&params, None).await,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -142,6 +142,21 @@ pub struct ConnectionParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ssh_key_passphrase: Option<String>,
     pub save_in_keychain: Option<bool>,
+    // Kubernetes Tunnel (mutually exclusive with SSH)
+    #[serde(default)]
+    pub k8s_enabled: Option<bool>,
+    #[serde(default)]
+    pub k8s_connection_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub k8s_context: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub k8s_namespace: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub k8s_resource_type: Option<String>, // "service" or "pod"
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub k8s_resource_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub k8s_port: Option<u16>,
     // Connection ID for stable pooling (not persisted, set at runtime)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connection_id: Option<String>,
@@ -179,11 +194,46 @@ pub struct ConnectionsFile {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct K8sConnection {
+    pub id: String,
+    pub name: String,
+    pub context: String,
+    pub namespace: String,
+    pub resource_type: String, // "service" or "pod"
+    pub resource_name: String,
+    pub port: u16,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct K8sConnectionInput {
+    pub name: String,
+    pub context: String,
+    pub namespace: String,
+    pub resource_type: String,
+    pub resource_name: String,
+    pub port: u16,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct K8sTestParams {
+    pub context: String,
+    pub namespace: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct ExportPayload {
     pub version: i32,
     pub groups: Vec<ConnectionGroup>,
     pub connections: Vec<SavedConnection>,
     pub ssh_connections: Vec<SshConnection>,
+    #[serde(default)]
+    pub k8s_connections: Vec<K8sConnection>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/src-tauri/src/pool_manager_tests.rs
+++ b/src-tauri/src/pool_manager_tests.rs
@@ -51,19 +51,7 @@ mod postgres_ssl_config_tests {
             password: Some("test".to_string()),
             database: DatabaseSelection::Single("testdb".to_string()),
             ssl_mode: Some(mode.to_string()),
-            ssl_ca: None,
-            ssl_cert: None,
-            ssl_key: None,
-            ssh_enabled: None,
-            ssh_connection_id: None,
-            ssh_host: None,
-            ssh_port: None,
-            ssh_user: None,
-            ssh_password: None,
-            ssh_key_file: None,
-            ssh_key_passphrase: None,
-            save_in_keychain: None,
-            connection_id: None,
+            ..Default::default()
         }
     }
 
@@ -75,20 +63,7 @@ mod postgres_ssl_config_tests {
             username: Some("test".to_string()),
             password: Some("test".to_string()),
             database: DatabaseSelection::Single("testdb".to_string()),
-            ssl_mode: None,
-            ssl_ca: None,
-            ssl_cert: None,
-            ssl_key: None,
-            ssh_enabled: None,
-            ssh_connection_id: None,
-            ssh_host: None,
-            ssh_port: None,
-            ssh_user: None,
-            ssh_password: None,
-            ssh_key_file: None,
-            ssh_key_passphrase: None,
-            save_in_keychain: None,
-            connection_id: None,
+            ..Default::default()
         }
     }
 
@@ -179,19 +154,7 @@ mod postgres_tls_connector_tests {
             password: Some("test".to_string()),
             database: DatabaseSelection::Single("testdb".to_string()),
             ssl_mode: Some(mode.to_string()),
-            ssl_ca: None,
-            ssl_cert: None,
-            ssl_key: None,
-            ssh_enabled: None,
-            ssh_connection_id: None,
-            ssh_host: None,
-            ssh_port: None,
-            ssh_user: None,
-            ssh_password: None,
-            ssh_key_file: None,
-            ssh_key_passphrase: None,
-            save_in_keychain: None,
-            connection_id: None,
+            ..Default::default()
         }
     }
 
@@ -261,18 +224,7 @@ mod postgres_tls_connector_tests {
             database: DatabaseSelection::Single("testdb".to_string()),
             ssl_mode: Some("verify-ca".to_string()),
             ssl_ca: Some(file_path.to_str().unwrap().to_string()),
-            ssl_cert: None,
-            ssl_key: None,
-            ssh_enabled: None,
-            ssh_connection_id: None,
-            ssh_host: None,
-            ssh_port: None,
-            ssh_user: None,
-            ssh_password: None,
-            ssh_key_file: None,
-            ssh_key_passphrase: None,
-            save_in_keychain: None,
-            connection_id: None,
+            ..Default::default()
         };
         let result = build_postgres_tls_connector(&params);
         assert!(result.is_ok());

--- a/src-tauri/tests/integration_tests.rs
+++ b/src-tauri/tests/integration_tests.rs
@@ -12,20 +12,7 @@ fn get_mysql_params() -> ConnectionParams {
         username: Some("root".to_string()),
         password: Some("password".to_string()),
         database: DatabaseSelection::Single("testdb".to_string()),
-        ssl_mode: None,
-        ssl_ca: None,
-        ssl_cert: None,
-        ssl_key: None,
-        ssh_enabled: None,
-        ssh_connection_id: None,
-        ssh_host: None,
-        ssh_port: None,
-        ssh_user: None,
-        ssh_password: None,
-        ssh_key_file: None,
-        ssh_key_passphrase: None,
-        save_in_keychain: None,
-        connection_id: None,
+        ..Default::default()
     }
 }
 
@@ -37,20 +24,7 @@ fn get_postgres_params() -> ConnectionParams {
         username: Some("postgres".to_string()),
         password: Some("password".to_string()),
         database: DatabaseSelection::Single("testdb".to_string()),
-        ssl_mode: None,
-        ssl_ca: None,
-        ssl_cert: None,
-        ssl_key: None,
-        ssh_enabled: None,
-        ssh_connection_id: None,
-        ssh_host: None,
-        ssh_port: None,
-        ssh_user: None,
-        ssh_password: None,
-        ssh_key_file: None,
-        ssh_key_passphrase: None,
-        save_in_keychain: None,
-        connection_id: None,
+        ..Default::default()
     }
 }
 

--- a/src/components/connections/ConnectionCard.tsx
+++ b/src/components/connections/ConnectionCard.tsx
@@ -88,6 +88,11 @@ export const ConnectionCard = ({
                 <Shield size={8} /> SSH
               </span>
             )}
+            {conn.params.k8s_enabled && (
+              <span className="flex items-center gap-0.5 text-[10px] font-bold text-blue-400 bg-blue-400/10 border border-blue-400/20 px-1.5 py-0.5 rounded-md">
+                <Shield size={8} /> K8s
+              </span>
+            )}
             {!isDriverEnabled && (
               <span className="flex items-center gap-1 text-[10px] text-amber-400 bg-amber-400/10 border border-amber-400/20 px-1.5 py-0.5 rounded-md">
                 <PlugZap size={8} /> {t('connections.pluginDisabled')}

--- a/src/components/connections/ConnectionListItem.tsx
+++ b/src/components/connections/ConnectionListItem.tsx
@@ -85,6 +85,11 @@ export const ConnectionListItem = ({
             <Shield size={8} /> SSH
           </span>
         )}
+        {conn.params.k8s_enabled && (
+          <span className="flex items-center gap-0.5 text-[10px] font-bold text-blue-400 bg-blue-400/10 border border-blue-400/20 px-1.5 py-0.5 rounded-md">
+            <Shield size={8} /> K8s
+          </span>
+        )}
         {!isDriverEnabled && (
           <span className="flex items-center gap-1 text-[10px] text-amber-400 bg-amber-400/10 border border-amber-400/20 px-1.5 py-0.5 rounded-md">
             <PlugZap size={8} /> {t('connections.pluginDisabled')}

--- a/src/components/layout/sidebar/OpenConnectionItem.tsx
+++ b/src/components/layout/sidebar/OpenConnectionItem.tsx
@@ -160,9 +160,16 @@ export const OpenConnectionItem = ({
           )}
 
           {/* SSH badge */}
-          {sshEnabled && !showShortcutHint && (
+          {sshEnabled && !showShortcutHint && !connection.k8sEnabled && (
             <div className="absolute top-1 right-1">
               <Shield size={9} className="text-emerald-400 fill-emerald-400/20" />
+            </div>
+          )}
+
+          {/* K8s badge */}
+          {connection.k8sEnabled && !showShortcutHint && (
+            <div className="absolute top-1 right-1">
+              <Shield size={9} className="text-blue-400 fill-blue-400/20" />
             </div>
           )}
 

--- a/src/components/modals/K8sConnectionsModal.tsx
+++ b/src/components/modals/K8sConnectionsModal.tsx
@@ -1,0 +1,542 @@
+import { useState, useEffect, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  X,
+  Plus,
+  Edit2,
+  Trash2,
+  Check,
+  Loader2,
+  Zap,
+  XCircle,
+} from "lucide-react";
+import {
+  loadK8sConnections,
+  saveK8sConnection,
+  updateK8sConnection,
+  deleteK8sConnection,
+  testK8sConnection,
+  getK8sContexts,
+  getK8sNamespaces,
+  getK8sResources,
+  validateK8sConnection,
+  type K8sConnection,
+  type K8sConnectionInput,
+} from "../../utils/k8s";
+import { toErrorMessage } from "../../utils/errors";
+import { Modal } from "../ui/Modal";
+import clsx from "clsx";
+
+interface K8sConnectionsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const InputClass =
+  "w-full px-3 py-2 bg-base border border-strong rounded-lg text-sm text-primary focus:border-blue-500 focus:outline-none transition-colors";
+const LabelClass = "block text-[10px] uppercase font-semibold tracking-wider text-muted mb-1";
+
+export function K8sConnectionsModal({
+  isOpen,
+  onClose,
+}: K8sConnectionsModalProps) {
+  const { t } = useTranslation();
+  const [connections, setConnections] = useState<K8sConnection[]>([]);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+
+  // Form state
+  const [name, setName] = useState("");
+  const [context, setContext] = useState("");
+  const [namespace, setNamespace] = useState("");
+  const [resourceType, setResourceType] = useState<string>("service");
+  const [resourceName, setResourceName] = useState("");
+  const [port, setPort] = useState<number>(3306);
+
+  // Discovery state
+  const [contexts, setContexts] = useState<string[]>([]);
+  const [namespaces, setNamespaces] = useState<string[]>([]);
+  const [resources, setResources] = useState<string[]>([]);
+
+  // Status
+  const [testStatus, setTestStatus] = useState<
+    "idle" | "testing" | "success" | "error"
+  >("idle");
+  const [testMessage, setTestMessage] = useState("");
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const loadConnections = useCallback(async () => {
+    const result = await loadK8sConnections();
+    setConnections(result);
+  }, []);
+
+  const loadContexts = useCallback(async () => {
+    try {
+      const result = await getK8sContexts();
+      setContexts(result);
+    } catch {
+      setContexts([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      loadConnections();
+      loadContexts();
+    }
+  }, [isOpen, loadConnections, loadContexts]);
+
+  useEffect(() => {
+    if (context) {
+      getK8sNamespaces(context)
+        .then(setNamespaces)
+        .catch(() => setNamespaces([]));
+    } else {
+      setNamespaces([]);
+    }
+  }, [context]);
+
+  useEffect(() => {
+    if (context && namespace && resourceType) {
+      getK8sResources(context, namespace, resourceType)
+        .then(setResources)
+        .catch(() => setResources([]));
+    } else {
+      setResources([]);
+    }
+  }, [context, namespace, resourceType]);
+
+  const resetForm = () => {
+    setName("");
+    setContext("");
+    setNamespace("");
+    setResourceType("service");
+    setResourceName("");
+    setPort(3306);
+    setTestStatus("idle");
+    setTestMessage("");
+    setValidationError(null);
+  };
+
+  const handleCreate = () => {
+    resetForm();
+    setIsCreating(true);
+    setEditingId(null);
+  };
+
+  const handleEdit = (conn: K8sConnection) => {
+    setName(conn.name);
+    setContext(conn.context);
+    setNamespace(conn.namespace);
+    setResourceType(conn.resource_type);
+    setResourceName(conn.resource_name);
+    setPort(conn.port);
+    setEditingId(conn.id);
+    setIsCreating(false);
+    setTestStatus("idle");
+    setTestMessage("");
+    setValidationError(null);
+  };
+
+  const handleCancel = () => {
+    resetForm();
+    setEditingId(null);
+    setIsCreating(false);
+  };
+
+  const handleSave = async () => {
+    const input: K8sConnectionInput = {
+      name,
+      context,
+      namespace,
+      resource_type: resourceType,
+      resource_name: resourceName,
+      port,
+    };
+
+    const validation = validateK8sConnection(input);
+    if (!validation.isValid) {
+      setValidationError(validation.error ?? "Validation failed");
+      return;
+    }
+
+    try {
+      if (isCreating) {
+        await saveK8sConnection(input);
+      } else if (editingId) {
+        await updateK8sConnection(editingId, input);
+      }
+      await loadConnections();
+      handleCancel();
+    } catch (error) {
+      setValidationError(toErrorMessage(error));
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await deleteK8sConnection(id);
+      await loadConnections();
+      if (editingId === id) handleCancel();
+    } catch (error) {
+      console.error("Failed to delete K8s connection:", error);
+    }
+  };
+
+  const handleTest = async () => {
+    if (!context || !namespace) return;
+    setTestStatus("testing");
+    try {
+      const result = await testK8sConnection(context, namespace);
+      setTestStatus("success");
+      setTestMessage(result);
+    } catch (error) {
+      setTestStatus("error");
+      setTestMessage(toErrorMessage(error));
+    }
+  };
+
+  const isEditing = isCreating || editingId !== null;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      overlayClassName="fixed inset-0 bg-black/60 flex items-center justify-center z-[100] backdrop-blur-sm"
+    >
+      <div className="bg-elevated border border-strong rounded-xl shadow-2xl w-[640px] max-h-[80vh] flex flex-col overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-3 border-b border-default bg-base">
+          <h2 className="text-sm font-semibold text-primary">
+            {t("k8sConnections.title", {
+              defaultValue: "Kubernetes Connections",
+            })}
+          </h2>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleCreate}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white rounded-md transition-colors"
+            >
+              <Plus size={12} />
+              {t("k8sConnections.add", { defaultValue: "Add" })}
+            </button>
+            <button
+              onClick={onClose}
+              className="p-1.5 text-muted hover:text-primary hover:bg-surface-secondary rounded-md transition-colors"
+            >
+              <X size={16} />
+            </button>
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto p-5 space-y-3">
+          {/* Connection list */}
+          {connections.map((conn) =>
+            editingId === conn.id ? (
+              /* Inline edit form */
+              <div
+                key={conn.id}
+                className="border border-blue-500/30 rounded-lg p-4 bg-base/50 space-y-3"
+              >
+                {/* Edit form — same fields as create */}
+                <EditForm
+                  name={name}
+                  setName={setName}
+                  context={context}
+                  setContext={setContext}
+                  namespace={namespace}
+                  setNamespace={setNamespace}
+                  resourceType={resourceType}
+                  setResourceType={setResourceType}
+                  resourceName={resourceName}
+                  setResourceName={setResourceName}
+                  port={port}
+                  setPort={setPort}
+                  contexts={contexts}
+                  namespaces={namespaces}
+                  resources={resources}
+                  validationError={validationError}
+                  testStatus={testStatus}
+                  testMessage={testMessage}
+                  onTest={handleTest}
+                  onSave={handleSave}
+                  onCancel={handleCancel}
+                />
+              </div>
+            ) : (
+              <div
+                key={conn.id}
+                className="flex items-center gap-3 p-3 rounded-lg bg-base border border-default hover:border-strong transition-colors"
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium text-primary truncate">
+                    {conn.name}
+                  </div>
+                  <div className="text-xs text-muted truncate">
+                    {conn.context}/{conn.namespace}/{conn.resource_type}/{conn.resource_name}:{conn.port}
+                  </div>
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <button
+                    onClick={() => handleEdit(conn)}
+                    className="p-1.5 text-muted hover:text-primary hover:bg-surface-secondary rounded transition-colors"
+                  >
+                    <Edit2 size={14} />
+                  </button>
+                  <button
+                    onClick={() => handleDelete(conn.id)}
+                    className="p-1.5 text-muted hover:text-red-400 hover:bg-red-500/10 rounded transition-colors"
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                </div>
+              </div>
+            )
+          )}
+
+          {/* Create form */}
+          {isCreating && (
+            <div className="border border-blue-500/30 rounded-lg p-4 bg-base/50 space-y-3">
+              <EditForm
+                name={name}
+                setName={setName}
+                context={context}
+                setContext={setContext}
+                namespace={namespace}
+                setNamespace={setNamespace}
+                resourceType={resourceType}
+                setResourceType={setResourceType}
+                resourceName={resourceName}
+                setResourceName={setResourceName}
+                port={port}
+                setPort={setPort}
+                contexts={contexts}
+                namespaces={namespaces}
+                resources={resources}
+                validationError={validationError}
+                testStatus={testStatus}
+                testMessage={testMessage}
+                onTest={handleTest}
+                onSave={handleSave}
+                onCancel={handleCancel}
+              />
+            </div>
+          )}
+
+          {/* Empty state */}
+          {connections.length === 0 && !isCreating && (
+            <p className="text-xs text-muted italic text-center py-6">
+              {t("k8sConnections.empty", {
+                defaultValue:
+                  "No Kubernetes connections saved. Click \"Add\" to create one.",
+              })}
+            </p>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+// ── Shared edit form ──
+
+interface EditFormProps {
+  name: string;
+  setName: (v: string) => void;
+  context: string;
+  setContext: (v: string) => void;
+  namespace: string;
+  setNamespace: (v: string) => void;
+  resourceType: string;
+  setResourceType: (v: string) => void;
+  resourceName: string;
+  setResourceName: (v: string) => void;
+  port: number;
+  setPort: (v: number) => void;
+  contexts: string[];
+  namespaces: string[];
+  resources: string[];
+  validationError: string | null;
+  testStatus: "idle" | "testing" | "success" | "error";
+  testMessage: string;
+  onTest: () => void;
+  onSave: () => void;
+  onCancel: () => void;
+}
+
+function EditForm({
+  name,
+  setName,
+  context,
+  setContext,
+  namespace,
+  setNamespace,
+  resourceType,
+  setResourceType,
+  resourceName,
+  setResourceName,
+  port,
+  setPort,
+  contexts,
+  namespaces,
+  resources,
+  validationError,
+  testStatus,
+  testMessage,
+  onTest,
+  onSave,
+  onCancel,
+}: EditFormProps) {
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className={LabelClass}>Name</label>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className={InputClass}
+          placeholder="My K8s cluster"
+        />
+      </div>
+
+      <div>
+        <label className={LabelClass}>Context</label>
+        <select
+          value={context}
+          onChange={(e) => setContext(e.target.value)}
+          className={InputClass}
+        >
+          <option value="">Choose a context...</option>
+          {contexts.map((ctx) => (
+            <option key={ctx} value={ctx}>
+              {ctx}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label className={LabelClass}>Namespace</label>
+        <select
+          value={namespace}
+          onChange={(e) => setNamespace(e.target.value)}
+          className={InputClass}
+        >
+          <option value="">Choose a namespace...</option>
+          {namespaces.map((ns) => (
+            <option key={ns} value={ns}>
+              {ns}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex gap-3">
+        <div className="flex-1">
+          <label className={LabelClass}>Resource Type</label>
+          <select
+            value={resourceType}
+            onChange={(e) => setResourceType(e.target.value)}
+            className={InputClass}
+          >
+            <option value="service">Service</option>
+            <option value="pod">Pod</option>
+          </select>
+        </div>
+
+        <div className="flex-1">
+          <label className={LabelClass}>Resource Name</label>
+          <select
+            value={resourceName}
+            onChange={(e) => setResourceName(e.target.value)}
+            className={InputClass}
+          >
+            <option value="">Choose a resource...</option>
+            {resources.map((res) => (
+              <option key={res} value={res}>
+                {res}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div>
+        <label className={LabelClass}>Container Port</label>
+        <input
+          type="number"
+          value={port}
+          onChange={(e) => setPort(Number(e.target.value))}
+          className={InputClass}
+          placeholder="3306"
+        />
+      </div>
+
+      {/* Test result */}
+      {testStatus !== "idle" && (
+        <div
+          className={clsx(
+            "text-xs px-3 py-2 rounded-md",
+            testStatus === "testing" && "text-muted",
+            testStatus === "success" && "text-green-400 bg-green-500/10",
+            testStatus === "error" && "text-red-400 bg-red-500/10"
+          )}
+        >
+          {testStatus === "testing" && (
+            <span className="flex items-center gap-1.5">
+              <Loader2 size={12} className="animate-spin" />
+              Testing...
+            </span>
+          )}
+          {testStatus === "success" && (
+            <span className="flex items-center gap-1.5">
+              <Check size={12} />
+              {testMessage}
+            </span>
+          )}
+          {testStatus === "error" && (
+            <span className="flex items-center gap-1.5">
+              <XCircle size={12} />
+              {testMessage}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Validation error */}
+      {validationError && (
+        <p className="text-xs text-red-400">{validationError}</p>
+      )}
+
+      {/* Actions */}
+      <div className="flex items-center gap-2 pt-1">
+        <button
+          onClick={onTest}
+          disabled={!context || !namespace}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-surface-secondary hover:bg-surface-tertiary text-secondary rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {testStatus === "testing" ? (
+            <Loader2 size={12} className="animate-spin" />
+          ) : (
+            <Zap size={12} />
+          )}
+          Test
+        </button>
+        <button
+          onClick={onSave}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white rounded-md transition-colors"
+        >
+          <Check size={12} />
+          Save
+        </button>
+        <button
+          onClick={onCancel}
+          className="px-3 py-1.5 text-xs font-medium text-muted hover:text-secondary rounded-md transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/modals/K8sConnectionsModal.tsx
+++ b/src/components/modals/K8sConnectionsModal.tsx
@@ -80,30 +80,42 @@ export function K8sConnectionsModal({
   }, []);
 
   useEffect(() => {
-    if (isOpen) {
-      loadConnections();
-      loadContexts();
-    }
+    if (!isOpen) return;
+
+    void (async () => {
+      await loadConnections();
+      await loadContexts();
+    })();
   }, [isOpen, loadConnections, loadContexts]);
 
   useEffect(() => {
-    if (context) {
-      getK8sNamespaces(context)
-        .then(setNamespaces)
-        .catch(() => setNamespaces([]));
-    } else {
-      setNamespaces([]);
-    }
+    void (async () => {
+      if (!context) {
+        setNamespaces([]);
+        return;
+      }
+
+      try {
+        setNamespaces(await getK8sNamespaces(context));
+      } catch {
+        setNamespaces([]);
+      }
+    })();
   }, [context]);
 
   useEffect(() => {
-    if (context && namespace && resourceType) {
-      getK8sResources(context, namespace, resourceType)
-        .then(setResources)
-        .catch(() => setResources([]));
-    } else {
-      setResources([]);
-    }
+    void (async () => {
+      if (!context || !namespace || !resourceType) {
+        setResources([]);
+        return;
+      }
+
+      try {
+        setResources(await getK8sResources(context, namespace, resourceType));
+      } catch {
+        setResources([]);
+      }
+    })();
   }, [context, namespace, resourceType]);
 
   const resetForm = () => {
@@ -195,8 +207,6 @@ export function K8sConnectionsModal({
       setTestMessage(toErrorMessage(error));
     }
   };
-
-  const isEditing = isCreating || editingId !== null;
 
   return (
     <Modal

--- a/src/components/modals/K8sConnectionsModal.tsx
+++ b/src/components/modals/K8sConnectionsModal.tsx
@@ -169,7 +169,9 @@ export function K8sConnectionsModal({
 
     const validation = validateK8sConnection(input);
     if (!validation.isValid) {
-      setValidationError(validation.error ?? "Validation failed");
+      setValidationError(
+        validation.error ?? t("k8sConnections.validationFailed"),
+      );
       return;
     }
 
@@ -399,66 +401,74 @@ function EditForm({
   onSave,
   onCancel,
 }: EditFormProps) {
+  const { t } = useTranslation();
   return (
     <div className="space-y-3">
       <div>
-        <label className={LabelClass}>Name</label>
+        <label className={LabelClass}>{t("k8sConnections.name")}</label>
         <input
           value={name}
           onChange={(e) => setName(e.target.value)}
           className={InputClass}
-          placeholder="My K8s cluster"
+          placeholder={t("k8sConnections.namePlaceholder")}
         />
       </div>
 
       <div>
-        <label className={LabelClass}>Context</label>
+        <label className={LabelClass}>{t("k8sConnections.context")}</label>
         <Select
           value={context || null}
           options={contexts}
           onChange={(val) => setContext(val)}
-          placeholder="Choose a context..."
+          placeholder={t("k8sConnections.chooseContext")}
           searchable={false}
         />
       </div>
 
       <div>
-        <label className={LabelClass}>Namespace</label>
+        <label className={LabelClass}>{t("k8sConnections.namespace")}</label>
         <Select
           value={namespace || null}
           options={namespaces}
           onChange={(val) => setNamespace(val)}
-          placeholder="Choose a namespace..."
+          placeholder={t("k8sConnections.chooseNamespace")}
           searchable={false}
         />
       </div>
 
       <div className="flex gap-3">
         <div className="flex-1">
-          <label className={LabelClass}>Resource Type</label>
+          <label className={LabelClass}>
+            {t("k8sConnections.resourceType")}
+          </label>
           <Select
             value={resourceType}
             options={["service", "pod"]}
-            labels={{ service: "Service", pod: "Pod" }}
+            labels={{
+              service: t("k8sConnections.resourceTypeService"),
+              pod: t("k8sConnections.resourceTypePod"),
+            }}
             onChange={(val) => setResourceType(val)}
             searchable={false}
           />
         </div>
 
         <div className="flex-1">
-          <label className={LabelClass}>Resource Name</label>
+          <label className={LabelClass}>
+            {t("k8sConnections.resourceName")}
+          </label>
           <Select
             value={resourceName || null}
             options={resources}
             onChange={(val) => setResourceName(val)}
-            placeholder="Choose a resource..."
+            placeholder={t("k8sConnections.chooseResource")}
             searchable={false}
           />
         </div>
       </div>
 
       <div>
-        <label className={LabelClass}>Container Port</label>
+        <label className={LabelClass}>{t("k8sConnections.port")}</label>
         <input
           type="number"
           value={port}
@@ -481,7 +491,7 @@ function EditForm({
           {testStatus === "testing" && (
             <span className="flex items-center gap-1.5">
               <Loader2 size={12} className="animate-spin" />
-              Testing...
+              {t("k8sConnections.testing")}
             </span>
           )}
           {testStatus === "success" && (
@@ -516,20 +526,20 @@ function EditForm({
           ) : (
             <Zap size={12} />
           )}
-          Test
+          {t("k8sConnections.test")}
         </button>
         <button
           onClick={onSave}
           className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white rounded-md transition-colors"
         >
           <Check size={12} />
-          Save
+          {t("common.save")}
         </button>
         <button
           onClick={onCancel}
           className="px-3 py-1.5 text-xs font-medium text-muted hover:text-secondary rounded-md transition-colors"
         >
-          Cancel
+          {t("common.cancel")}
         </button>
       </div>
     </div>

--- a/src/components/modals/K8sConnectionsModal.tsx
+++ b/src/components/modals/K8sConnectionsModal.tsx
@@ -25,6 +25,7 @@ import {
 } from "../../utils/k8s";
 import { toErrorMessage } from "../../utils/errors";
 import { Modal } from "../ui/Modal";
+import { Select } from "../ui/Select";
 import clsx from "clsx";
 
 interface K8sConnectionsModalProps {
@@ -33,8 +34,8 @@ interface K8sConnectionsModalProps {
 }
 
 const InputClass =
-  "w-full px-3 py-2 bg-base border border-strong rounded-lg text-sm text-primary focus:border-blue-500 focus:outline-none transition-colors";
-const LabelClass = "block text-[10px] uppercase font-semibold tracking-wider text-muted mb-1";
+  "w-full px-3 pt-2 pb-1 bg-base border border-strong rounded-lg text-primary focus:border-blue-500 focus:outline-none leading-tight";
+const LabelClass = "block text-xs uppercase font-bold text-muted mb-1";
 
 export function K8sConnectionsModal({
   isOpen,
@@ -412,63 +413,47 @@ function EditForm({
 
       <div>
         <label className={LabelClass}>Context</label>
-        <select
-          value={context}
-          onChange={(e) => setContext(e.target.value)}
-          className={InputClass}
-        >
-          <option value="">Choose a context...</option>
-          {contexts.map((ctx) => (
-            <option key={ctx} value={ctx}>
-              {ctx}
-            </option>
-          ))}
-        </select>
+        <Select
+          value={context || null}
+          options={contexts}
+          onChange={(val) => setContext(val)}
+          placeholder="Choose a context..."
+          searchable={false}
+        />
       </div>
 
       <div>
         <label className={LabelClass}>Namespace</label>
-        <select
-          value={namespace}
-          onChange={(e) => setNamespace(e.target.value)}
-          className={InputClass}
-        >
-          <option value="">Choose a namespace...</option>
-          {namespaces.map((ns) => (
-            <option key={ns} value={ns}>
-              {ns}
-            </option>
-          ))}
-        </select>
+        <Select
+          value={namespace || null}
+          options={namespaces}
+          onChange={(val) => setNamespace(val)}
+          placeholder="Choose a namespace..."
+          searchable={false}
+        />
       </div>
 
       <div className="flex gap-3">
         <div className="flex-1">
           <label className={LabelClass}>Resource Type</label>
-          <select
+          <Select
             value={resourceType}
-            onChange={(e) => setResourceType(e.target.value)}
-            className={InputClass}
-          >
-            <option value="service">Service</option>
-            <option value="pod">Pod</option>
-          </select>
+            options={["service", "pod"]}
+            labels={{ service: "Service", pod: "Pod" }}
+            onChange={(val) => setResourceType(val)}
+            searchable={false}
+          />
         </div>
 
         <div className="flex-1">
           <label className={LabelClass}>Resource Name</label>
-          <select
-            value={resourceName}
-            onChange={(e) => setResourceName(e.target.value)}
-            className={InputClass}
-          >
-            <option value="">Choose a resource...</option>
-            {resources.map((res) => (
-              <option key={res} value={res}>
-                {res}
-              </option>
-            ))}
-          </select>
+          <Select
+            value={resourceName || null}
+            options={resources}
+            onChange={(val) => setResourceName(val)}
+            placeholder="Choose a resource..."
+            searchable={false}
+          />
         </div>
       </div>
 

--- a/src/components/modals/NewConnectionModal.tsx
+++ b/src/components/modals/NewConnectionModal.tsx
@@ -399,6 +399,9 @@ export const NewConnectionModal = ({
         setSshMode(
           initialConnection.params.ssh_connection_id ? "existing" : "inline",
         );
+        setK8sMode(
+          initialConnection.params.k8s_connection_id ? "existing" : "inline",
+        );
 
         let params = initialConnection.params;
         try {

--- a/src/components/modals/NewConnectionModal.tsx
+++ b/src/components/modals/NewConnectionModal.tsx
@@ -305,6 +305,27 @@ export const NewConnectionModal = ({
     }
   };
 
+  // ── K8s cascading dropdown loading ──
+  useEffect(() => {
+    if (formData.k8s_context) {
+      loadK8sNamespacesList(formData.k8s_context);
+    } else {
+      setK8sNamespaces([]);
+    }
+  }, [formData.k8s_context]);
+
+  useEffect(() => {
+    if (formData.k8s_context && formData.k8s_namespace && formData.k8s_resource_type) {
+      loadK8sResourcesList(
+        formData.k8s_context,
+        formData.k8s_namespace,
+        formData.k8s_resource_type,
+      );
+    } else {
+      setK8sResources([]);
+    }
+  }, [formData.k8s_context, formData.k8s_namespace, formData.k8s_resource_type]);
+
   const updateField = (
     field: keyof ConnectionParams,
     value: string | number | boolean | undefined,
@@ -1545,9 +1566,6 @@ export const NewConnectionModal = ({
                   value={formData.k8s_context || ""}
                   onChange={(e) => {
                     updateField("k8s_context", e.target.value);
-                    if (e.target.value) loadK8sNamespacesList(e.target.value);
-                    setK8sNamespaces([]);
-                    setK8sResources([]);
                   }}
                   className="w-full px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary focus:border-blue-500 focus:outline-none appearance-auto cursor-pointer transition-colors"
                 >
@@ -1578,14 +1596,6 @@ export const NewConnectionModal = ({
                   value={formData.k8s_namespace || ""}
                   onChange={(e) => {
                     updateField("k8s_namespace", e.target.value);
-                    if (e.target.value && formData.k8s_context && formData.k8s_resource_type) {
-                      loadK8sResourcesList(
-                        formData.k8s_context,
-                        e.target.value,
-                        formData.k8s_resource_type
-                      );
-                    }
-                    setK8sResources([]);
                   }}
                   className="w-full px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary focus:border-blue-500 focus:outline-none appearance-auto cursor-pointer transition-colors"
                 >
@@ -1617,13 +1627,6 @@ export const NewConnectionModal = ({
                     value={formData.k8s_resource_type || ""}
                     onChange={(e) => {
                       updateField("k8s_resource_type", e.target.value);
-                      if (e.target.value && formData.k8s_context && formData.k8s_namespace) {
-                        loadK8sResourcesList(
-                          formData.k8s_context,
-                          formData.k8s_namespace,
-                          e.target.value
-                        );
-                      }
                     }}
                     className="w-full px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary focus:border-blue-500 focus:outline-none appearance-auto cursor-pointer transition-colors"
                   >

--- a/src/components/modals/NewConnectionModal.tsx
+++ b/src/components/modals/NewConnectionModal.tsx
@@ -198,7 +198,6 @@ export const NewConnectionModal = ({
   const [k8sContexts, setK8sContexts] = useState<string[]>([]);
   const [k8sNamespaces, setK8sNamespaces] = useState<string[]>([]);
   const [k8sResources, setK8sResources] = useState<string[]>([]);
-  const [k8sLoading, setK8sLoading] = useState(false);
 
   // ── databases ──
   const [availableDatabases, setAvailableDatabases] = useState<string[]>([]);
@@ -282,26 +281,20 @@ export const NewConnectionModal = ({
   };
 
   const loadK8sNamespacesList = async (context: string) => {
-    setK8sLoading(true);
     try {
       const result = await getK8sNamespaces(context);
       setK8sNamespaces(result);
     } catch {
       setK8sNamespaces([]);
-    } finally {
-      setK8sLoading(false);
     }
   };
 
   const loadK8sResourcesList = async (context: string, namespace: string, resourceType: string) => {
-    setK8sLoading(true);
     try {
       const result = await getK8sResources(context, namespace, resourceType);
       setK8sResources(result);
     } catch {
       setK8sResources([]);
-    } finally {
-      setK8sLoading(false);
     }
   };
 

--- a/src/components/modals/NewConnectionModal.tsx
+++ b/src/components/modals/NewConnectionModal.tsx
@@ -20,6 +20,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
 import clsx from "clsx";
 import { SshConnectionsModal } from "./SshConnectionsModal";
+import { K8sConnectionsModal } from "./K8sConnectionsModal";
 import { Select } from "../ui/Select";
 import { SlotAnchor } from "../ui/SlotAnchor";
 import { useDrivers } from "../../hooks/useDrivers";
@@ -27,6 +28,13 @@ import { usePluginSlotRegistry } from "../../hooks/usePluginSlotRegistry";
 import { Modal } from "../ui/Modal";
 import type { PluginManifest } from "../../types/plugins";
 import { loadSshConnections, type SshConnection } from "../../utils/ssh";
+import {
+  loadK8sConnections,
+  getK8sContexts,
+  getK8sNamespaces,
+  getK8sResources,
+  type K8sConnection,
+} from "../../utils/k8s";
 import { isMultiDatabaseCapable } from "../../utils/database";
 import { fetchConnectionWithCredentials } from "../../utils/credentials";
 import { getDriverIcon, getDriverColorStyle } from "../../utils/driverUI";
@@ -58,6 +66,14 @@ interface ConnectionParams {
   ssh_key_file?: string;
   ssh_key_passphrase?: string;
   save_in_keychain?: boolean;
+  // K8s
+  k8s_enabled?: boolean;
+  k8s_connection_id?: string;
+  k8s_context?: string;
+  k8s_namespace?: string;
+  k8s_resource_type?: string;
+  k8s_resource_name?: string;
+  k8s_port?: number;
 }
 
 interface SavedConnection {
@@ -151,6 +167,7 @@ export const NewConnectionModal = ({
     ssl_mode: "",
     ssh_enabled: false,
     ssh_port: 22,
+    k8s_enabled: false,
   });
   const [selectedDatabasesState, setSelectedDatabasesState] = useState<
     string[]
@@ -165,7 +182,7 @@ export const NewConnectionModal = ({
   >(null);
 
   // ── tab ──
-  const [activeTab, setActiveTab] = useState<"general" | "databases" | "ssh" | "ssl">(
+  const [activeTab, setActiveTab] = useState<"general" | "databases" | "ssh" | "ssl" | "k8s">(
     "general",
   );
 
@@ -173,6 +190,15 @@ export const NewConnectionModal = ({
   const [sshConnections, setSshConnections] = useState<SshConnection[]>([]);
   const [isSshModalOpen, setIsSshModalOpen] = useState(false);
   const [sshMode, setSshMode] = useState<"existing" | "inline">("existing");
+
+  // ── K8s ──
+  const [k8sConnections, setK8sConnections] = useState<K8sConnection[]>([]);
+  const [isK8sModalOpen, setIsK8sModalOpen] = useState(false);
+  const [k8sMode, setK8sMode] = useState<"existing" | "inline">("existing");
+  const [k8sContexts, setK8sContexts] = useState<string[]>([]);
+  const [k8sNamespaces, setK8sNamespaces] = useState<string[]>([]);
+  const [k8sResources, setK8sResources] = useState<string[]>([]);
+  const [k8sLoading, setK8sLoading] = useState(false);
 
   // ── databases ──
   const [availableDatabases, setAvailableDatabases] = useState<string[]>([]);
@@ -239,6 +265,44 @@ export const NewConnectionModal = ({
   const loadSshConnectionsList = async () => {
     const result = await loadSshConnections();
     setSshConnections(result);
+  };
+
+  const loadK8sConnectionsList = async () => {
+    const result = await loadK8sConnections();
+    setK8sConnections(result);
+  };
+
+  const loadK8sContextsList = async () => {
+    try {
+      const result = await getK8sContexts();
+      setK8sContexts(result);
+    } catch {
+      setK8sContexts([]);
+    }
+  };
+
+  const loadK8sNamespacesList = async (context: string) => {
+    setK8sLoading(true);
+    try {
+      const result = await getK8sNamespaces(context);
+      setK8sNamespaces(result);
+    } catch {
+      setK8sNamespaces([]);
+    } finally {
+      setK8sLoading(false);
+    }
+  };
+
+  const loadK8sResourcesList = async (context: string, namespace: string, resourceType: string) => {
+    setK8sLoading(true);
+    try {
+      const result = await getK8sResources(context, namespace, resourceType);
+      setK8sResources(result);
+    } catch {
+      setK8sResources([]);
+    } finally {
+      setK8sLoading(false);
+    }
   };
 
   const updateField = (
@@ -371,6 +435,7 @@ export const NewConnectionModal = ({
           database: "",
           ssh_enabled: false,
           ssh_port: 22,
+          k8s_enabled: false,
         });
         setSelectedDatabasesState([]);
         setSshMode("existing");
@@ -378,6 +443,8 @@ export const NewConnectionModal = ({
       }
 
       await loadSshConnectionsList();
+      await loadK8sConnectionsList();
+      await loadK8sContextsList();
     };
     void init();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -402,6 +469,13 @@ export const NewConnectionModal = ({
       ssh_key_file: undefined,
       ssh_key_passphrase: undefined,
       save_in_keychain: false,
+      k8s_enabled: false,
+      k8s_connection_id: undefined,
+      k8s_context: undefined,
+      k8s_namespace: undefined,
+      k8s_resource_type: undefined,
+      k8s_resource_name: undefined,
+      k8s_port: undefined,
     });
     setSelectedDatabasesState([]);
     setDbSearchQuery("");
@@ -1175,6 +1249,10 @@ export const NewConnectionModal = ({
             const enabled = e.target.checked;
             updateField("ssh_enabled", enabled);
             if (enabled && !formData.ssh_port) updateField("ssh_port", 22);
+            // Mutual exclusion with K8s
+            if (enabled && formData.k8s_enabled) {
+              updateField("k8s_enabled", false);
+            }
           }}
           className="accent-blue-500 w-3.5 h-3.5 rounded"
         />
@@ -1335,6 +1413,269 @@ export const NewConnectionModal = ({
     </div>
   );
 
+  // ── rendered K8s tab content ──
+  const k8sTabContent = !isNetworkDriver ? (
+    <p className="text-xs text-muted italic">
+      {t("newConnection.k8sNotAvailable", {
+        defaultValue: "Kubernetes is not available for this driver.",
+      })}
+    </p>
+  ) : (
+    <div className="space-y-4">
+      {/* Enable toggle */}
+      <label className="flex items-center gap-2.5 cursor-pointer select-none w-fit">
+        <input
+          type="checkbox"
+          id="k8s-toggle"
+          checked={!!formData.k8s_enabled}
+          onChange={(e) => {
+            const enabled = e.target.checked;
+            updateField("k8s_enabled", enabled);
+            // Mutual exclusion with SSH
+            if (enabled && formData.ssh_enabled) {
+              updateField("ssh_enabled", false);
+            }
+          }}
+          className="accent-blue-500 w-3.5 h-3.5 rounded"
+        />
+        <span className="text-sm font-medium text-secondary">
+          {t("newConnection.useK8s", {
+            defaultValue: "Use Kubernetes Port-Forward",
+          })}
+        </span>
+      </label>
+
+      {formData.k8s_enabled && (
+        <div className="space-y-4">
+          {/* Mode tabs */}
+          <div className="flex rounded-md border border-strong overflow-hidden w-fit">
+            {(["existing", "inline"] as const).map((mode) => (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => {
+                  setK8sMode(mode);
+                  if (mode === "existing") {
+                    updateField("k8s_context", undefined);
+                    updateField("k8s_namespace", undefined);
+                    updateField("k8s_resource_type", undefined);
+                    updateField("k8s_resource_name", undefined);
+                    updateField("k8s_port", undefined);
+                  } else {
+                    updateField("k8s_connection_id", undefined);
+                  }
+                }}
+                className={clsx(
+                  "px-3 py-1.5 text-xs font-medium transition-colors",
+                  k8sMode === mode
+                    ? "bg-blue-600 text-white"
+                    : "bg-elevated text-secondary hover:text-primary",
+                )}
+              >
+                {mode === "existing"
+                  ? t("newConnection.useK8sConnection", {
+                      defaultValue: "Saved Connection",
+                    })
+                  : t("newConnection.createInlineK8s", {
+                      defaultValue: "Inline",
+                    })}
+              </button>
+            ))}
+          </div>
+
+          {/* Existing K8s connection */}
+          {k8sMode === "existing" && (
+            <div className="space-y-3">
+              <div className="flex flex-col gap-1">
+                <label className="text-[10px] uppercase font-semibold tracking-wider text-muted">
+                  {t("newConnection.selectK8sConnection", {
+                    defaultValue: "Select K8s Connection",
+                  })}
+                </label>
+                <div className="flex items-center gap-2">
+                  <select
+                    value={formData.k8s_connection_id || ""}
+                    onChange={(e) =>
+                      updateField("k8s_connection_id", e.target.value)
+                    }
+                    className="flex-1 px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary focus:border-blue-500 focus:outline-none appearance-auto cursor-pointer transition-colors"
+                  >
+                    <option value="">
+                      {k8sConnections.length === 0
+                        ? t("newConnection.noK8sConnections", {
+                            defaultValue: "No saved connections — create one below",
+                          })
+                        : t("newConnection.chooseK8s", {
+                            defaultValue: "Choose a connection...",
+                          })}
+                    </option>
+                    {k8sConnections.map((conn) => (
+                      <option key={conn.id} value={conn.id}>
+                        {conn.name} ({conn.context}/{conn.namespace}/{conn.resource_name}:{conn.port})
+                      </option>
+                    ))}
+                  </select>
+                  <button
+                    type="button"
+                    onClick={() => setIsK8sModalOpen(true)}
+                    className="px-2.5 py-1.5 text-xs bg-surface-secondary hover:bg-surface-tertiary rounded-md text-secondary transition-colors"
+                  >
+                    {t("newConnection.manageK8s", {
+                      defaultValue: "Manage",
+                    })}
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Inline K8s fields */}
+          {k8sMode === "inline" && (
+            <div className="space-y-3">
+              <div className="flex flex-col gap-1">
+                <label className="text-[10px] uppercase font-semibold tracking-wider text-muted">
+                  {t("newConnection.k8sContext", {
+                    defaultValue: "Context",
+                  })}
+                </label>
+                <select
+                  value={formData.k8s_context || ""}
+                  onChange={(e) => {
+                    updateField("k8s_context", e.target.value);
+                    if (e.target.value) loadK8sNamespacesList(e.target.value);
+                    setK8sNamespaces([]);
+                    setK8sResources([]);
+                  }}
+                  className="w-full px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary focus:border-blue-500 focus:outline-none appearance-auto cursor-pointer transition-colors"
+                >
+                  <option value="">
+                    {k8sContexts.length === 0
+                      ? t("newConnection.noK8sContexts", {
+                          defaultValue: "No contexts found (is kubectl installed?)",
+                        })
+                      : t("newConnection.chooseContext", {
+                          defaultValue: "Choose a context...",
+                        })}
+                  </option>
+                  {k8sContexts.map((ctx) => (
+                    <option key={ctx} value={ctx}>
+                      {ctx}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="flex flex-col gap-1">
+                <label className="text-[10px] uppercase font-semibold tracking-wider text-muted">
+                  {t("newConnection.k8sNamespace", {
+                    defaultValue: "Namespace",
+                  })}
+                </label>
+                <select
+                  value={formData.k8s_namespace || ""}
+                  onChange={(e) => {
+                    updateField("k8s_namespace", e.target.value);
+                    if (e.target.value && formData.k8s_context && formData.k8s_resource_type) {
+                      loadK8sResourcesList(
+                        formData.k8s_context,
+                        e.target.value,
+                        formData.k8s_resource_type
+                      );
+                    }
+                    setK8sResources([]);
+                  }}
+                  className="w-full px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary focus:border-blue-500 focus:outline-none appearance-auto cursor-pointer transition-colors"
+                >
+                  <option value="">
+                    {k8sNamespaces.length === 0
+                      ? t("newConnection.selectContextFirst", {
+                          defaultValue: "Select a context first",
+                        })
+                      : t("newConnection.chooseNamespace", {
+                          defaultValue: "Choose a namespace...",
+                        })}
+                  </option>
+                  {k8sNamespaces.map((ns) => (
+                    <option key={ns} value={ns}>
+                      {ns}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="flex gap-3">
+                <div className="flex flex-col gap-1 flex-1">
+                  <label className="text-[10px] uppercase font-semibold tracking-wider text-muted">
+                    {t("newConnection.k8sResourceType", {
+                      defaultValue: "Resource Type",
+                    })}
+                  </label>
+                  <select
+                    value={formData.k8s_resource_type || ""}
+                    onChange={(e) => {
+                      updateField("k8s_resource_type", e.target.value);
+                      if (e.target.value && formData.k8s_context && formData.k8s_namespace) {
+                        loadK8sResourcesList(
+                          formData.k8s_context,
+                          formData.k8s_namespace,
+                          e.target.value
+                        );
+                      }
+                    }}
+                    className="w-full px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary focus:border-blue-500 focus:outline-none appearance-auto cursor-pointer transition-colors"
+                  >
+                    <option value="">Select type...</option>
+                    <option value="service">Service</option>
+                    <option value="pod">Pod</option>
+                  </select>
+                </div>
+
+                <div className="flex flex-col gap-1 flex-1">
+                  <label className="text-[10px] uppercase font-semibold tracking-wider text-muted">
+                    {t("newConnection.k8sResourceName", {
+                      defaultValue: "Resource Name",
+                    })}
+                  </label>
+                  <select
+                    value={formData.k8s_resource_name || ""}
+                    onChange={(e) =>
+                      updateField("k8s_resource_name", e.target.value)
+                    }
+                    className="w-full px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary focus:border-blue-500 focus:outline-none appearance-auto cursor-pointer transition-colors"
+                  >
+                    <option value="">
+                      {k8sResources.length === 0
+                        ? t("newConnection.selectTypeFirst", {
+                            defaultValue: "Select context/namespace/type first",
+                          })
+                        : t("newConnection.chooseResource", {
+                            defaultValue: "Choose a resource...",
+                          })}
+                    </option>
+                    {k8sResources.map((res) => (
+                      <option key={res} value={res}>
+                        {res}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+
+              <FieldInput
+                label={t("newConnection.k8sPort", {
+                  defaultValue: "Container Port",
+                })}
+                value={formData.k8s_port ?? ""}
+                onChange={(v) => updateField("k8s_port", Number(v))}
+                placeholder="3306"
+              />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+
   return (
     <Modal
       isOpen={isOpen}
@@ -1460,7 +1801,8 @@ export const NewConnectionModal = ({
                     ? [{ id: "ssl", label: "SSL" }]
                     : []),
                   ...(isNetworkDriver ? [{ id: "ssh", label: "SSH" }] : []),
-                ] as { id: "general" | "databases" | "ssh" | "ssl"; label: string }[]
+                  ...(isNetworkDriver ? [{ id: "k8s", label: "Kubernetes" }] : []),
+                ] as { id: "general" | "databases" | "ssh" | "ssl" | "k8s"; label: string }[]
               ).map((tab) => (
                 <button
                   key={tab.id}
@@ -1496,7 +1838,9 @@ export const NewConnectionModal = ({
                   ? databasesTabContent
                   : activeTab === "ssl"
                     ? sslTabContent
-                    : sshTabContent}
+                    : activeTab === "k8s"
+                      ? k8sTabContent
+                      : sshTabContent}
             </div>
           </div>
         </div>
@@ -1569,6 +1913,13 @@ export const NewConnectionModal = ({
         onClose={async () => {
           setIsSshModalOpen(false);
           await loadSshConnectionsList();
+        }}
+      />
+      <K8sConnectionsModal
+        isOpen={isK8sModalOpen}
+        onClose={async () => {
+          setIsK8sModalOpen(false);
+          await loadK8sConnectionsList();
         }}
       />
     </Modal>

--- a/src/components/modals/NewConnectionModal.tsx
+++ b/src/components/modals/NewConnectionModal.tsx
@@ -1320,24 +1320,23 @@ export const NewConnectionModal = ({
                 <label className="text-[10px] uppercase font-semibold tracking-wider text-muted">
                   {t("newConnection.selectSshConnection")}
                 </label>
-                <select
-                  value={formData.ssh_connection_id || ""}
-                  onChange={(e) =>
-                    updateField("ssh_connection_id", e.target.value)
-                  }
-                  className="w-full px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary focus:border-blue-500 focus:outline-none appearance-auto cursor-pointer transition-colors"
-                >
-                  <option value="">
-                    {sshConnections.length === 0
+                <Select
+                  value={formData.ssh_connection_id || null}
+                  options={sshConnections.map((conn) => conn.id)}
+                  labels={Object.fromEntries(
+                    sshConnections.map((conn) => [
+                      conn.id,
+                      `${conn.name} (${conn.user}@${conn.host}:${conn.port})`,
+                    ]),
+                  )}
+                  onChange={(val) => updateField("ssh_connection_id", val)}
+                  placeholder={
+                    sshConnections.length === 0
                       ? t("newConnection.noSshConnections")
-                      : "-- " + t("newConnection.selectSshConnection") + " --"}
-                  </option>
-                  {sshConnections.map((conn) => (
-                    <option key={conn.id} value={conn.id}>
-                      {conn.name} ({conn.user}@{conn.host}:{conn.port})
-                    </option>
-                  ))}
-                </select>
+                      : "-- " + t("newConnection.selectSshConnection") + " --"
+                  }
+                  searchable={false}
+                />
               </div>
               <button
                 type="button"
@@ -1510,28 +1509,28 @@ export const NewConnectionModal = ({
                   })}
                 </label>
                 <div className="flex items-center gap-2">
-                  <select
-                    value={formData.k8s_connection_id || ""}
-                    onChange={(e) =>
-                      updateField("k8s_connection_id", e.target.value)
-                    }
-                    className="flex-1 px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary focus:border-blue-500 focus:outline-none appearance-auto cursor-pointer transition-colors"
-                  >
-                    <option value="">
-                      {k8sConnections.length === 0
+                  <Select
+                    className="flex-1"
+                    value={formData.k8s_connection_id || null}
+                    options={k8sConnections.map((conn) => conn.id)}
+                    labels={Object.fromEntries(
+                      k8sConnections.map((conn) => [
+                        conn.id,
+                        `${conn.name} (${conn.context}/${conn.namespace}/${conn.resource_name}:${conn.port})`,
+                      ]),
+                    )}
+                    onChange={(val) => updateField("k8s_connection_id", val)}
+                    placeholder={
+                      k8sConnections.length === 0
                         ? t("newConnection.noK8sConnections", {
                             defaultValue: "No saved connections — create one below",
                           })
                         : t("newConnection.chooseK8s", {
                             defaultValue: "Choose a connection...",
-                          })}
-                    </option>
-                    {k8sConnections.map((conn) => (
-                      <option key={conn.id} value={conn.id}>
-                        {conn.name} ({conn.context}/{conn.namespace}/{conn.resource_name}:{conn.port})
-                      </option>
-                    ))}
-                  </select>
+                          })
+                    }
+                    searchable={false}
+                  />
                   <button
                     type="button"
                     onClick={() => setIsK8sModalOpen(true)}
@@ -1555,28 +1554,23 @@ export const NewConnectionModal = ({
                     defaultValue: "Context",
                   })}
                 </label>
-                <select
-                  value={formData.k8s_context || ""}
-                  onChange={(e) => {
-                    updateField("k8s_context", e.target.value);
+                <Select
+                  value={formData.k8s_context || null}
+                  options={k8sContexts}
+                  onChange={(val) => {
+                    updateField("k8s_context", val);
                   }}
-                  className="w-full px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary focus:border-blue-500 focus:outline-none appearance-auto cursor-pointer transition-colors"
-                >
-                  <option value="">
-                    {k8sContexts.length === 0
+                  placeholder={
+                    k8sContexts.length === 0
                       ? t("newConnection.noK8sContexts", {
                           defaultValue: "No contexts found (is kubectl installed?)",
                         })
                       : t("newConnection.chooseContext", {
                           defaultValue: "Choose a context...",
-                        })}
-                  </option>
-                  {k8sContexts.map((ctx) => (
-                    <option key={ctx} value={ctx}>
-                      {ctx}
-                    </option>
-                  ))}
-                </select>
+                        })
+                  }
+                  searchable={false}
+                />
               </div>
 
               <div className="flex flex-col gap-1">
@@ -1585,28 +1579,23 @@ export const NewConnectionModal = ({
                     defaultValue: "Namespace",
                   })}
                 </label>
-                <select
-                  value={formData.k8s_namespace || ""}
-                  onChange={(e) => {
-                    updateField("k8s_namespace", e.target.value);
+                <Select
+                  value={formData.k8s_namespace || null}
+                  options={k8sNamespaces}
+                  onChange={(val) => {
+                    updateField("k8s_namespace", val);
                   }}
-                  className="w-full px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary focus:border-blue-500 focus:outline-none appearance-auto cursor-pointer transition-colors"
-                >
-                  <option value="">
-                    {k8sNamespaces.length === 0
+                  placeholder={
+                    k8sNamespaces.length === 0
                       ? t("newConnection.selectContextFirst", {
                           defaultValue: "Select a context first",
                         })
                       : t("newConnection.chooseNamespace", {
                           defaultValue: "Choose a namespace...",
-                        })}
-                  </option>
-                  {k8sNamespaces.map((ns) => (
-                    <option key={ns} value={ns}>
-                      {ns}
-                    </option>
-                  ))}
-                </select>
+                        })
+                  }
+                  searchable={false}
+                />
               </div>
 
               <div className="flex gap-3">
@@ -1616,17 +1605,25 @@ export const NewConnectionModal = ({
                       defaultValue: "Resource Type",
                     })}
                   </label>
-                  <select
-                    value={formData.k8s_resource_type || ""}
-                    onChange={(e) => {
-                      updateField("k8s_resource_type", e.target.value);
+                  <Select
+                    value={formData.k8s_resource_type || null}
+                    options={["service", "pod"]}
+                    labels={{
+                      service: t("newConnection.k8sResourceTypeService", {
+                        defaultValue: "Service",
+                      }),
+                      pod: t("newConnection.k8sResourceTypePod", {
+                        defaultValue: "Pod",
+                      }),
                     }}
-                    className="w-full px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary focus:border-blue-500 focus:outline-none appearance-auto cursor-pointer transition-colors"
-                  >
-                    <option value="">Select type...</option>
-                    <option value="service">Service</option>
-                    <option value="pod">Pod</option>
-                  </select>
+                    onChange={(val) => {
+                      updateField("k8s_resource_type", val);
+                    }}
+                    placeholder={t("newConnection.k8sSelectType", {
+                      defaultValue: "Select type...",
+                    })}
+                    searchable={false}
+                  />
                 </div>
 
                 <div className="flex flex-col gap-1 flex-1">
@@ -1635,28 +1632,23 @@ export const NewConnectionModal = ({
                       defaultValue: "Resource Name",
                     })}
                   </label>
-                  <select
-                    value={formData.k8s_resource_name || ""}
-                    onChange={(e) =>
-                      updateField("k8s_resource_name", e.target.value)
+                  <Select
+                    value={formData.k8s_resource_name || null}
+                    options={k8sResources}
+                    onChange={(val) =>
+                      updateField("k8s_resource_name", val)
                     }
-                    className="w-full px-3 py-2 bg-base border border-strong rounded-md text-sm text-primary focus:border-blue-500 focus:outline-none appearance-auto cursor-pointer transition-colors"
-                  >
-                    <option value="">
-                      {k8sResources.length === 0
+                    placeholder={
+                      k8sResources.length === 0
                         ? t("newConnection.selectTypeFirst", {
                             defaultValue: "Select context/namespace/type first",
                           })
                         : t("newConnection.chooseResource", {
                             defaultValue: "Choose a resource...",
-                          })}
-                    </option>
-                    {k8sResources.map((res) => (
-                      <option key={res} value={res}>
-                        {res}
-                      </option>
-                    ))}
-                  </select>
+                          })
+                    }
+                    searchable={false}
+                  />
                 </div>
               </div>
 

--- a/src/components/modals/SshConnectionsModal.tsx
+++ b/src/components/modals/SshConnectionsModal.tsx
@@ -23,6 +23,7 @@ import {
 } from "../../utils/ssh";
 import { toErrorMessage } from "../../utils/errors";
 import { Modal } from "../ui/Modal";
+import { Select } from "../ui/Select";
 import clsx from "clsx";
 
 interface SshConnectionsModalProps {
@@ -452,23 +453,18 @@ export function SshConnectionsModal({
                 <label className={LabelClass}>
                   {t("sshConnections.authType")}
                 </label>
-                <select
+                <Select
                   value={formData.auth_type || "password"}
-                  onChange={(e) =>
-                    updateField(
-                      "auth_type",
-                      e.target.value as "password" | "ssh_key",
-                    )
+                  options={["password", "ssh_key"]}
+                  labels={{
+                    password: t("sshConnections.authTypePassword"),
+                    ssh_key: t("sshConnections.authTypeSshKey"),
+                  }}
+                  onChange={(val) =>
+                    updateField("auth_type", val as "password" | "ssh_key")
                   }
-                  className={InputClass}
-                >
-                  <option value="password">
-                    {t("sshConnections.authTypePassword")}
-                  </option>
-                  <option value="ssh_key">
-                    {t("sshConnections.authTypeSshKey")}
-                  </option>
-                </select>
+                  searchable={false}
+                />
               </div>
 
               {formData.auth_type === "password" && (

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -627,7 +627,29 @@
       "require": "Erforderlich",
       "verify-ca": "CA prüfen",
       "verify-full": "Vollständig prüfen"
-    }
+    },
+    "chooseContext": "Kontext auswählen...",
+    "chooseK8s": "Verbindung auswählen...",
+    "chooseNamespace": "Namespace auswählen...",
+    "chooseResource": "Ressource auswählen...",
+    "createInlineK8s": "Inline",
+    "k8sContext": "Kontext",
+    "k8sNamespace": "Namespace",
+    "k8sNotAvailable": "Kubernetes ist für diesen Treiber nicht verfügbar.",
+    "k8sPort": "Container-Port",
+    "k8sResourceName": "Ressourcenname",
+    "k8sResourceType": "Ressourcentyp",
+    "k8sResourceTypePod": "Pod",
+    "k8sResourceTypeService": "Service",
+    "k8sSelectType": "Typ auswählen...",
+    "manageK8s": "Verwalten",
+    "noK8sConnections": "Keine gespeicherten Verbindungen — erstelle unten eine",
+    "noK8sContexts": "Keine Kontexte gefunden (ist kubectl installiert?)",
+    "selectContextFirst": "Zuerst einen Kontext auswählen",
+    "selectK8sConnection": "K8s-Verbindung auswählen",
+    "selectTypeFirst": "Zuerst Kontext/Namespace/Typ auswählen",
+    "useK8s": "Kubernetes-Port-Forward verwenden",
+    "useK8sConnection": "Gespeicherte Verbindung"
   },
   "sshConnections": {
     "title": "SSH-Verbindungen",
@@ -1410,5 +1432,25 @@
     "body": "Wir haben einen eigenen Treffpunkt für Tabularis-Nutzer eröffnet: Hilfe, Tipps und Mitgestaltung der Roadmap.",
     "cta": "Jetzt beitreten",
     "dismiss": "Schließen"
+  },
+  "k8sConnections": {
+    "title": "Kubernetes-Verbindungen",
+    "add": "Hinzufügen",
+    "empty": "Keine Kubernetes-Verbindungen gespeichert. Klicke auf „Hinzufügen“, um eine zu erstellen.",
+    "name": "Name",
+    "namePlaceholder": "Mein K8s-Cluster",
+    "context": "Kontext",
+    "chooseContext": "Kontext auswählen...",
+    "namespace": "Namespace",
+    "chooseNamespace": "Namespace auswählen...",
+    "resourceType": "Ressourcentyp",
+    "resourceTypeService": "Service",
+    "resourceTypePod": "Pod",
+    "resourceName": "Ressourcenname",
+    "chooseResource": "Ressource auswählen...",
+    "port": "Container-Port",
+    "test": "Testen",
+    "testing": "Wird getestet...",
+    "validationFailed": "Validierung fehlgeschlagen"
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -640,7 +640,29 @@
       "require": "Require",
       "verify-ca": "Verify CA",
       "verify-full": "Verify Full"
-    }
+    },
+    "chooseContext": "Choose a context...",
+    "chooseK8s": "Choose a connection...",
+    "chooseNamespace": "Choose a namespace...",
+    "chooseResource": "Choose a resource...",
+    "createInlineK8s": "Inline",
+    "k8sContext": "Context",
+    "k8sNamespace": "Namespace",
+    "k8sNotAvailable": "Kubernetes is not available for this driver.",
+    "k8sPort": "Container Port",
+    "k8sResourceName": "Resource Name",
+    "k8sResourceType": "Resource Type",
+    "k8sResourceTypePod": "Pod",
+    "k8sResourceTypeService": "Service",
+    "k8sSelectType": "Select type...",
+    "manageK8s": "Manage",
+    "noK8sConnections": "No saved connections — create one below",
+    "noK8sContexts": "No contexts found (is kubectl installed?)",
+    "selectContextFirst": "Select a context first",
+    "selectK8sConnection": "Select K8s Connection",
+    "selectTypeFirst": "Select context/namespace/type first",
+    "useK8s": "Use Kubernetes Port-Forward",
+    "useK8sConnection": "Saved Connection"
   },
   "sshConnections": {
     "title": "SSH Connections",
@@ -1463,5 +1485,25 @@
     "body": "We just launched a dedicated home for Tabularis users. Get help, share tips, shape the roadmap.",
     "cta": "Join now",
     "dismiss": "Dismiss"
+  },
+  "k8sConnections": {
+    "title": "Kubernetes Connections",
+    "add": "Add",
+    "empty": "No Kubernetes connections saved. Click \"Add\" to create one.",
+    "name": "Name",
+    "namePlaceholder": "My K8s cluster",
+    "context": "Context",
+    "chooseContext": "Choose a context...",
+    "namespace": "Namespace",
+    "chooseNamespace": "Choose a namespace...",
+    "resourceType": "Resource Type",
+    "resourceTypeService": "Service",
+    "resourceTypePod": "Pod",
+    "resourceName": "Resource Name",
+    "chooseResource": "Choose a resource...",
+    "port": "Container Port",
+    "test": "Test",
+    "testing": "Testing...",
+    "validationFailed": "Validation failed"
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -627,7 +627,29 @@
       "require": "Requerido",
       "verify-ca": "Verificar CA",
       "verify-full": "Verificación completa"
-    }
+    },
+    "chooseContext": "Elige un contexto...",
+    "chooseK8s": "Elige una conexión...",
+    "chooseNamespace": "Elige un namespace...",
+    "chooseResource": "Elige un recurso...",
+    "createInlineK8s": "En línea",
+    "k8sContext": "Contexto",
+    "k8sNamespace": "Namespace",
+    "k8sNotAvailable": "Kubernetes no está disponible para este controlador.",
+    "k8sPort": "Puerto del contenedor",
+    "k8sResourceName": "Nombre del recurso",
+    "k8sResourceType": "Tipo de recurso",
+    "k8sResourceTypePod": "Pod",
+    "k8sResourceTypeService": "Service",
+    "k8sSelectType": "Selecciona tipo...",
+    "manageK8s": "Gestionar",
+    "noK8sConnections": "No hay conexiones guardadas — crea una abajo",
+    "noK8sContexts": "No se encontraron contextos (¿está kubectl instalado?)",
+    "selectContextFirst": "Selecciona primero un contexto",
+    "selectK8sConnection": "Selecciona conexión de K8s",
+    "selectTypeFirst": "Selecciona primero contexto/namespace/tipo",
+    "useK8s": "Usar Port-Forward de Kubernetes",
+    "useK8sConnection": "Conexión guardada"
   },
   "sshConnections": {
     "title": "Conexiones SSH",
@@ -1362,5 +1384,25 @@
     "body": "Acabamos de abrir una comunidad dedicada a Tabularis: pide ayuda, comparte trucos y da forma al roadmap.",
     "cta": "Únete ahora",
     "dismiss": "Cerrar"
+  },
+  "k8sConnections": {
+    "title": "Conexiones de Kubernetes",
+    "add": "Añadir",
+    "empty": "No hay conexiones de Kubernetes guardadas. Haz clic en \"Añadir\" para crear una.",
+    "name": "Nombre",
+    "namePlaceholder": "Mi clúster de K8s",
+    "context": "Contexto",
+    "chooseContext": "Elige un contexto...",
+    "namespace": "Namespace",
+    "chooseNamespace": "Elige un namespace...",
+    "resourceType": "Tipo de recurso",
+    "resourceTypeService": "Service",
+    "resourceTypePod": "Pod",
+    "resourceName": "Nombre del recurso",
+    "chooseResource": "Elige un recurso...",
+    "port": "Puerto del contenedor",
+    "test": "Probar",
+    "testing": "Probando...",
+    "validationFailed": "Error de validación"
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -627,7 +627,29 @@
       "require": "Exiger",
       "verify-ca": "Vérifier CA",
       "verify-full": "Vérification complète"
-    }
+    },
+    "chooseContext": "Choisir un contexte...",
+    "chooseK8s": "Choisir une connexion...",
+    "chooseNamespace": "Choisir un namespace...",
+    "chooseResource": "Choisir une ressource...",
+    "createInlineK8s": "En ligne",
+    "k8sContext": "Contexte",
+    "k8sNamespace": "Namespace",
+    "k8sNotAvailable": "Kubernetes n'est pas disponible pour ce pilote.",
+    "k8sPort": "Port du conteneur",
+    "k8sResourceName": "Nom de la ressource",
+    "k8sResourceType": "Type de ressource",
+    "k8sResourceTypePod": "Pod",
+    "k8sResourceTypeService": "Service",
+    "k8sSelectType": "Sélectionner le type...",
+    "manageK8s": "Gérer",
+    "noK8sConnections": "Aucune connexion enregistrée — créez-en une ci-dessous",
+    "noK8sContexts": "Aucun contexte trouvé (kubectl est-il installé ?)",
+    "selectContextFirst": "Sélectionnez d'abord un contexte",
+    "selectK8sConnection": "Sélectionner une connexion K8s",
+    "selectTypeFirst": "Sélectionnez d'abord contexte/namespace/type",
+    "useK8s": "Utiliser le Port-Forward Kubernetes",
+    "useK8sConnection": "Connexion enregistrée"
   },
   "sshConnections": {
     "title": "Connexions SSH",
@@ -1410,5 +1432,25 @@
     "body": "Nous venons d’ouvrir une communauté dédiée à Tabularis : entraide, astuces et influence sur la roadmap.",
     "cta": "Rejoindre maintenant",
     "dismiss": "Fermer"
+  },
+  "k8sConnections": {
+    "title": "Connexions Kubernetes",
+    "add": "Ajouter",
+    "empty": "Aucune connexion Kubernetes enregistrée. Cliquez sur « Ajouter » pour en créer une.",
+    "name": "Nom",
+    "namePlaceholder": "Mon cluster K8s",
+    "context": "Contexte",
+    "chooseContext": "Choisir un contexte...",
+    "namespace": "Namespace",
+    "chooseNamespace": "Choisir un namespace...",
+    "resourceType": "Type de ressource",
+    "resourceTypeService": "Service",
+    "resourceTypePod": "Pod",
+    "resourceName": "Nom de la ressource",
+    "chooseResource": "Choisir une ressource...",
+    "port": "Port du conteneur",
+    "test": "Tester",
+    "testing": "Test en cours...",
+    "validationFailed": "Échec de la validation"
   }
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -627,7 +627,29 @@
       "require": "Richiesto",
       "verify-ca": "Verifica CA",
       "verify-full": "Verifica completa"
-    }
+    },
+    "chooseContext": "Scegli un contesto...",
+    "chooseK8s": "Scegli una connessione...",
+    "chooseNamespace": "Scegli un namespace...",
+    "chooseResource": "Scegli una risorsa...",
+    "createInlineK8s": "Inline",
+    "k8sContext": "Contesto",
+    "k8sNamespace": "Namespace",
+    "k8sNotAvailable": "Kubernetes non è disponibile per questo driver.",
+    "k8sPort": "Porta container",
+    "k8sResourceName": "Nome risorsa",
+    "k8sResourceType": "Tipo di risorsa",
+    "k8sResourceTypePod": "Pod",
+    "k8sResourceTypeService": "Service",
+    "k8sSelectType": "Seleziona tipo...",
+    "manageK8s": "Gestisci",
+    "noK8sConnections": "Nessuna connessione salvata — creane una qui sotto",
+    "noK8sContexts": "Nessun contesto trovato (kubectl è installato?)",
+    "selectContextFirst": "Seleziona prima un contesto",
+    "selectK8sConnection": "Seleziona connessione K8s",
+    "selectTypeFirst": "Seleziona prima contesto/namespace/tipo",
+    "useK8s": "Usa Port-Forward Kubernetes",
+    "useK8sConnection": "Connessione salvata"
   },
   "sshConnections": {
     "title": "Connessioni SSH",
@@ -1388,5 +1410,25 @@
     "body": "Abbiamo una community Discord dedicata a Tabularis: ricevi aiuto, scambia consigli e influenza la roadmap.",
     "cta": "Entra subito",
     "dismiss": "Chiudi"
+  },
+  "k8sConnections": {
+    "title": "Connessioni Kubernetes",
+    "add": "Aggiungi",
+    "empty": "Nessuna connessione Kubernetes salvata. Clicca \"Aggiungi\" per crearne una.",
+    "name": "Nome",
+    "namePlaceholder": "Il mio cluster K8s",
+    "context": "Contesto",
+    "chooseContext": "Scegli un contesto...",
+    "namespace": "Namespace",
+    "chooseNamespace": "Scegli un namespace...",
+    "resourceType": "Tipo di risorsa",
+    "resourceTypeService": "Service",
+    "resourceTypePod": "Pod",
+    "resourceName": "Nome risorsa",
+    "chooseResource": "Scegli una risorsa...",
+    "port": "Porta container",
+    "test": "Test",
+    "testing": "Test in corso...",
+    "validationFailed": "Validazione fallita"
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -638,7 +638,29 @@
       "require": "必須",
       "verify-ca": "CAを検証",
       "verify-full": "完全検証"
-    }
+    },
+    "chooseContext": "コンテキストを選択...",
+    "chooseK8s": "接続を選択...",
+    "chooseNamespace": "ネームスペースを選択...",
+    "chooseResource": "リソースを選択...",
+    "createInlineK8s": "インライン",
+    "k8sContext": "コンテキスト",
+    "k8sNamespace": "ネームスペース",
+    "k8sNotAvailable": "このドライバーでは Kubernetes を使用できません。",
+    "k8sPort": "コンテナポート",
+    "k8sResourceName": "リソース名",
+    "k8sResourceType": "リソースタイプ",
+    "k8sResourceTypePod": "Pod",
+    "k8sResourceTypeService": "Service",
+    "k8sSelectType": "タイプを選択...",
+    "manageK8s": "管理",
+    "noK8sConnections": "保存された接続がありません — 下で作成してください",
+    "noK8sContexts": "コンテキストが見つかりません（kubectl はインストールされていますか？）",
+    "selectContextFirst": "先にコンテキストを選択してください",
+    "selectK8sConnection": "K8s 接続を選択",
+    "selectTypeFirst": "先にコンテキスト/ネームスペース/タイプを選択してください",
+    "useK8s": "Kubernetes ポートフォワードを使用",
+    "useK8sConnection": "保存された接続"
   },
   "sshConnections": {
     "title": "SSH 接続",
@@ -1425,5 +1447,25 @@
     "body": "Tabularis ユーザー専用のコミュニティを立ち上げました。質問・情報交換・ロードマップへのフィードバックをお寄せください。",
     "cta": "今すぐ参加",
     "dismiss": "閉じる"
+  },
+  "k8sConnections": {
+    "title": "Kubernetes 接続",
+    "add": "追加",
+    "empty": "保存された Kubernetes 接続がありません。「追加」をクリックして作成してください。",
+    "name": "名前",
+    "namePlaceholder": "マイ K8s クラスター",
+    "context": "コンテキスト",
+    "chooseContext": "コンテキストを選択...",
+    "namespace": "ネームスペース",
+    "chooseNamespace": "ネームスペースを選択...",
+    "resourceType": "リソースタイプ",
+    "resourceTypeService": "Service",
+    "resourceTypePod": "Pod",
+    "resourceName": "リソース名",
+    "chooseResource": "リソースを選択...",
+    "port": "コンテナポート",
+    "test": "テスト",
+    "testing": "テスト中...",
+    "validationFailed": "検証に失敗しました"
   }
 }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -641,7 +641,29 @@
       "allow": "Разрешён",
       "prefer": "Предпочтительный",
       "require": "Обязательный"
-    }
+    },
+    "chooseContext": "Выберите контекст...",
+    "chooseK8s": "Выберите подключение...",
+    "chooseNamespace": "Выберите пространство имён...",
+    "chooseResource": "Выберите ресурс...",
+    "createInlineK8s": "Встроенно",
+    "k8sContext": "Контекст",
+    "k8sNamespace": "Пространство имён",
+    "k8sNotAvailable": "Kubernetes недоступен для этого драйвера.",
+    "k8sPort": "Порт контейнера",
+    "k8sResourceName": "Имя ресурса",
+    "k8sResourceType": "Тип ресурса",
+    "k8sResourceTypePod": "Pod",
+    "k8sResourceTypeService": "Service",
+    "k8sSelectType": "Выберите тип...",
+    "manageK8s": "Управление",
+    "noK8sConnections": "Нет сохранённых подключений — создайте ниже",
+    "noK8sContexts": "Контексты не найдены (установлен ли kubectl?)",
+    "selectContextFirst": "Сначала выберите контекст",
+    "selectK8sConnection": "Выберите подключение K8s",
+    "selectTypeFirst": "Сначала выберите контекст/пространство имён/тип",
+    "useK8s": "Использовать проброс портов Kubernetes",
+    "useK8sConnection": "Сохранённое подключение"
   },
   "sshConnections": {
     "title": "SSH-подключения",
@@ -1504,5 +1526,25 @@
     "body": "Мы только что открыли отдельное место для пользователей Tabularis. Получайте помощь, делитесь советами, участвуйте в формировании дорожной карты.",
     "cta": "Вступить сейчас",
     "dismiss": "Закрыть"
+  },
+  "k8sConnections": {
+    "title": "Подключения Kubernetes",
+    "add": "Добавить",
+    "empty": "Нет сохранённых подключений Kubernetes. Нажмите «Добавить», чтобы создать.",
+    "name": "Имя",
+    "namePlaceholder": "Мой кластер K8s",
+    "context": "Контекст",
+    "chooseContext": "Выберите контекст...",
+    "namespace": "Пространство имён",
+    "chooseNamespace": "Выберите пространство имён...",
+    "resourceType": "Тип ресурса",
+    "resourceTypeService": "Service",
+    "resourceTypePod": "Pod",
+    "resourceName": "Имя ресурса",
+    "chooseResource": "Выберите ресурс...",
+    "port": "Порт контейнера",
+    "test": "Проверить",
+    "testing": "Проверка...",
+    "validationFailed": "Ошибка проверки"
   }
 }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -595,7 +595,29 @@
       "require": "要求",
       "verify-ca": "验证 CA",
       "verify-full": "完全验证"
-    }
+    },
+    "chooseContext": "选择上下文...",
+    "chooseK8s": "选择连接...",
+    "chooseNamespace": "选择命名空间...",
+    "chooseResource": "选择资源...",
+    "createInlineK8s": "内联",
+    "k8sContext": "上下文",
+    "k8sNamespace": "命名空间",
+    "k8sNotAvailable": "此驱动不支持 Kubernetes。",
+    "k8sPort": "容器端口",
+    "k8sResourceName": "资源名称",
+    "k8sResourceType": "资源类型",
+    "k8sResourceTypePod": "Pod",
+    "k8sResourceTypeService": "Service",
+    "k8sSelectType": "选择类型...",
+    "manageK8s": "管理",
+    "noK8sConnections": "没有已保存的连接 — 在下方创建一个",
+    "noK8sContexts": "未找到上下文（是否已安装 kubectl？）",
+    "selectContextFirst": "请先选择上下文",
+    "selectK8sConnection": "选择 K8s 连接",
+    "selectTypeFirst": "请先选择上下文/命名空间/类型",
+    "useK8s": "使用 Kubernetes 端口转发",
+    "useK8sConnection": "已保存的连接"
   },
   "sshConnections": {
     "title": "SSH 连接",
@@ -1351,5 +1373,25 @@
     "body": "我们为 Tabularis 用户开设了专属社区：获取帮助、分享技巧、共建路线图。",
     "cta": "立即加入",
     "dismiss": "关闭"
+  },
+  "k8sConnections": {
+    "title": "Kubernetes 连接",
+    "add": "添加",
+    "empty": "没有已保存的 Kubernetes 连接。点击“添加”创建一个。",
+    "name": "名称",
+    "namePlaceholder": "我的 K8s 集群",
+    "context": "上下文",
+    "chooseContext": "选择上下文...",
+    "namespace": "命名空间",
+    "chooseNamespace": "选择命名空间...",
+    "resourceType": "资源类型",
+    "resourceTypeService": "Service",
+    "resourceTypePod": "Pod",
+    "resourceName": "资源名称",
+    "chooseResource": "选择资源...",
+    "port": "容器端口",
+    "test": "测试",
+    "testing": "测试中...",
+    "validationFailed": "验证失败"
   }
 }

--- a/src/utils/connectionManager.ts
+++ b/src/utils/connectionManager.ts
@@ -7,6 +7,7 @@ export interface ConnectionStatus {
   database: string;
   host?: string;
   sshEnabled: boolean;
+  k8sEnabled: boolean;
   isOpen: boolean;
   isActive: boolean;
   isConnecting: boolean;
@@ -28,6 +29,7 @@ export function buildConnectionStatus(
     database: Array.isArray(conn.params.database) ? conn.params.database[0] : conn.params.database,
     host: conn.params.host,
     sshEnabled: conn.params.ssh_enabled ?? false,
+    k8sEnabled: conn.params.k8s_enabled ?? false,
     isOpen,
     isActive,
     isConnecting: data?.isConnecting ?? false,

--- a/src/utils/connections.ts
+++ b/src/utils/connections.ts
@@ -28,6 +28,14 @@ export interface ConnectionParams {
   ssh_password?: string;
   ssh_key_file?: string;
   ssh_key_passphrase?: string;
+  // K8s
+  k8s_enabled?: boolean;
+  k8s_connection_id?: string;
+  k8s_context?: string;
+  k8s_namespace?: string;
+  k8s_resource_type?: string;
+  k8s_resource_name?: string;
+  k8s_port?: number;
 }
 
 /**

--- a/src/utils/k8s.ts
+++ b/src/utils/k8s.ts
@@ -1,0 +1,150 @@
+/**
+ * Kubernetes connection utilities
+ * Manages kubectl port-forward tunnel configurations
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+
+export interface K8sConnection {
+  id: string;
+  name: string;
+  context: string;
+  namespace: string;
+  resource_type: "service" | "pod";
+  resource_name: string;
+  port: number;
+}
+
+export interface K8sConnectionInput {
+  name: string;
+  context: string;
+  namespace: string;
+  resource_type: string;
+  resource_name: string;
+  port: number;
+}
+
+/**
+ * Load all saved K8s connections
+ */
+export async function loadK8sConnections(): Promise<K8sConnection[]> {
+  try {
+    return await invoke<K8sConnection[]>("get_k8s_connections");
+  } catch (error) {
+    console.error("Failed to load K8s connections:", error);
+    return [];
+  }
+}
+
+/**
+ * Save a new K8s connection
+ */
+export async function saveK8sConnection(
+  k8s: K8sConnectionInput
+): Promise<K8sConnection> {
+  return await invoke<K8sConnection>("save_k8s_connection", { k8s });
+}
+
+/**
+ * Update an existing K8s connection
+ */
+export async function updateK8sConnection(
+  id: string,
+  k8s: K8sConnectionInput
+): Promise<K8sConnection> {
+  return await invoke<K8sConnection>("update_k8s_connection", { id, k8s });
+}
+
+/**
+ * Delete a K8s connection
+ */
+export async function deleteK8sConnection(id: string): Promise<void> {
+  await invoke("delete_k8s_connection", { id });
+}
+
+/**
+ * Test a K8s connection (verify context and namespace reachability)
+ */
+export async function testK8sConnection(
+  context: string,
+  namespace: string
+): Promise<string> {
+  return await invoke<string>("test_k8s_connection_cmd", { context, namespace });
+}
+
+/**
+ * List available kubectl contexts
+ */
+export async function getK8sContexts(): Promise<string[]> {
+  return await invoke<string[]>("get_k8s_contexts_cmd");
+}
+
+/**
+ * List namespaces in a kubectl context
+ */
+export async function getK8sNamespaces(context: string): Promise<string[]> {
+  return await invoke<string[]>("get_k8s_namespaces_cmd", { context });
+}
+
+/**
+ * List resources (services or pods) in a context/namespace
+ */
+export async function getK8sResources(
+  context: string,
+  namespace: string,
+  resourceType: string
+): Promise<string[]> {
+  return await invoke<string[]>("get_k8s_resources_cmd", {
+    context,
+    namespace,
+    resourceType,
+  });
+}
+
+/**
+ * Format a K8s connection for display
+ */
+export function formatK8sConnectionString(k8s: K8sConnection): string {
+  return `${k8s.context}/${k8s.namespace}/${k8s.resource_type}/${k8s.resource_name}:${k8s.port}`;
+}
+
+/**
+ * Validation result for K8s connection params
+ */
+export interface K8sValidationResult {
+  isValid: boolean;
+  error?: string;
+}
+
+/**
+ * Validate K8s connection parameters
+ */
+export function validateK8sConnection(
+  k8s: Partial<K8sConnectionInput>
+): K8sValidationResult {
+  if (!k8s.name || k8s.name.trim() === "") {
+    return { isValid: false, error: "Connection name is required" };
+  }
+
+  if (!k8s.context || k8s.context.trim() === "") {
+    return { isValid: false, error: "Kubernetes context is required" };
+  }
+
+  if (!k8s.namespace || k8s.namespace.trim() === "") {
+    return { isValid: false, error: "Namespace is required" };
+  }
+
+  if (!k8s.resource_type || (k8s.resource_type !== "service" && k8s.resource_type !== "pod")) {
+    return { isValid: false, error: "Resource type must be 'service' or 'pod'" };
+  }
+
+  if (!k8s.resource_name || k8s.resource_name.trim() === "") {
+    return { isValid: false, error: "Resource name is required" };
+  }
+
+  if (!k8s.port || k8s.port < 1 || k8s.port > 65535) {
+    return { isValid: false, error: "Port must be between 1 and 65535" };
+  }
+
+  return { isValid: true };
+}

--- a/tests/utils/connectionManager.test.ts
+++ b/tests/utils/connectionManager.test.ts
@@ -74,6 +74,7 @@ describe('connectionManager', () => {
         database: 'mydb',
         host: 'localhost',
         sshEnabled: false,
+        k8sEnabled: false,
         isOpen: true,
         isActive: true,
         isConnecting: false,

--- a/tests/utils/k8s.test.ts
+++ b/tests/utils/k8s.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  validateK8sConnection,
+  formatK8sConnectionString,
+  testK8sConnection,
+  getK8sContexts,
+  getK8sNamespaces,
+  getK8sResources,
+  loadK8sConnections,
+  saveK8sConnection,
+  updateK8sConnection,
+  deleteK8sConnection,
+  type K8sConnection,
+  type K8sConnectionInput,
+} from "../../src/utils/k8s";
+
+// Mock Tauri's invoke
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+describe("k8s", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("validateK8sConnection", () => {
+    const validInput: K8sConnectionInput = {
+      name: "My Cluster",
+      context: "gke_project_us-central1_cluster",
+      namespace: "database",
+      resource_type: "service",
+      resource_name: "mysql-svc",
+      port: 3306,
+    };
+
+    describe("required fields", () => {
+      it("should fail when name is missing", () => {
+        const result = validateK8sConnection({ ...validInput, name: "" });
+        expect(result.isValid).toBe(false);
+        expect(result.error).toBe("Connection name is required");
+      });
+
+      it("should fail when name is whitespace", () => {
+        const result = validateK8sConnection({ ...validInput, name: "   " });
+        expect(result.isValid).toBe(false);
+        expect(result.error).toBe("Connection name is required");
+      });
+
+      it("should fail when context is missing", () => {
+        const result = validateK8sConnection({ ...validInput, context: "" });
+        expect(result.isValid).toBe(false);
+        expect(result.error).toBe("Kubernetes context is required");
+      });
+
+      it("should fail when namespace is missing", () => {
+        const result = validateK8sConnection({
+          ...validInput,
+          namespace: "",
+        });
+        expect(result.isValid).toBe(false);
+        expect(result.error).toBe("Namespace is required");
+      });
+
+      it("should fail when resource_name is missing", () => {
+        const result = validateK8sConnection({
+          ...validInput,
+          resource_name: "",
+        });
+        expect(result.isValid).toBe(false);
+        expect(result.error).toBe("Resource name is required");
+      });
+    });
+
+    describe("resource type validation", () => {
+      it("should fail when resource_type is invalid", () => {
+        const result = validateK8sConnection({
+          ...validInput,
+          resource_type: "deployment",
+        });
+        expect(result.isValid).toBe(false);
+        expect(result.error).toBe(
+          "Resource type must be 'service' or 'pod'",
+        );
+      });
+
+      it("should succeed with resource_type 'service'", () => {
+        const result = validateK8sConnection({
+          ...validInput,
+          resource_type: "service",
+        });
+        expect(result.isValid).toBe(true);
+      });
+
+      it("should succeed with resource_type 'pod'", () => {
+        const result = validateK8sConnection({
+          ...validInput,
+          resource_type: "pod",
+        });
+        expect(result.isValid).toBe(true);
+      });
+    });
+
+    describe("port validation", () => {
+      it("should fail when port is 0", () => {
+        const result = validateK8sConnection({ ...validInput, port: 0 });
+        expect(result.isValid).toBe(false);
+        expect(result.error).toBe("Port must be between 1 and 65535");
+      });
+
+      it("should fail when port is > 65535", () => {
+        const result = validateK8sConnection({
+          ...validInput,
+          port: 70000,
+        });
+        expect(result.isValid).toBe(false);
+        expect(result.error).toBe("Port must be between 1 and 65535");
+      });
+
+      it("should succeed with port 1", () => {
+        const result = validateK8sConnection({ ...validInput, port: 1 });
+        expect(result.isValid).toBe(true);
+      });
+
+      it("should succeed with port 65535", () => {
+        const result = validateK8sConnection({ ...validInput, port: 65535 });
+        expect(result.isValid).toBe(true);
+      });
+    });
+
+    it("should succeed with all valid fields", () => {
+      const result = validateK8sConnection(validInput);
+      expect(result.isValid).toBe(true);
+    });
+  });
+
+  describe("formatK8sConnectionString", () => {
+    it("should format K8s connection string correctly", () => {
+      const k8s: K8sConnection = {
+        id: "1",
+        name: "My Cluster",
+        context: "gke_project_cluster",
+        namespace: "database",
+        resource_type: "service",
+        resource_name: "mysql-svc",
+        port: 3306,
+      };
+
+      expect(formatK8sConnectionString(k8s)).toBe(
+        "gke_project_cluster/database/service/mysql-svc:3306",
+      );
+    });
+
+    it("should format pod connection string correctly", () => {
+      const k8s: K8sConnection = {
+        id: "2",
+        name: "Dev Pod",
+        context: "minikube",
+        namespace: "default",
+        resource_type: "pod",
+        resource_name: "postgres-0",
+        port: 5432,
+      };
+
+      expect(formatK8sConnectionString(k8s)).toBe(
+        "minikube/default/pod/postgres-0:5432",
+      );
+    });
+  });
+
+  describe("testK8sConnection", () => {
+    it("should call invoke with correct parameters", async () => {
+      const { invoke } = await import("@tauri-apps/api/core");
+      vi.mocked(invoke).mockResolvedValue("K8s connection verified!");
+
+      const result = await testK8sConnection("my-context", "my-namespace");
+
+      expect(invoke).toHaveBeenCalledWith("test_k8s_connection_cmd", {
+        context: "my-context",
+        namespace: "my-namespace",
+      });
+      expect(result).toBe("K8s connection verified!");
+    });
+
+    it("should propagate errors from invoke", async () => {
+      const { invoke } = await import("@tauri-apps/api/core");
+      vi.mocked(invoke).mockRejectedValue(new Error("Context not found"));
+
+      await expect(
+        testK8sConnection("bad-context", "default"),
+      ).rejects.toThrow("Context not found");
+    });
+  });
+
+  describe("getK8sContexts", () => {
+    it("should return list of contexts", async () => {
+      const { invoke } = await import("@tauri-apps/api/core");
+      vi.mocked(invoke).mockResolvedValue([
+        "minikube",
+        "gke_project_cluster",
+      ]);
+
+      const result = await getK8sContexts();
+
+      expect(invoke).toHaveBeenCalledWith("get_k8s_contexts_cmd");
+      expect(result).toEqual(["minikube", "gke_project_cluster"]);
+    });
+  });
+
+  describe("getK8sNamespaces", () => {
+    it("should call invoke with context parameter", async () => {
+      const { invoke } = await import("@tauri-apps/api/core");
+      vi.mocked(invoke).mockResolvedValue(["default", "kube-system"]);
+
+      const result = await getK8sNamespaces("minikube");
+
+      expect(invoke).toHaveBeenCalledWith("get_k8s_namespaces_cmd", {
+        context: "minikube",
+      });
+      expect(result).toEqual(["default", "kube-system"]);
+    });
+  });
+
+  describe("getK8sResources", () => {
+    it("should call invoke with all parameters", async () => {
+      const { invoke } = await import("@tauri-apps/api/core");
+      vi.mocked(invoke).mockResolvedValue(["mysql-svc", "postgres-svc"]);
+
+      const result = await getK8sResources(
+        "minikube",
+        "database",
+        "service",
+      );
+
+      expect(invoke).toHaveBeenCalledWith("get_k8s_resources_cmd", {
+        context: "minikube",
+        namespace: "database",
+        resourceType: "service",
+      });
+      expect(result).toEqual(["mysql-svc", "postgres-svc"]);
+    });
+  });
+
+  describe("loadK8sConnections", () => {
+    it("should return empty array on error", async () => {
+      const { invoke } = await import("@tauri-apps/api/core");
+      vi.mocked(invoke).mockRejectedValue(new Error("File not found"));
+
+      const result = await loadK8sConnections();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("saveK8sConnection", () => {
+    it("should call invoke with k8s parameter", async () => {
+      const { invoke } = await import("@tauri-apps/api/core");
+      const saved: K8sConnection = {
+        id: "abc-123",
+        name: "Test",
+        context: "minikube",
+        namespace: "default",
+        resource_type: "service",
+        resource_name: "db",
+        port: 3306,
+      };
+      vi.mocked(invoke).mockResolvedValue(saved);
+
+      const input: K8sConnectionInput = {
+        name: "Test",
+        context: "minikube",
+        namespace: "default",
+        resource_type: "service",
+        resource_name: "db",
+        port: 3306,
+      };
+
+      const result = await saveK8sConnection(input);
+
+      expect(invoke).toHaveBeenCalledWith("save_k8s_connection", {
+        k8s: input,
+      });
+      expect(result).toEqual(saved);
+    });
+  });
+
+  describe("updateK8sConnection", () => {
+    it("should call invoke with id and k8s parameter", async () => {
+      const { invoke } = await import("@tauri-apps/api/core");
+      const updated: K8sConnection = {
+        id: "abc-123",
+        name: "Updated",
+        context: "minikube",
+        namespace: "default",
+        resource_type: "pod",
+        resource_name: "db-0",
+        port: 5432,
+      };
+      vi.mocked(invoke).mockResolvedValue(updated);
+
+      const input: K8sConnectionInput = {
+        name: "Updated",
+        context: "minikube",
+        namespace: "default",
+        resource_type: "pod",
+        resource_name: "db-0",
+        port: 5432,
+      };
+
+      const result = await updateK8sConnection("abc-123", input);
+
+      expect(invoke).toHaveBeenCalledWith("update_k8s_connection", {
+        id: "abc-123",
+        k8s: input,
+      });
+      expect(result).toEqual(updated);
+    });
+  });
+
+  describe("deleteK8sConnection", () => {
+    it("should call invoke with id parameter", async () => {
+      const { invoke } = await import("@tauri-apps/api/core");
+      vi.mocked(invoke).mockResolvedValue(undefined);
+
+      await deleteK8sConnection("abc-123");
+
+      expect(invoke).toHaveBeenCalledWith("delete_k8s_connection", {
+        id: "abc-123",
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

   Adds built-in Kubernetes port-forward support as a first-class transport option (alongside SSH tunnels). Users can
 connect to any database running inside a Kubernetes cluster by configuring a kubectl context, namespace, resource
 (service/pod), and container port.

   ## How it works

   - Runs `kubectl port-forward` as a managed child process, binding a local port that the database driver connects to
 transparently
   - Tunnels are reused across connections to the same resource (keyed by context/namespace/resource/port)
   - Auto-discovers kubectl contexts, namespaces, and resources from `~/.kube/config`
   - Saved K8s connections persist in `k8s_connections.json` (same pattern as SSH)
   - Mutually exclusive with SSH — enabling K8s disables SSH and vice versa

   ## New files

   | File | Purpose |
   |------|---------|
   | `src-tauri/src/k8s_tunnel.rs` | Tunnel lifecycle, discovery functions, 12 unit tests |
   | `src/utils/k8s.ts` | Frontend CRUD, discovery, validation |
   | `src/components/modals/K8sConnectionsModal.tsx` | Manage saved K8s connections |
   | `tests/utils/k8s.test.ts` | 24 frontend unit tests |

   ## Modified files

   - `src-tauri/src/models.rs` — K8s fields on `ConnectionParams`, new structs
   - `src-tauri/src/commands.rs` — K8s commands, tunnel expansion, export/import, 6 tests
   - `src-tauri/src/lib.rs` — Module + command registration
   - `src/components/modals/NewConnectionModal.tsx` — Kubernetes tab with cascading dropdowns
   - `src/components/connections/` + `sidebar/` — Blue K8s badge on connections
   - `src/utils/connectionManager.ts` / `connections.ts` — K8s fields in types
   - Existing test files updated to use `..Default::default()` spread

   ## Test coverage

   - **594** Rust tests pass (18 new K8s-specific)
   - **24** new TypeScript tests
   - Manually smoke-tested with a real K8s cluster

   ## Requirements

   - `kubectl` installed and in `$PATH`
   - A valid kubeconfig (`~/.kube/config` or `$KUBECONFIG`)

<img width="403" height="154" alt="image" src="https://github.com/user-attachments/assets/11761cbb-5140-4203-bf39-a9b5c66affcc" />
<img width="775" height="512" alt="image" src="https://github.com/user-attachments/assets/78f33dad-888b-4244-817f-cf41d80b2421" />
