### PR TITLE
fix(sqlserver): add missing triggers capability field

### DIFF
--- a/src-tauri/src/drivers/sqlserver/mod.rs
+++ b/src-tauri/src/drivers/sqlserver/mod.rs
@@ -64,6 +64,7 @@ impl SqlServerDriver {
                     no_connection_required: false,
                     manage_tables: true,
                     readonly: false,
+                    triggers: false,
                 },
                 is_builtin: true,
                 default_username: "sa".to_string(),


### PR DESCRIPTION
Fixes a build break introduced when `main` was synced into `feat/sql-server`.

## Problem

Commit [3aea073](https://github.com/TabularisDB/tabularis/commit/3aea073) merged the trigger management feature ([#fd66558](https://github.com/TabularisDB/tabularis/commit/fd66558)), which added a required `triggers: bool` field to `DriverCapabilities`. SQLite, MySQL, and PostgreSQL drivers were updated as part of that merge — the SQL Server driver was missed.

Result: `feat/sql-server` fails to compile with:

```
error[E0063]: missing field `triggers` in initializer of `DriverCapabilities`
  --> src/drivers/sqlserver/mod.rs:47:30
```

## Fix

Add `triggers: false` to the SQL Server `DriverCapabilities` initializer. Trigger management on SQL Server is not yet wired up — the capability is opted out, matching the pre-merge behaviour of the feature on other drivers that don''t support it yet.

## Verification

- `cargo build` succeeds.
- `cargo test --lib drivers::sqlserver` — all unit tests pass.
- App builds and launches via `pnpm tauri dev`; SQL Server driver registers as expected.

## Out of scope

Originally this branch also carried ALTER COLUMN / ADD COLUMN DDL preview support and a couple of follow-up fixes around TDS protocol-state drain. Those have been split out and are being reworked separately — this PR is now focused exclusively on unblocking the build.