### PR TITLE
fix: Save Query modal no longer overrides editor theme globally

### DIFF
--- a/src/components/modals/QueryModal.tsx
+++ b/src/components/modals/QueryModal.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect } from 'react';
 import { X, Save } from 'lucide-react';
-import MonacoEditor from '@monaco-editor/react';
+import MonacoEditor, { type BeforeMount } from '@monaco-editor/react';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '../../hooks/useTheme';
+import { useSettings } from '../../hooks/useSettings';
+import { loadMonacoTheme } from '../../themes/themeUtils';
 import { Modal } from '../ui/Modal';
 import { Select } from '../ui/Select';
 
@@ -24,7 +26,16 @@ export const QueryModal = ({ isOpen, onClose, onSave, initialName = '', initialS
   const [database, setDatabase] = useState<string | null>(initialDatabase ?? null);
   const [error, setError] = useState('');
   const [isSaving, setIsSaving] = useState(false);
-  const { currentTheme } = useTheme();
+  const { currentTheme, allThemes } = useTheme();
+  const { settings } = useSettings();
+
+  const editorTheme = settings.editorTheme
+    ? (allThemes.find((t) => t.id === settings.editorTheme) ?? currentTheme)
+    : currentTheme;
+
+  const handleBeforeMount: BeforeMount = (monaco) => {
+    loadMonacoTheme(editorTheme, monaco);
+  };
 
   useEffect(() => {
     if (isOpen) {
@@ -99,7 +110,8 @@ export const QueryModal = ({ isOpen, onClose, onSave, initialName = '', initialS
                 <MonacoEditor
                     height="100%"
                     defaultLanguage="sql"
-                    theme={currentTheme.id}
+                    theme={editorTheme.id}
+                    beforeMount={handleBeforeMount}
                     value={sql}
                     onChange={(val) => setSql(val || '')}
                     options={{

--- a/tests/components/modals/QueryModal.test.tsx
+++ b/tests/components/modals/QueryModal.test.tsx
@@ -17,7 +17,18 @@ vi.mock("@monaco-editor/react", () => ({
 vi.mock("../../../src/hooks/useTheme", () => ({
   useTheme: vi.fn(() => ({
     currentTheme: { id: "tabularis-dark" },
+    allThemes: [{ id: "tabularis-dark" }],
   })),
+}));
+
+vi.mock("../../../src/hooks/useSettings", () => ({
+  useSettings: vi.fn(() => ({
+    settings: {},
+  })),
+}));
+
+vi.mock("../../../src/themes/themeUtils", () => ({
+  loadMonacoTheme: vi.fn(),
 }));
 
 describe("QueryModal", () => {


### PR DESCRIPTION
Closes #247

## The problem

Opening the Save Query modal swaps the Monaco theme to the UI theme. Monaco keeps a single global theme registry, so the swap silently affects every other Monaco editor in the app (the main SQL console, notebook cells, the SQL preview, ...) and the original editor theme is never restored when the modal closes.

It only shows up when the user has picked an editor theme in Settings → Appearance that is different from the UI theme — which is exactly the configuration the editor-theme setting exists for.

## Why it happened

`QueryModal` was passing `theme={currentTheme.id}` straight to `<MonacoEditor>` and never calling `loadMonacoTheme` in `beforeMount`. `SqlEditorWrapper` already does the right thing: it resolves `settings.editorTheme ?? currentTheme` and registers the theme before mount, so the global `setTheme()` call lines up with whatever the user actually chose for the editor.

## The fix

Use the same resolution and registration path in `QueryModal`. Now the modal opens with the same theme the surrounding editors use, no global override happens, and closing the modal leaves everything as it was.

## Test plan

- [x] Set UI theme and editor theme to two different themes in Settings → Appearance.
- [x] Open the main SQL editor and confirm syntax colors match the editor theme.
- [x] Right-click a query → Save Query.
- [x] Confirm the editor inside the modal uses the editor theme (not the UI theme).
- [x] Confirm the main editor behind the modal still uses the editor theme.
- [x] Close the modal and confirm nothing changed.