### PR TITLE
fix(mcp): dispatch plugin drivers via the registry + harden the --mcp subprocess

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -122,6 +122,10 @@ pub fn run() {
     let args = cli::parse();
 
     if args.mcp {
+        // Initialize the logger so plugin-loading and driver RPC errors (which
+        // use the `log` crate) are visible. The custom logger writes to stderr
+        // only, leaving the stdout JSON-RPC stream clean.
+        init_logger(create_log_buffer(1000), log::LevelFilter::Info);
         let rt = tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");
         rt.block_on(mcp::run_mcp_server());
         return;

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -7,13 +7,17 @@ use crate::config::{
     DEFAULT_MCP_APPROVAL_TIMEOUT_SECONDS, DEFAULT_MCP_PREFLIGHT_EXPLAIN,
 };
 use crate::credential_cache;
+use crate::drivers::driver_trait::DatabaseDriver;
+use crate::drivers::registry as driver_registry;
 use crate::drivers::{mysql, postgres, sqlite};
 use crate::heartbeat;
 use crate::models::{ConnectionParams, SshConnection};
 use crate::paths;
 use crate::persistence;
+use crate::plugins;
 use serde_json::{json, Value};
 use std::io::{self, BufRead, Write};
+use std::sync::Arc;
 
 pub mod install;
 pub mod preflight;
@@ -207,8 +211,51 @@ async fn resolve_db_params(
     Ok((conn, db_params))
 }
 
+/// Populate the driver registry for the standalone MCP subprocess: the three
+/// built-in drivers plus any installed plugin drivers, honoring the user's
+/// `active_external_drivers` preference. Without this, MCP can only reach
+/// mysql/postgres/sqlite connections — every other driver fails with
+/// "Unsupported driver".
+async fn register_drivers_for_mcp() {
+    driver_registry::register_driver(mysql::MysqlDriver::new()).await;
+    driver_registry::register_driver(postgres::PostgresDriver::new()).await;
+    driver_registry::register_driver(sqlite::SqliteDriver::new()).await;
+
+    let app_config = config::load_config_from_disk();
+    let plugin_configs = app_config.plugins.unwrap_or_default();
+    let enabled_ids = app_config.active_external_drivers;
+    plugins::manager::load_plugins_with_configs(plugin_configs, enabled_ids.as_deref()).await;
+}
+
+/// Resolve the driver for an MCP-known connection. Returns the connection,
+/// the resolved DB params, and the registered driver. Errors with a JSON-RPC
+/// "Unsupported driver" payload when no driver matches the connection's
+/// `driver` id (e.g. the plugin failed to load).
+async fn resolve_db_driver(
+    conn_id: &str,
+) -> Result<
+    (
+        crate::models::SavedConnection,
+        ConnectionParams,
+        Arc<dyn DatabaseDriver>,
+    ),
+    JsonRpcError,
+> {
+    let (conn, db_params) = resolve_db_params(conn_id).await?;
+    let driver = driver_registry::get_driver(&conn.params.driver)
+        .await
+        .ok_or_else(|| JsonRpcError {
+            code: -32000,
+            message: format!("Unsupported driver: {}", conn.params.driver),
+            data: None,
+        })?;
+    Ok((conn, db_params, driver))
+}
+
 pub async fn run_mcp_server() {
     eprintln!("[MCP] Starting Tabularis MCP Server...");
+
+    register_drivers_for_mcp().await;
 
     let stdin = io::stdin();
     let mut stdout = io::stdout();
@@ -228,12 +275,20 @@ pub async fn run_mcp_server() {
                     Ok(request) => {
                         let response = handle_request(request).await;
                         if let Some(resp) = response {
-                            let json = serde_json::to_string(&resp).unwrap();
+                            let json = serde_json::to_string(&resp)
+                                .expect("serializing a JsonRpcResponse cannot fail");
                             // Log output to stderr
                             eprintln!("[MCP] Sending: {}", json);
-                            stdout.write_all(json.as_bytes()).unwrap();
-                            stdout.write_all(b"\n").unwrap();
-                            stdout.flush().unwrap();
+                            // Stop cleanly if the client has gone away (BrokenPipe)
+                            // rather than panicking the whole server.
+                            if let Err(e) = stdout
+                                .write_all(json.as_bytes())
+                                .and_then(|_| stdout.write_all(b"\n"))
+                                .and_then(|_| stdout.flush())
+                            {
+                                eprintln!("[MCP] Failed to write response, stopping: {}", e);
+                                break;
+                            }
                         }
                     }
                     Err(e) => {
@@ -402,47 +457,22 @@ async fn handle_read_resource(params: Option<Value>) -> Result<Value, JsonRpcErr
         }
         let conn_id = parts[2];
 
-        let config_path = paths::get_app_config_dir().join("connections.json");
-        let connections =
-            persistence::load_connections(&config_path).map_err(|e| JsonRpcError {
+        // Resolve through the same path as the tools so keychain passwords and
+        // SSH tunnels are applied — not just the raw saved params.
+        let (conn, params, driver) = resolve_db_driver(conn_id).await?;
+        let schema = if conn.params.driver == "postgres" {
+            Some("public")
+        } else {
+            None
+        };
+        let tables = driver
+            .get_tables(&params, schema)
+            .await
+            .map_err(|e| JsonRpcError {
                 code: -32000,
                 message: e,
                 data: None,
             })?;
-
-        // Try to find by ID or exact name (case-insensitive) first, then partial name match
-        let conn = connections
-            .iter()
-            .find(|c| c.id == conn_id || c.name.eq_ignore_ascii_case(conn_id))
-            .or_else(|| {
-                connections
-                    .iter()
-                    .find(|c| c.name.to_lowercase().contains(&conn_id.to_lowercase()))
-            })
-            .ok_or(JsonRpcError {
-                code: -32000,
-                message: format!("Connection not found: {}", conn_id),
-                data: None,
-            })?;
-
-        let params =
-            commands::resolve_connection_params(&conn.params).map_err(|e| JsonRpcError {
-                code: -32000,
-                message: e,
-                data: None,
-            })?;
-
-        let tables = match conn.params.driver.as_str() {
-            "mysql" => mysql::get_tables(&params, None).await,
-            "postgres" => postgres::get_tables(&params, "public").await,
-            "sqlite" => sqlite::get_tables(&params).await,
-            _ => Err("Unsupported driver".into()),
-        }
-        .map_err(|e| JsonRpcError {
-            code: -32000,
-            message: e,
-            data: None,
-        })?;
 
         // Format as simplified DDL or JSON
         let schema_json = serde_json::to_string_pretty(&tables).unwrap();
@@ -700,23 +730,22 @@ async fn tool_list_tables(
 
     audit.connection_id = Some(conn_id.to_string());
 
-    let (conn, db_params) = resolve_db_params(conn_id).await?;
+    let (conn, db_params, driver) = resolve_db_driver(conn_id).await?;
     audit.connection_name = Some(conn.name.clone());
 
-    let tables = match conn.params.driver.as_str() {
-        "mysql" => mysql::get_tables(&db_params, schema).await,
-        "postgres" => {
-            let s = schema.unwrap_or("public");
-            postgres::get_tables(&db_params, s).await
-        }
-        "sqlite" => sqlite::get_tables(&db_params).await,
-        _ => Err("Unsupported driver".into()),
-    }
-    .map_err(|e| JsonRpcError {
-        code: -32000,
-        message: e,
-        data: None,
-    })?;
+    let effective_schema = if conn.params.driver == "postgres" {
+        Some(schema.unwrap_or("public"))
+    } else {
+        schema
+    };
+    let tables = driver
+        .get_tables(&db_params, effective_schema)
+        .await
+        .map_err(|e| JsonRpcError {
+            code: -32000,
+            message: e,
+            data: None,
+        })?;
 
     let names: Vec<&str> = tables.iter().map(|t| t.name.as_str()).collect();
     audit.rows = Some(names.len());
@@ -752,37 +781,22 @@ async fn tool_describe_table(
 
     audit.connection_id = Some(conn_id.to_string());
 
-    let (conn, db_params) = resolve_db_params(conn_id).await?;
+    let (conn, db_params, driver) = resolve_db_driver(conn_id).await?;
     audit.connection_name = Some(conn.name.clone());
 
-    let (columns, foreign_keys, indexes) = match conn.params.driver.as_str() {
-        "mysql" => {
-            let cols = mysql::get_columns(&db_params, table_name, schema).await;
-            let fks = mysql::get_foreign_keys(&db_params, table_name, schema).await;
-            let idxs = mysql::get_indexes(&db_params, table_name, schema).await;
-            (cols, fks, idxs)
-        }
-        "postgres" => {
-            let s = schema.unwrap_or("public");
-            let cols = postgres::get_columns(&db_params, table_name, s).await;
-            let fks = postgres::get_foreign_keys(&db_params, table_name, s).await;
-            let idxs = postgres::get_indexes(&db_params, table_name, s).await;
-            (cols, fks, idxs)
-        }
-        "sqlite" => {
-            let cols = sqlite::get_columns(&db_params, table_name).await;
-            let fks = sqlite::get_foreign_keys(&db_params, table_name).await;
-            let idxs = sqlite::get_indexes(&db_params, table_name).await;
-            (cols, fks, idxs)
-        }
-        _ => {
-            return Err(JsonRpcError {
-                code: -32000,
-                message: "Unsupported driver".to_string(),
-                data: None,
-            })
-        }
+    let effective_schema = if conn.params.driver == "postgres" {
+        Some(schema.unwrap_or("public"))
+    } else {
+        schema
     };
+    // Run the three metadata fetches concurrently so a slow driver costs one
+    // round-trip's worth of latency, not three (and at most one call timeout
+    // rather than three sequential ones blocking the MCP request loop).
+    let (columns, foreign_keys, indexes) = tokio::join!(
+        driver.get_columns(&db_params, table_name, effective_schema),
+        driver.get_foreign_keys(&db_params, table_name, effective_schema),
+        driver.get_indexes(&db_params, table_name, effective_schema),
+    );
 
     let result = json!({
         "table": table_name,
@@ -832,7 +846,7 @@ async fn tool_run_query(
     let kind = ai_activity::classify_query_kind(query);
     audit.query_kind = Some(kind.to_string());
 
-    let (conn, db_params) = resolve_db_params(conn_id).await?;
+    let (conn, db_params, driver) = resolve_db_driver(conn_id).await?;
     audit.connection_name = Some(conn.name.clone());
 
     // Read-only enforcement (fail-closed: unknown counts as write).
@@ -991,21 +1005,14 @@ async fn tool_run_query(
         }
     }
 
-    let result = match conn.params.driver.as_str() {
-        "mysql" => {
-            mysql::execute_query(&db_params, &effective_query, Some(max_rows), 1, None).await
-        }
-        "postgres" => {
-            postgres::execute_query(&db_params, &effective_query, Some(max_rows), 1, None).await
-        }
-        "sqlite" => sqlite::execute_query(&db_params, &effective_query, Some(max_rows), 1).await,
-        _ => Err("Unsupported driver".into()),
-    }
-    .map_err(|e| JsonRpcError {
-        code: -32000,
-        message: e,
-        data: None,
-    })?;
+    let result = driver
+        .execute_query(&db_params, &effective_query, Some(max_rows), 1, None)
+        .await
+        .map_err(|e| JsonRpcError {
+            code: -32000,
+            message: e,
+            data: None,
+        })?;
 
     audit.rows = Some(result.rows.len());
 

--- a/src-tauri/src/mcp/preflight.rs
+++ b/src-tauri/src/mcp/preflight.rs
@@ -10,7 +10,7 @@
 
 use serde_json::Value;
 
-use crate::drivers::{mysql, postgres, sqlite};
+use crate::drivers::registry as driver_registry;
 use crate::models::ConnectionParams;
 
 /// Result of a pre-flight EXPLAIN attempt.
@@ -26,17 +26,16 @@ pub async fn preflight_explain(
     query: &str,
     schema: Option<&str>,
 ) -> PreflightOutcome {
-    let plan_result = match driver {
-        "postgres" => postgres::explain_query(params, query, false, schema).await,
-        "mysql" => mysql::explain_query(params, query, false, schema).await,
-        "sqlite" => sqlite::explain_query(params, query).await,
-        other => {
+    let registered = match driver_registry::get_driver(driver).await {
+        Some(d) => d,
+        None => {
             return PreflightOutcome {
                 plan: None,
-                error: Some(format!("EXPLAIN not supported for driver: {}", other)),
+                error: Some(format!("EXPLAIN not supported for driver: {}", driver)),
             };
         }
     };
+    let plan_result = registered.explain_query(params, query, false, schema).await;
 
     match plan_result {
         Ok(plan) => match serde_json::to_value(&plan) {

--- a/src-tauri/src/plugins/driver.rs
+++ b/src-tauri/src/plugins/driver.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use serde_json::{json, Value};
@@ -16,8 +17,26 @@ use crate::models::{
 };
 use crate::plugins::rpc::{JsonRpcRequest, JsonRpcResponse};
 
+/// Maximum time to wait for a plugin to answer a single JSON-RPC call before
+/// giving up. Generous enough for slow query execution, bounded so a wedged
+/// plugin cannot block the (single-threaded) MCP request loop forever.
+const PLUGIN_CALL_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Shorter ceiling for the startup `initialize` handshake so one unresponsive
+/// plugin cannot stall MCP server startup indefinitely.
+const PLUGIN_INIT_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Message sent to the management task that owns the plugin child process.
+enum PluginCommand {
+    /// Dispatch a JSON-RPC request and route the response back via the sender.
+    Call(JsonRpcRequest, oneshot::Sender<Result<Value, String>>),
+    /// Drop the pending entry for `id` because the caller stopped waiting
+    /// (timed out). Prevents an unbounded leak of orphaned response senders.
+    Cancel(u64),
+}
+
 pub struct PluginProcess {
-    sender: mpsc::Sender<(JsonRpcRequest, oneshot::Sender<Result<Value, String>>)>,
+    sender: mpsc::Sender<PluginCommand>,
     next_id: AtomicU64,
     shutdown_tx: tokio::sync::Mutex<Option<oneshot::Sender<()>>>,
     pub pid: Option<u32>,
@@ -25,8 +44,7 @@ pub struct PluginProcess {
 
 impl PluginProcess {
     async fn new(executable_path: PathBuf, interpreter: Option<String>) -> Result<Self, String> {
-        let (tx, rx) =
-            mpsc::channel::<(JsonRpcRequest, oneshot::Sender<Result<Value, String>>)>(100);
+        let (tx, rx) = mpsc::channel::<PluginCommand>(100);
         let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
 
         // Spawn the child process directly in the async context so that any
@@ -42,6 +60,12 @@ impl PluginProcess {
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::inherit())
+            // Kill the child if its owning task is dropped without a clean
+            // shutdown — e.g. when the `--mcp` subprocess exits on stdin EOF
+            // and the Tokio runtime is torn down. Without this, the management
+            // task is cancelled before its `select!` can call `child.kill()`,
+            // leaving orphaned plugin processes running.
+            .kill_on_drop(true)
             .spawn()
             .map_err(|e| {
                 format!(
@@ -75,7 +99,7 @@ impl PluginProcess {
                     }
                     msg = rx.recv() => {
                         match msg {
-                            Some((req, resp_tx)) => {
+                            Some(PluginCommand::Call(req, resp_tx)) => {
                                 let id = req.id;
                                 pending_requests.insert(id, resp_tx);
 
@@ -88,6 +112,11 @@ impl PluginProcess {
                                         let _ = tx.send(Err(format!("Plugin communication error: {}", e)));
                                     }
                                 }
+                            }
+                            Some(PluginCommand::Cancel(id)) => {
+                                // Caller timed out; drop the orphaned sender so
+                                // pending_requests does not grow without bound.
+                                pending_requests.remove(&id);
                             }
                             None => {
                                 // Channel closed without explicit shutdown — kill the process anyway.
@@ -147,6 +176,20 @@ impl PluginProcess {
     }
 
     async fn call(&self, method: &str, params: Value) -> Result<Value, String> {
+        self.call_with_timeout(method, params, PLUGIN_CALL_TIMEOUT)
+            .await
+    }
+
+    /// Sends a JSON-RPC request to the plugin and waits at most `timeout` for a
+    /// response. A hung or unresponsive plugin therefore fails this single call
+    /// instead of blocking the caller — and, in the single-threaded MCP request
+    /// loop, every subsequent request — forever.
+    async fn call_with_timeout(
+        &self,
+        method: &str,
+        params: Value,
+        timeout: Duration,
+    ) -> Result<Value, String> {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
         let req = JsonRpcRequest {
             jsonrpc: "2.0".to_string(),
@@ -157,12 +200,24 @@ impl PluginProcess {
 
         let (tx, rx) = oneshot::channel();
         self.sender
-            .send((req, tx))
+            .send(PluginCommand::Call(req, tx))
             .await
             .map_err(|_| "Plugin process channel closed".to_string())?;
 
-        rx.await
-            .map_err(|_| "Plugin process did not respond".to_string())?
+        match tokio::time::timeout(timeout, rx).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(_)) => Err("Plugin process did not respond".to_string()),
+            Err(_) => {
+                // Tell the management task to drop the now-orphaned pending
+                // entry so it does not leak one slot per timeout.
+                let _ = self.sender.send(PluginCommand::Cancel(id)).await;
+                Err(format!(
+                    "Plugin call '{}' timed out after {}s",
+                    method,
+                    timeout.as_secs()
+                ))
+            }
+        }
     }
 }
 
@@ -181,9 +236,16 @@ impl RpcDriver {
         settings: HashMap<String, serde_json::Value>,
     ) -> Result<Self, String> {
         let process = Arc::new(PluginProcess::new(executable_path, interpreter).await?);
-        // Send initialize RPC with settings; silently ignore any error or non-response.
+        // Send initialize RPC with settings; silently ignore any error or
+        // non-response. The short timeout keeps one unresponsive plugin from
+        // stalling startup (notably the standalone `--mcp` subprocess, which
+        // registers every plugin before serving any request).
         let _ = process
-            .call("initialize", json!({ "settings": settings }))
+            .call_with_timeout(
+                "initialize",
+                json!({ "settings": settings }),
+                PLUGIN_INIT_TIMEOUT,
+            )
             .await;
         Ok(Self {
             manifest,

--- a/src-tauri/src/plugins/manager.rs
+++ b/src-tauri/src/plugins/manager.rs
@@ -8,6 +8,7 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use tauri::AppHandle;
 
+use crate::config::PluginConfig;
 use crate::drivers::driver_trait::{DriverCapabilities, PluginManifest, PluginSettingDefinition};
 use crate::models::DataTypeInfo;
 use crate::plugins::driver::RpcDriver;
@@ -65,7 +66,16 @@ pub async fn load_plugins<R: tauri::Runtime>(app: &AppHandle<R>, enabled_ids: Op
     let plugin_configs = crate::config::load_config_internal(app)
         .plugins
         .unwrap_or_default();
+    load_plugins_with_configs(plugin_configs, enabled_ids).await;
+}
 
+/// Variant of [`load_plugins`] that takes plugin configs directly. Used by the
+/// standalone `--mcp` subprocess which has no Tauri `AppHandle` but needs to
+/// register the same drivers so MCP tools can reach plugin-driven connections.
+pub async fn load_plugins_with_configs(
+    plugin_configs: HashMap<String, PluginConfig>,
+    enabled_ids: Option<&[String]>,
+) {
     let proj_dirs = match ProjectDirs::from("com", "debba", "tabularis") {
         Some(d) => d,
         None => return,
@@ -145,6 +155,18 @@ pub async fn load_plugin_from_dir(
 
     let config: ConfigManifest = serde_json::from_str(&manifest_str)
         .map_err(|e| format!("Failed to parse plugin manifest {:?}: {}", manifest_path, e))?;
+
+    // Refuse plugins that claim a built-in driver id. Registration is a plain
+    // insert keyed by id, so otherwise a plugin with id "mysql"/"postgres"/
+    // "sqlite" would shadow the built-in driver and receive existing
+    // connections' resolved credentials.
+    const BUILTIN_DRIVER_IDS: [&str; 3] = ["mysql", "postgres", "sqlite"];
+    if BUILTIN_DRIVER_IDS.contains(&config.id.as_str()) {
+        return Err(format!(
+            "Plugin id '{}' collides with a built-in driver and was refused",
+            config.id
+        ));
+    }
 
     let manifest = PluginManifest {
         id: config.id,


### PR DESCRIPTION
## Summary

MCP could only reach built-in mysql/postgres/sqlite connections — every plugin-driven connection (Hacker News, Redis, …) failed with `Unsupported driver`. This routes all MCP driver operations through the shared driver registry (the same path the GUI uses) and registers the built-in + installed plugin drivers when the standalone `--mcp` subprocess starts.

Closes #255.

## What changed

- **Registry dispatch:** schema resource, `list_tables`, `describe_table`, `run_query`, and pre-flight `EXPLAIN` now resolve the driver via `registry::get_driver` instead of a hardcoded `match`.
- **Subprocess driver registration:** `--mcp` mode registers the three built-ins + installed plugins (`load_plugins_with_configs`), honoring `active_external_drivers`.

## Hardening surfaced by reaching plugins from MCP

- Bound plugin RPC calls with a timeout (120 s call / 15 s `initialize`) so a wedged plugin can't block the single-threaded request loop forever, and cancel the pending entry on timeout so it doesn't leak.
- `kill_on_drop` the plugin child so it isn't orphaned when the subprocess exits on stdin EOF.
- Refuse plugins that claim a built-in driver id (`mysql`/`postgres`/`sqlite`).
- Resolve `resources/read` through the keychain/SSH-aware path.
- Initialize the logger in `--mcp` mode (stderr only) so plugin-load errors are visible.
- Stop cleanly instead of panicking when a stdout write fails (BrokenPipe).
- Run `describe_table`'s column/FK/index fetches concurrently.

## Test plan

- [x] `cargo build` clean (no warnings) on latest `main`
- [x] `cargo test --lib plugins` passes
- [x] Verified end-to-end against a Hacker News plugin connection via the `--mcp` binary: `list_tables` → `["stories"]`, `run_query` → real rows, `resources/read` → schema (previously all `Unsupported driver`)
- [x] Confirmed no orphaned plugin process remains after the `--mcp` subprocess exits