### PR TITLE
New tabs DML (Data Manipulation Language)

### DIFF
--- a/src/components/modals/GenerateSQLModal.tsx
+++ b/src/components/modals/GenerateSQLModal.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { X, Loader2, Copy, Check, FileCode } from "lucide-react";
+import clsx from "clsx";
+import {X, Loader2, Copy, Check, FileCode, List, Table2, PenLine, Trash2, Play} from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
+import { useNavigate } from "react-router-dom";
 import { useDatabase } from "../../hooks/useDatabase";
 import { Modal } from "../ui/Modal";
 import { SqlPreview } from "../ui/SqlPreview";
@@ -25,9 +27,14 @@ export const GenerateSQLModal = ({
   tableName,
 }: GenerateSQLModalProps) => {
   const { t } = useTranslation();
-  const { activeConnectionId, activeDriver, activeSchema, activeCapabilities } = useDatabase();
+  const navigate = useNavigate();
+  const { activeConnectionId, activeDriver, activeSchema, activeCapabilities } =
+    useDatabase();
   const { showAlert } = useAlert();
+  type SqlTab = "create" | "select-all" | "select-fields" | "update" | "delete";
+  const [tab, setTab] = useState<SqlTab>("create");
   const [sql, setSql] = useState<string>("");
+  const [columns, setColumns] = useState<TableColumn[]>([]);
   const [loading, setLoading] = useState(false);
   const [copied, setCopied] = useState(false);
 
@@ -38,7 +45,7 @@ export const GenerateSQLModal = ({
       setLoading(true);
       try {
         const schemaParam = activeSchema ? { schema: activeSchema } : {};
-        const [columns, foreignKeys, indexes] = await Promise.all([
+        const [fetchedColumns, foreignKeys, indexes] = await Promise.all([
           invoke<TableColumn[]>("get_columns", {
             connectionId: activeConnectionId,
             tableName,
@@ -56,12 +63,13 @@ export const GenerateSQLModal = ({
           }),
         ]);
 
+        setColumns(fetchedColumns);
         const generatedSQL = generateCreateTableSQL(
           tableName,
-          columns,
+          fetchedColumns,
           foreignKeys,
           indexes,
-          activeCapabilities ?? 'sqlite',
+          activeCapabilities ?? "sqlite",
         );
         setSql(generatedSQL);
       } catch (err) {
@@ -73,10 +81,57 @@ export const GenerateSQLModal = ({
     };
 
     void generateSQL();
-  }, [isOpen, activeConnectionId, tableName, activeDriver, activeCapabilities, t, activeSchema, showAlert]);
+  }, [
+    isOpen,
+    activeConnectionId,
+    tableName,
+    activeDriver,
+    activeCapabilities,
+    t,
+    activeSchema,
+    showAlert,
+  ]);
+
+  const getTabSql = (currentTab: SqlTab): string => {
+    switch (currentTab) {
+      case "create":
+        return sql;
+      case "select-all":
+        return `SELECT *\nFROM ${tableName};`;
+      case "select-fields": {
+        if (columns.length === 0)
+          return `SELECT *\nFROM ${tableName}\nLIMIT 100;`;
+        const fields = columns.map((c) => `  ${c.name}`).join(",\n");
+        return `SELECT\n${fields}\nFROM ${tableName}\nLIMIT 100;`;
+      }
+      case "update": {
+        if (columns.length === 0)
+          return `UPDATE ${tableName}\nSET column = ?\nWHERE 1 = 0;`;
+        const setClauses = columns.map((c) => `  ${c.name} = ?`).join(",\n");
+        return `UPDATE ${tableName}\nSET\n${setClauses}\nWHERE 1 = 0;`;
+      }
+      case "delete":
+        return `DELETE\nFROM ${tableName}\nWHERE 1 = 0;`;
+    }
+  };
+
+  const displayedSql = getTabSql(tab);
+
+  const handleRunInConsole = () => {
+    navigate("/editor", {
+      state: {
+        initialQuery: displayedSql,
+        queryName: `${tableName} – ${tab}`,
+        undefined,
+        preventAutoRun: true,
+        schema: activeSchema ?? undefined
+      },
+    });
+    onClose();
+  };
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(sql);
+    await navigator.clipboard.writeText(displayedSql);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
@@ -104,6 +159,53 @@ export const GenerateSQLModal = ({
           </button>
         </div>
 
+        {/* Tabs */}
+        <div className="flex gap-1 border-b border-default px-6 overflow-x-auto">
+          {(
+            [
+              {
+                id: "create" as SqlTab,
+                icon: FileCode,
+                labelKey: "generateSQL.tabCreateTable",
+              },
+              {
+                id: "select-all" as SqlTab,
+                icon: List,
+                labelKey: "generateSQL.tabSelectAll",
+              },
+              {
+                id: "select-fields" as SqlTab,
+                icon: Table2,
+                labelKey: "generateSQL.tabSelectFields",
+              },
+              {
+                id: "update" as SqlTab,
+                icon: PenLine,
+                labelKey: "generateSQL.tabUpdate",
+              },
+              {
+                id: "delete" as SqlTab,
+                icon: Trash2,
+                labelKey: "generateSQL.tabDelete",
+              },
+            ] as const
+          ).map(({ id: tabId, icon: Icon, labelKey }) => (
+            <button
+              key={tabId}
+              onClick={() => setTab(tabId)}
+              className={clsx(
+                "flex items-center gap-2 px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors whitespace-nowrap",
+                tab === tabId
+                  ? "text-primary border-blue-500"
+                  : "text-muted border-transparent hover:text-primary",
+              )}
+            >
+              <Icon size={14} />
+              {t(labelKey)}
+            </button>
+          ))}
+        </div>
+
         {/* Content */}
         <div className="flex-1 p-6 overflow-hidden flex flex-col">
           {loading ? (
@@ -115,7 +217,7 @@ export const GenerateSQLModal = ({
             <div className="flex-1 flex flex-col gap-4">
               <div className="flex-1 overflow-hidden rounded-lg border border-default">
                 <SqlPreview
-                  sql={sql}
+                  sql={displayedSql}
                   height="100%"
                   showLineNumbers={true}
                   className="h-full"
@@ -128,6 +230,13 @@ export const GenerateSQLModal = ({
         {/* Footer */}
         {!loading && (
           <div className="p-4 border-t border-default bg-base/50 flex justify-end gap-3">
+            <button
+              onClick={handleRunInConsole}
+              className="px-4 py-2 bg-surface-secondary hover:bg-surface-tertiary text-secondary hover:text-primary border border-default rounded-lg text-sm font-medium transition-colors flex items-center gap-2"
+            >
+              <Play size={16} />
+              {t("generateSQL.runInConsole")}
+            </button>
             <button
               onClick={handleCopy}
               className="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg text-sm font-medium transition-colors flex items-center gap-2"

--- a/src/components/modals/GenerateSQLModal.tsx
+++ b/src/components/modals/GenerateSQLModal.tsx
@@ -14,6 +14,7 @@ import {
   type ForeignKey,
   type Index,
 } from "../../utils/sqlGenerator";
+import { toBindParamName } from "../../utils/queryParameters";
 
 interface GenerateSQLModalProps {
   isOpen: boolean;
@@ -106,8 +107,10 @@ export const GenerateSQLModal = ({
       }
       case "update": {
         if (columns.length === 0)
-          return `UPDATE ${tableName}\nSET column = ?\nWHERE 1 = 0;`;
-        const setClauses = columns.map((c) => `  ${c.name} = ?`).join(",\n");
+          return `UPDATE ${tableName}\nSET column = :column\nWHERE 1 = 0;`;
+        const setClauses = columns
+          .map((c) => `  ${c.name} = :${toBindParamName(c.name)}`)
+          .join(",\n");
         return `UPDATE ${tableName}\nSET\n${setClauses}\nWHERE 1 = 0;`;
       }
       case "delete":

--- a/src/components/ui/SqlPreview.tsx
+++ b/src/components/ui/SqlPreview.tsx
@@ -48,7 +48,6 @@ export const SqlPreview = ({
           lineNumbers: showLineNumbers ? "on" : "off",
           glyphMargin: false,
           folding: false,
-          lineDecorationsWidth: 0,
           lineNumbersMinChars: 5,
           scrollBeyondLastLine: false,
           automaticLayout: true,

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1001,8 +1001,14 @@
   "generateSQL": {
     "title": "Generiertes SQL: {{table}}",
     "loading": "SQL wird generiert...",
+    "runInConsole": "In Konsole ausführen",
     "copy": "SQL kopieren",
-    "copied": "Kopiert!"
+    "copied": "Kopiert!",
+    "tabCreateTable": "Tabelle erstellen",
+    "tabSelectAll": "SELECT *",
+    "tabSelectFields": "SELECT [Felder]",
+    "tabUpdate": "UPDATE",
+    "tabDelete": "DELETE"
   },
   "modifyColumn": {
     "titleAdd": "Spalte hinzufügen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1022,8 +1022,14 @@
   "generateSQL": {
     "title": "Generated SQL: {{table}}",
     "loading": "Generating SQL...",
+    "runInConsole": "Run in console",
     "copy": "Copy SQL",
-    "copied": "Copied!"
+    "copied": "Copied!",
+    "tabCreateTable": "Create Table",
+    "tabSelectAll": "Select *",
+    "tabSelectFields": "Select [fields]",
+    "tabUpdate": "Update",
+    "tabDelete": "Delete"
   },
   "modifyColumn": {
     "titleAdd": "Add Column",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -996,8 +996,14 @@
   "generateSQL": {
     "title": "SQL Generado: {{table}}",
     "loading": "Generando SQL...",
+    "runInConsole": "Ejecutar en consola",
     "copy": "Copiar SQL",
-    "copied": "¡Copiado!"
+    "copied": "¡Copiado!",
+    "tabCreateTable": "Crear Tabla",
+    "tabSelectAll": "Select *",
+    "tabSelectFields": "Select [campos]",
+    "tabUpdate": "Update",
+    "tabDelete": "Delete"
   },
   "modifyColumn": {
     "titleAdd": "Agregar Columna",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1001,8 +1001,14 @@
   "generateSQL": {
     "title": "SQL généré : {{table}}",
     "loading": "Génération du SQL...",
+    "runInConsole": "Exécuter dans la console",
     "copy": "Copier le SQL",
-    "copied": "Copié !"
+    "copied": "Copié !",
+    "tabCreateTable": "Créer une table",
+    "tabSelectAll": "SELECT *",
+    "tabSelectFields": "SELECT [champs]",
+    "tabUpdate": "UPDATE",
+    "tabDelete": "DELETE"
   },
   "modifyColumn": {
     "titleAdd": "Ajouter une colonne",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1003,8 +1003,14 @@
   "generateSQL": {
     "title": "SQL Generato: {{table}}",
     "loading": "Generazione SQL in corso...",
+    "runInConsole": "Esegui nella console",
     "copy": "Copia SQL",
-    "copied": "Copiato!"
+    "copied": "Copiato!",
+    "tabCreateTable": "Crea tabella",
+    "tabSelectAll": "SELECT *",
+    "tabSelectFields": "SELECT [campi]",
+    "tabUpdate": "UPDATE",
+    "tabDelete": "DELETE"
   },
   "modifyColumn": {
     "titleAdd": "Aggiungi Colonna",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1013,8 +1013,14 @@
   "generateSQL": {
     "title": "生成された SQL: {{table}}",
     "loading": "SQL を生成中...",
+    "runInConsole": "コンソールで実行",
     "copy": "SQL をコピー",
-    "copied": "コピーしました！"
+    "copied": "コピーしました！",
+    "tabCreateTable": "テーブル作成",
+    "tabSelectAll": "SELECT *",
+    "tabSelectFields": "SELECT [フィールド]",
+    "tabUpdate": "UPDATE",
+    "tabDelete": "DELETE"
   },
   "modifyColumn": {
     "titleAdd": "カラムを追加",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1006,8 +1006,14 @@
   "generateSQL": {
     "title": "Сгенерированный SQL: {{table}}",
     "loading": "Генерация SQL...",
+    "runInConsole": "Запустить в консоли",
     "copy": "Копировать SQL",
-    "copied": "Скопировано!"
+    "copied": "Скопировано!",
+    "tabCreateTable": "Создать таблицу",
+    "tabSelectAll": "SELECT *",
+    "tabSelectFields": "SELECT [поля]",
+    "tabUpdate": "UPDATE",
+    "tabDelete": "DELETE"
   },
   "modifyColumn": {
     "titleAdd": "Добавить столбец",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -951,8 +951,14 @@
   "generateSQL": {
     "title": "生成的 SQL：{{table}}",
     "loading": "生成 SQL 中...",
+    "runInConsole": "在控制台中运行",
     "copy": "复制 SQL",
-    "copied": "已复制！"
+    "copied": "已复制！",
+    "tabCreateTable": "创建表",
+    "tabSelectAll": "SELECT *",
+    "tabSelectFields": "SELECT [字段]",
+    "tabUpdate": "UPDATE",
+    "tabDelete": "DELETE"
   },
   "modifyColumn": {
     "titleAdd": "添加列",

--- a/src/utils/queryParameters.ts
+++ b/src/utils/queryParameters.ts
@@ -1,3 +1,19 @@
+/**
+ * Converts an arbitrary identifier (e.g. a column name) into a valid named
+ * bind-parameter name compatible with the editor's `:param` syntax.
+ * The result always matches /^[a-zA-Z_][a-zA-Z0-9_]*$/, so that
+ * extractQueryParams / interpolateQueryParams recognise it.
+ */
+export const toBindParamName = (name: string): string => {
+  // Replace every character that is not a letter, digit or underscore.
+  const sanitized = name.replace(/[^a-zA-Z0-9_]/g, "_");
+  // A bind-parameter name must start with a letter or underscore, never a digit.
+  if (sanitized === "" || /^[0-9]/.test(sanitized)) {
+    return `_${sanitized}`;
+  }
+  return sanitized;
+};
+
 export const extractQueryParams = (sql: string): string[] => {
   if (!sql) return [];
   // Matches :paramName but ignores ::cast (Postgres)

--- a/tests/utils/queryParameters.test.ts
+++ b/tests/utils/queryParameters.test.ts
@@ -1,7 +1,39 @@
 import { describe, it, expect } from 'vitest';
-import { extractQueryParams, interpolateQueryParams } from '../../src/utils/queryParameters';
+import { extractQueryParams, interpolateQueryParams, toBindParamName } from '../../src/utils/queryParameters';
 
 describe('queryParameters', () => {
+  describe('toBindParamName', () => {
+    it('should keep valid identifiers unchanged', () => {
+      expect(toBindParamName('user_id')).toBe('user_id');
+      expect(toBindParamName('email')).toBe('email');
+    });
+
+    it('should replace spaces and special characters with underscores', () => {
+      expect(toBindParamName('user name')).toBe('user_name');
+      expect(toBindParamName('email-address')).toBe('email_address');
+      expect(toBindParamName('order.total')).toBe('order_total');
+    });
+
+    it('should prefix identifiers starting with a digit', () => {
+      expect(toBindParamName('123')).toBe('_123');
+      expect(toBindParamName('2nd_column')).toBe('_2nd_column');
+    });
+
+    it('should handle empty input', () => {
+      expect(toBindParamName('')).toBe('_');
+    });
+
+    it('should always produce an editor-recognised :param name', () => {
+      const pattern = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+      for (const name of ['user name', '123', '', 'a-b-c', 'données', '€']) {
+        const param = toBindParamName(name);
+        expect(param).toMatch(pattern);
+        // The generated name must round-trip through the editor's extractor.
+        expect(extractQueryParams(`SELECT * FROM t WHERE c = :${param}`)).toEqual([param]);
+      }
+    });
+  });
+
   describe('extractQueryParams', () => {
     it('should extract simple parameters', () => {
       const sql = 'SELECT * FROM users WHERE id = :id AND name = :name';


### PR DESCRIPTION
**Summary**
I've added new tabs for the SQL commands, placing them in the context menu of the Generate SQL tool: They are SELECT *, SELECT [fields], UPDATE, and DELETE.

The changes are located in the same Generate SQL modal.
<img width="952" height="851" alt="image" src="https://github.com/user-attachments/assets/0f7ac463-1f71-42d4-82ba-d158590a23dd" />

**Changes:**
1. I added tabs for each stamment
2. I've added the "Run in Console" option button, copied from your code, which I found earlier.
3. I added the translation keys to all the localization files (en, es, de, fr, it, ja, ru, zh). Were added to each `generateSQL` 
section: Keys: The `tabCreateTable`, `tabSelectAll`, `tabSelectFields`, `tabUpdate`, `tabDelete` and `runInConsole`

**The result are:**
1. The tabs are funcionality
<img width="569" height="591" alt="image" src="https://github.com/user-attachments/assets/4c2db84c-b667-4d90-bc6f-345421970a57" />

2. Click button: Run in console
<img width="391" height="126" alt="image" src="https://github.com/user-attachments/assets/d50081d4-dc2a-45f9-909a-6589d24196fa" />

3. It creates the navigation with sql statemment 
<img width="406" height="665" alt="image" src="https://github.com/user-attachments/assets/368cc106-2cdd-4853-9849-34cfb2bebb18" />

Coded in Manjaro Linux.

I hope you add it to the repository. These are features that were missing and are very useful.
Thanks.

Ps. I used AI because I'm new to React. But I did run the necessary tests.
