### PR TITLE
fix(ai): cache AI key reads to stop repeated Keychain prompts on the AI tab

### DIFF
--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -285,7 +285,7 @@ pub async fn get_ai_models(
                 // Always refresh custom-openai as it depends on user configuration
                 if let (Some(base_url), Ok(api_key)) = (
                     app_config.ai_custom_openai_url.clone(),
-                    config::get_ai_api_key("custom-openai"),
+                    config::get_ai_api_key(&app, "custom-openai"),
                 ) {
                     if !base_url.is_empty() && !api_key.is_empty() {
                         let custom_models = fetch_custom_openai_models(&base_url, &api_key).await;
@@ -311,7 +311,7 @@ pub async fn get_ai_models(
     }
 
     // 2. OpenAI (Dynamic if key exists)
-    if let Ok(key) = config::get_ai_api_key("openai") {
+    if let Ok(key) = config::get_ai_api_key(&app, "openai") {
         let remote_models = fetch_openai_models(&key).await;
         if !remote_models.is_empty() {
             if let Some(static_list) = models.get_mut("openai") {
@@ -342,7 +342,7 @@ pub async fn get_ai_models(
     // 4. Custom OpenAI (Dynamic if configured)
     if let (Some(base_url), Ok(api_key)) = (
         app_config.ai_custom_openai_url,
-        config::get_ai_api_key("custom-openai"),
+        config::get_ai_api_key(&app, "custom-openai"),
     ) {
         if !base_url.is_empty() && !api_key.is_empty() {
             let custom_models = fetch_custom_openai_models(&base_url, &api_key).await;
@@ -424,13 +424,14 @@ async fn resolve_model(
 }
 
 async fn dispatch_provider(
+    app: &AppHandle,
     app_config: &config::AppConfig,
     gen_req: &AiGenerateRequest,
     system_prompt: &str,
     ollama_port: u16,
 ) -> Result<String, String> {
     let api_key = if gen_req.provider != "ollama" {
-        config::get_ai_api_key(&gen_req.provider)?
+        config::get_ai_api_key(app, &gen_req.provider)?
     } else {
         String::new()
     };
@@ -463,10 +464,10 @@ pub async fn generate_query(app: AppHandle, mut req: AiGenerateRequest) -> Resul
     let ollama_port = app_config.ai_ollama_port.unwrap_or(11434);
     req.model = resolve_model(&req.provider, &req.model, &app_config, ollama_port).await?;
 
-    let raw_prompt = config::get_system_prompt(app);
+    let raw_prompt = config::get_system_prompt(app.clone());
     let system_prompt = raw_prompt.replace("{{SCHEMA}}", &req.schema);
 
-    let result = dispatch_provider(&app_config, &req, &system_prompt, ollama_port).await;
+    let result = dispatch_provider(&app, &app_config, &req, &system_prompt, ollama_port).await;
 
     match &result {
         Ok(_) => log::info!("AI query generated successfully using {}", req.model),
@@ -483,7 +484,7 @@ pub async fn explain_query(app: AppHandle, mut req: AiExplainRequest) -> Result<
     let ollama_port = app_config.ai_ollama_port.unwrap_or(11434);
     req.model = resolve_model(&req.provider, &req.model, &app_config, ollama_port).await?;
 
-    let raw_prompt = config::get_explain_prompt(app);
+    let raw_prompt = config::get_explain_prompt(app.clone());
     let system_prompt = raw_prompt.replace("{{LANGUAGE}}", &req.language);
 
     let gen_req = AiGenerateRequest {
@@ -493,7 +494,7 @@ pub async fn explain_query(app: AppHandle, mut req: AiExplainRequest) -> Result<
         schema: String::new(),
     };
 
-    let result = dispatch_provider(&app_config, &gen_req, &system_prompt, ollama_port).await;
+    let result = dispatch_provider(&app, &app_config, &gen_req, &system_prompt, ollama_port).await;
 
     match &result {
         Ok(_) => log::info!(
@@ -516,7 +517,7 @@ pub async fn analyze_explain_plan(
     let ollama_port = app_config.ai_ollama_port.unwrap_or(11434);
     req.model = resolve_model(&req.provider, &req.model, &app_config, ollama_port).await?;
 
-    let raw_prompt = config::get_explainplan_prompt(app);
+    let raw_prompt = config::get_explainplan_prompt(app.clone());
     let system_prompt = raw_prompt.replace("{{LANGUAGE}}", &req.language);
 
     let gen_req = AiGenerateRequest {
@@ -526,7 +527,7 @@ pub async fn analyze_explain_plan(
         schema: String::new(),
     };
 
-    let result = dispatch_provider(&app_config, &gen_req, &system_prompt, ollama_port).await;
+    let result = dispatch_provider(&app, &app_config, &gen_req, &system_prompt, ollama_port).await;
 
     match &result {
         Ok(_) => log::info!(
@@ -553,7 +554,7 @@ async fn generate_with_simple_prompt(
     let ollama_port = app_config.ai_ollama_port.unwrap_or(11434);
     let resolved_model = resolve_model(&provider, &model, &app_config, ollama_port).await?;
 
-    let system_prompt = get_prompt(app);
+    let system_prompt = get_prompt(app.clone());
 
     let gen_req = AiGenerateRequest {
         provider: provider.clone(),
@@ -562,7 +563,7 @@ async fn generate_with_simple_prompt(
         schema: String::new(),
     };
 
-    let result = dispatch_provider(&app_config, &gen_req, &system_prompt, ollama_port).await;
+    let result = dispatch_provider(&app, &app_config, &gen_req, &system_prompt, ollama_port).await;
 
     match &result {
         Ok(v) => log::info!("{} generated: {}", label, v),
@@ -617,7 +618,7 @@ pub async fn suggest_table_name(
     };
 
     let system_prompt = "You are a database naming expert. Reply with only a snake_case table name, no explanation.";
-    let result = dispatch_provider(&app_config, &gen_req, system_prompt, ollama_port).await;
+    let result = dispatch_provider(&app, &app_config, &gen_req, system_prompt, ollama_port).await;
 
     match &result {
         Ok(name) => {

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -410,13 +410,21 @@ pub fn set_selected_schemas(
 }
 
 #[tauri::command]
-pub fn set_ai_key(provider: String, key: String) -> Result<(), String> {
-    keychain_utils::set_ai_key(&provider, &key)
+pub fn set_ai_key(app: AppHandle, provider: String, key: String) -> Result<(), String> {
+    keychain_utils::set_ai_key(&provider, &key)?;
+    // Write-through so subsequent reads avoid hitting the keychain (and its prompt).
+    let cache = app.state::<std::sync::Arc<crate::credential_cache::CredentialCache>>();
+    crate::credential_cache::set_ai_key_cached(&cache, &provider, &key);
+    Ok(())
 }
 
 #[tauri::command]
-pub fn delete_ai_key(provider: String) -> Result<(), String> {
-    keychain_utils::delete_ai_key(&provider)
+pub fn delete_ai_key(app: AppHandle, provider: String) -> Result<(), String> {
+    keychain_utils::delete_ai_key(&provider)?;
+    // Drop the cached value so the next read reflects the deletion.
+    let cache = app.state::<std::sync::Arc<crate::credential_cache::CredentialCache>>();
+    crate::credential_cache::invalidate_ai_key(&cache, &provider);
+    Ok(())
 }
 
 /// Get the configured maximum BLOB size in bytes, or DEFAULT_MAX_BLOB_SIZE if not set
@@ -427,9 +435,12 @@ pub fn get_max_blob_size<R: tauri::Runtime>(app: &AppHandle<R>) -> u64 {
         .unwrap_or(crate::drivers::common::DEFAULT_MAX_BLOB_SIZE)
 }
 
-pub fn get_ai_api_key(provider: &str) -> Result<String, String> {
-    // 1. Try Keychain First (Override)
-    if let Ok(key) = keychain_utils::get_ai_key(provider) {
+pub fn get_ai_api_key(app: &AppHandle, provider: &str) -> Result<String, String> {
+    // 1. Try Keychain First (Override) — via the in-memory credential cache so
+    //    repeated lookups don't trigger a macOS Keychain authorization prompt
+    //    each time. The keychain is read at most once per provider per session.
+    let cache = app.state::<std::sync::Arc<crate::credential_cache::CredentialCache>>();
+    if let Ok(key) = crate::credential_cache::get_ai_key_cached(&cache, provider) {
         if !key.is_empty() {
             return Ok(key);
         }
@@ -466,9 +477,10 @@ pub struct AiKeyStatus {
     pub from_env: bool,
 }
 
-pub fn get_ai_api_key_status(provider: &str) -> AiKeyStatus {
-    // 1. Check Keychain
-    let keychain_exists = keychain_utils::get_ai_key(provider).is_ok();
+pub fn get_ai_api_key_status(app: &AppHandle, provider: &str) -> AiKeyStatus {
+    // 1. Check Keychain (through the cache to avoid repeated auth prompts)
+    let cache = app.state::<std::sync::Arc<crate::credential_cache::CredentialCache>>();
+    let keychain_exists = crate::credential_cache::get_ai_key_cached(&cache, provider).is_ok();
 
     // 2. Check Env Var
     let env_var = match provider {
@@ -511,13 +523,13 @@ pub fn get_ai_api_key_status(provider: &str) -> AiKeyStatus {
 }
 
 #[tauri::command]
-pub fn check_ai_key(provider: String) -> bool {
-    get_ai_api_key(&provider).is_ok()
+pub fn check_ai_key(app: AppHandle, provider: String) -> bool {
+    get_ai_api_key(&app, &provider).is_ok()
 }
 
 #[tauri::command]
-pub fn check_ai_key_status(provider: String) -> AiKeyStatus {
-    get_ai_api_key_status(&provider)
+pub fn check_ai_key_status(app: AppHandle, provider: String) -> AiKeyStatus {
+    get_ai_api_key_status(&app, &provider)
 }
 
 const DEFAULT_SYSTEM_PROMPT: &str = "You are an expert SQL assistant. Your task is to generate a SQL query based on the user's request and the provided database schema.\nReturn ONLY the SQL query, without any markdown formatting, explanations, or code blocks.\n\nSchema:\n{{SCHEMA}}";

--- a/src-tauri/src/credential_cache.rs
+++ b/src-tauri/src/credential_cache.rs
@@ -130,18 +130,22 @@ pub fn get_ai_key_cached(cache: &CredentialCache, provider: &str) -> Result<Stri
             None => {}
         }
     }
-    let result = crate::keychain_utils::get_ai_key(provider);
-    {
-        let mut guard = cache.ai_keys.lock().unwrap();
-        guard.insert(
-            provider.to_string(),
-            match &result {
-                Ok(v) => CacheEntry::Present(v.clone()),
-                Err(_) => CacheEntry::Absent,
-            },
-        );
+    match crate::keychain_utils::get_ai_key(provider) {
+        // A value, or a definitive miss (NoEntry): both are safe to memoize so
+        // we never re-prompt for this provider again this session.
+        Ok(maybe) => {
+            let entry = match &maybe {
+                Some(v) => CacheEntry::Present(v.clone()),
+                None => CacheEntry::Absent,
+            };
+            cache.ai_keys.lock().unwrap().insert(provider.to_string(), entry);
+            maybe.ok_or_else(|| "No entry".to_string())
+        }
+        // Transient failure (denied prompt, timeout, securityd error): do NOT
+        // cache, so the next read retries the keychain instead of pinning the
+        // key as permanently absent.
+        Err(e) => Err(e),
     }
-    result
 }
 
 // ─── Write-through helpers ────────────────────────────────────────────────────

--- a/src-tauri/src/keychain_utils.rs
+++ b/src-tauri/src/keychain_utils.rs
@@ -159,14 +159,22 @@ pub fn set_ai_key(provider: &str, key: &str) -> Result<(), String> {
     })
 }
 
-pub fn get_ai_key(provider: &str) -> Result<String, String> {
+/// Read an AI key from the keychain.
+///
+/// Returns `Ok(Some(key))` when present, `Ok(None)` when the keychain
+/// definitively has no such entry (`NoEntry`), and `Err` only for genuine /
+/// transient failures (access denied, prompt timeout, securityd error, ...).
+/// Distinguishing the two lets the cache layer avoid storing a transient
+/// failure as a permanent "absent" — which would otherwise make a configured
+/// key appear missing until the app restarts.
+pub fn get_ai_key(provider: &str) -> Result<Option<String>, String> {
     #[cfg(debug_assertions)]
     log::info!("[Keychain] Getting AI key for {}", provider);
     let entry =
         Entry::new(SERVICE_NAME, &format!("ai_key:{}", provider)).map_err(|e| e.to_string())?;
     match entry.get_password() {
-        Ok(pwd) => Ok(pwd),
-        Err(keyring::Error::NoEntry) => Err("No key found".to_string()),
+        Ok(pwd) => Ok(Some(pwd)),
+        Err(keyring::Error::NoEntry) => Ok(None),
         Err(e) => {
             eprintln!("[Keychain] Error getting AI key for {}: {}", provider, e);
             Err(e.to_string())


### PR DESCRIPTION
## Problem

Opening the **AI** settings tab repeatedly triggers the macOS Keychain
authorization prompt. A single tab open issues 8+ keychain reads:

- `SettingsProvider` calls `check_ai_key` per provider on mount
- `AiTab` calls `check_ai_key_status` per provider on mount
- `get_ai_models` reads the OpenAI / custom-openai keys

Each call hit `keychain_utils::get_ai_key` directly, so the keychain was
read on every render.

## Fix

`ca2e668` already added `CredentialCache` (with `get_ai_key_cached` /
`set_ai_key_cached` / `invalidate_ai_key`) to "cache db/ssh/ai creds",
but the AI read paths were never wired to it. This PR completes that:

- **config**: `get_ai_api_key` / `get_ai_api_key_status` read through the
  cache; `check_ai_key` / `check_ai_key_status` / `set_ai_key` /
  `delete_ai_key` take `AppHandle` to reach the managed cache state
  (write-through on set, invalidate on delete).
- **ai**: `&AppHandle` threaded through `dispatch_provider` and
  `get_ai_models`.

Result: the keychain is read **at most once per provider per session**,
matching how DB/SSH credentials already behave. Repeated prompts on tab
open are gone.

### Bonus: transient-error robustness

`keychain_utils::get_ai_key` now returns `Result<Option<String>, String>`
so the cache only records "absent" on a definitive `NoEntry`. Previously
a denied/timed-out prompt was cached as permanent absence, making a
configured key appear missing until the app restarted.

## Notes

- **No frontend changes**: Tauri injects `AppHandle`, so the existing
  `invoke(...)` call sites are unchanged.
- DB/SSH keychain readers still use `Result<String, String>` and conflate
  `NoEntry` with real errors; adopting the `Option` shape there is a
  sensible follow-up, out of scope here.

## Test plan

- [x] `cargo check --tests` passes
- [ ] Open the AI settings tab → no repeated Keychain prompts
- [ ] Set / delete an AI key → status updates without restart
- [ ] Generate / explain / model-list still works per provider
