### PR TITLE
fix(mcp): close approval/read-only bypass in run_query

### DIFF
--- a/src-tauri/src/ai_activity.rs
+++ b/src-tauri/src/ai_activity.rs
@@ -360,6 +360,24 @@ pub fn classify_query_kind(sql: &str) -> &'static str {
     if trimmed.is_empty() {
         return "unknown";
     }
+    // Fail closed for multi-statement payloads: a leading `SELECT 1; DROP …`
+    // must NOT be tagged as a clean read just because the first keyword is
+    // SELECT — the read-only and approval gates rely on this classification.
+    //
+    // SQL dialects disagree on backslash escaping inside string literals:
+    // MySQL/MariaDB treat `\'` as an escaped quote by default, while
+    // PostgreSQL standard-conforming strings treat `\` as a literal byte.
+    // That disagreement shifts where a string literal ends, and therefore
+    // where a `;` becomes a visible statement separator — e.g. MySQL reads
+    // `SELECT '\''; DROP TABLE users` as two statements, the standard reading
+    // as one. We strip under both interpretations and fail closed if EITHER
+    // reveals a trailing statement, so a payload cannot hide an injected
+    // separator by exploiting whichever dialect we happen not to assume.
+    if has_trailing_statements(&stripped)
+        || has_trailing_statements(&strip_impl(sql, true))
+    {
+        return "unknown";
+    }
     let upper = trimmed.to_uppercase();
     let first = first_keyword(&upper);
 
@@ -372,6 +390,26 @@ pub fn classify_query_kind(sql: &str) -> &'static str {
         "WITH" => classify_cte(&upper),
         _ => "unknown",
     }
+}
+
+/// Returns true when `stripped` contains a semicolon followed by additional
+/// non-whitespace SQL content — i.e., more than one statement.
+///
+/// The input must already have been run through `strip_impl`, which replaces
+/// string-literal, comment, and quoted-identifier bytes with whitespace, so
+/// any `;` that survives here is a real statement terminator under the
+/// escaping interpretation used to produce `stripped`.
+fn has_trailing_statements(stripped: &str) -> bool {
+    let mut found_semi = false;
+    for c in stripped.chars() {
+        if found_semi && !c.is_whitespace() {
+            return true;
+        }
+        if c == ';' {
+            found_semi = true;
+        }
+    }
+    false
 }
 
 fn first_keyword(upper: &str) -> String {
@@ -420,7 +458,22 @@ fn contains_keyword(haystack: &str, needle: &str) -> bool {
 /// Replace string literals and SQL comments with whitespace so keyword
 /// scanning cannot be fooled by tokens that live inside a value, comment,
 /// or quoted identifier.
+///
+/// Uses the SQL-standard reading of single-quoted strings (only `''` escapes
+/// a quote). For the backslash-aware reading used to harden multi-statement
+/// detection against MySQL-style escaping, see [`strip_impl`].
 pub fn strip_strings_and_comments(sql: &str) -> String {
+    strip_impl(sql, false)
+}
+
+/// Backing implementation for [`strip_strings_and_comments`].
+///
+/// When `backslash_escapes` is true, a `\` inside a single-quoted string
+/// escapes the following byte (MySQL/MariaDB default). When false, backslash
+/// is an ordinary literal byte (SQL standard / PostgreSQL standard strings).
+/// Only single-quoted string scanning honours the flag — comments and quoted
+/// identifiers are dialect-independent here.
+fn strip_impl(sql: &str, backslash_escapes: bool) -> String {
     let bytes = sql.as_bytes();
     let mut out = Vec::with_capacity(bytes.len());
     let mut i = 0;
@@ -460,7 +513,13 @@ pub fn strip_strings_and_comments(sql: &str) -> String {
             out.push(b' ');
             i += 1;
             while i < bytes.len() {
-                if bytes[i] == b'\'' && i + 1 < bytes.len() && bytes[i + 1] == b'\'' {
+                if backslash_escapes && bytes[i] == b'\\' && i + 1 < bytes.len() {
+                    // MySQL-style backslash escape: the next byte is part of
+                    // the string regardless of what it is (including `'`).
+                    out.push(b' ');
+                    out.push(b' ');
+                    i += 2;
+                } else if bytes[i] == b'\'' && i + 1 < bytes.len() && bytes[i + 1] == b'\'' {
                     out.push(b' ');
                     out.push(b' ');
                     i += 2;

--- a/src-tauri/src/ai_activity_tests.rs
+++ b/src-tauri/src/ai_activity_tests.rs
@@ -474,6 +474,94 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Multi-statement payloads must NOT be tagged as a clean select just
+    // because the leading keyword is SELECT. The read-only / approval gates
+    // rely on `kind != "select"` to fail closed.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn classify_select_then_drop_is_unknown() {
+        assert_eq!(
+            classify_query_kind("SELECT 1; DROP TABLE users;"),
+            "unknown"
+        );
+    }
+
+    #[test]
+    fn classify_select_then_delete_is_unknown() {
+        assert_eq!(
+            classify_query_kind("SELECT * FROM t; DELETE FROM t WHERE id = 1"),
+            "unknown"
+        );
+    }
+
+    #[test]
+    fn classify_select_then_update_is_unknown() {
+        assert_eq!(
+            classify_query_kind("SELECT 1;\nUPDATE accounts SET balance = 0"),
+            "unknown"
+        );
+    }
+
+    #[test]
+    fn classify_trailing_semicolon_keeps_kind() {
+        // A single statement with a trailing `;` is still that kind — the
+        // multi-statement gate only fires when content follows the semicolon.
+        assert_eq!(classify_query_kind("SELECT 1;"), "select");
+        assert_eq!(classify_query_kind("UPDATE t SET x = 1;"), "write");
+        assert_eq!(classify_query_kind("DROP TABLE t;  "), "ddl");
+    }
+
+    #[test]
+    fn classify_semicolon_inside_string_is_single_statement() {
+        // Semicolons inside literals are stripped before scanning, so the
+        // query is still a clean SELECT.
+        assert_eq!(
+            classify_query_kind("SELECT ';DROP TABLE users;' FROM dual"),
+            "select"
+        );
+    }
+
+    #[test]
+    fn classify_semicolon_inside_comment_is_single_statement() {
+        assert_eq!(
+            classify_query_kind("SELECT 1 /* ; DROP TABLE u */ FROM dual"),
+            "select"
+        );
+        assert_eq!(
+            classify_query_kind("SELECT 1 -- ; DROP TABLE u\nFROM dual"),
+            "select"
+        );
+    }
+
+    #[test]
+    fn classify_mysql_backslash_escape_cannot_hide_separator() {
+        // MySQL/MariaDB read `'\''` as the one-character string `'`, so the
+        // `;` that follows is a real statement separator. Under the SQL-
+        // standard reading the `''` would be an escaped quote and the `;`
+        // would stay inside the string. We fail closed to the multi-statement
+        // interpretation so neither dialect can smuggle a write past the gate.
+        assert_eq!(
+            classify_query_kind("SELECT '\\''; DROP TABLE users"),
+            "unknown"
+        );
+        assert_eq!(
+            classify_query_kind("SELECT '\\'; DELETE FROM accounts"),
+            "unknown"
+        );
+    }
+
+    #[test]
+    fn classify_escaped_quote_boundary_is_single_statement() {
+        // `''` is a real escaped quote here, so the `;` lives inside the
+        // literal and the query stays a clean SELECT under both readings.
+        assert_eq!(
+            classify_query_kind("SELECT 'it''s; DROP' FROM dual"),
+            "select"
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // Session state / compute_or_rotate_session_id
     // -----------------------------------------------------------------------
 

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -949,7 +949,28 @@ async fn tool_run_query(
                         .map(str::trim)
                         .filter(|s| !s.is_empty())
                     {
+                        // Re-classify and re-enforce read-only on the edited
+                        // query. Without this, an approver can flip a benign
+                        // SELECT into a DELETE/DROP (or a multi-statement
+                        // payload) and slip past the gate that runs against
+                        // the *original* query above.
                         effective_query = edited.to_string();
+                        let new_kind = ai_activity::classify_query_kind(&effective_query);
+                        audit.query = Some(effective_query.clone());
+                        audit.query_kind = Some(new_kind.to_string());
+
+                        if config::is_connection_readonly(config, &conn.id)
+                            && new_kind != "select"
+                        {
+                            audit.status = "blocked_readonly".to_string();
+                            let msg = "Edited query blocked by Tabularis read-only mode. Enable writes for this connection in Settings → MCP → Read-only mode.".to_string();
+                            audit.error = Some(msg.clone());
+                            return Err(JsonRpcError {
+                                code: -32000,
+                                message: msg,
+                                data: None,
+                            });
+                        }
                     }
                 } else {
                     let reason = decision


### PR DESCRIPTION
## Summary

The MCP `run_query` approval/read-only gates classify a query by its **leading keyword**, so a stacked payload such as `SELECT 1; DROP TABLE users` was tagged as a clean read (`select`) and slipped past **both** the read-only gate and the approval gate. Separately, when an approver edited an approved query before confirming, the edit was executed **without being re-classified** — so an approved `SELECT` could be flipped into a `DELETE`/`DROP`.

This PR makes the classifier fail closed on multi-statement payloads and re-enforces the gates on the approver-edited query.

## The bypass

1. **Multi-statement payload** — `classify_query_kind("SELECT 1; DROP TABLE users")` returned `"select"` because only the first keyword was inspected. Both gates rely on `kind != "select"` to block, so the write reached the driver.
2. **Approver-edited query** — on approval, `edited_query` replaced the original query but the original `kind` was kept, so read-only was never re-checked against what actually runs.

## Changes

- **`ai_activity.rs`** — `classify_query_kind` now returns `"unknown"` (fail closed) when a `;` is followed by more SQL. String literals are stripped under **both** the SQL-standard (`''`) and MySQL backslash-escape (`\'`) readings, and a trailing statement under *either* reading trips the gate — so a payload can't hide a `;` separator by exploiting whichever dialect we don't assume (e.g. `SELECT '\''; DROP TABLE users`).
- **`mcp/mod.rs`** — `tool_run_query` re-classifies the approver-edited query and re-applies the read-only gate before execution, updating the audit record with the effective query/kind.

## Test plan

- [x] `cargo test --lib ai_activity` — 54 passing, incl. new cases:
  - `SELECT 1; DROP …` / `…; DELETE …` / `…; UPDATE …` → `unknown`
  - MySQL `'\''; DROP …` cannot hide the separator → `unknown`
  - legitimate `;` inside string literals / comments / `''` escape boundary → stays `select`
  - single trailing `;` keeps its kind
- [x] `cargo check --lib` clean

## Notes

Rebased on current `main` (incl. #256). The execution layer's prepared-statement protocol already rejected most stacked queries, but the classifier is the documented fail-closed gate — this restores that contract.