### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ You can override or add custom models for AI providers by editing `config.json` 
   "aiCustomModels": {
     "openai": ["gpt-4o", "gpt-4-turbo", "gpt-3.5-turbo", "gpt-5-preview"],
     "anthropic": ["claude-3-opus-20240229", "claude-3-sonnet-20240229"],
-    "minimax": ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"],
+    "minimax": ["MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"],
     "openrouter": ["google/gemini-pro-1.5", "meta-llama/llama-3-70b-instruct"]
   }
 }
@@ -378,7 +378,7 @@ Optional Text-to-SQL and query explanation powered by:
 
 - **OpenAI**
 - **Anthropic**
-- **MiniMax** (MiniMax-M2.7 and MiniMax-M2.7-highspeed, 204K context)
+- **MiniMax** (MiniMax-M3 default, with MiniMax-M2.7 and MiniMax-M2.7-highspeed)
 - **OpenRouter** (access to Gemini, Llama, DeepSeek, etc.)
 - **Ollama** (Local LLM support for total privacy)
 - **OpenAI-Compatible APIs** (Groq, Perplexity, Azure OpenAI, LocalAI, and more)

--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -922,8 +922,11 @@ mod tests {
 
         // Check MiniMax models
         let minimax = models.get("minimax").unwrap();
+        assert!(minimax.contains(&"MiniMax-M3".to_string()));
         assert!(minimax.contains(&"MiniMax-M2.7".to_string()));
         assert!(minimax.contains(&"MiniMax-M2.7-highspeed".to_string()));
+        // M3 should be listed first so it is selected as the default model
+        assert_eq!(minimax.first().map(String::as_str), Some("MiniMax-M3"));
 
         // Ollama is not in yaml, so it shouldn't be here yet
         assert!(!models.contains_key("ollama"));

--- a/src-tauri/src/ai_models.yaml
+++ b/src-tauri/src/ai_models.yaml
@@ -15,6 +15,7 @@ anthropic:
   - claude-3.5-haiku
 
 minimax:
+  - MiniMax-M3
   - MiniMax-M2.7
   - MiniMax-M2.7-highspeed
 

--- a/tests/utils/minimax.test.ts
+++ b/tests/utils/minimax.test.ts
@@ -40,12 +40,12 @@ describe('MiniMax AI Provider Integration', () => {
         'custom-openai': false,
       };
       const models: Record<string, string[]> = {
-        minimax: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
+        minimax: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
       };
 
       const result = detectAIProviderFromKeys(keyStatus, models);
       expect(result.provider).toBe('minimax');
-      expect(result.model).toBe('MiniMax-M2.7');
+      expect(result.model).toBe('MiniMax-M3');
     });
 
     it('should prefer openai over minimax', () => {
@@ -84,7 +84,7 @@ describe('MiniMax AI Provider Integration', () => {
       expect(result.provider).toBe('anthropic');
     });
 
-    it('should select M2.7 as default model', () => {
+    it('should select M3 as default model', () => {
       const keyStatus: Record<AiProvider, boolean> = {
         openai: false,
         anthropic: false,
@@ -94,11 +94,11 @@ describe('MiniMax AI Provider Integration', () => {
         'custom-openai': false,
       };
       const models: Record<string, string[]> = {
-        minimax: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
+        minimax: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
       };
 
       const result = detectAIProviderFromKeys(keyStatus, models);
-      expect(result.model).toBe('MiniMax-M2.7');
+      expect(result.model).toBe('MiniMax-M3');
     });
 
     it('should return null model when minimax models list is empty', () => {

--- a/tests/utils/settings.test.ts
+++ b/tests/utils/settings.test.ts
@@ -319,13 +319,13 @@ describe('settings', () => {
         minimax: true,
       };
       const models: Record<string, string[]> = {
-        minimax: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
+        minimax: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
       };
 
       const result = detectAIProviderFromKeys(keyStatus, models);
 
       expect(result.provider).toBe('minimax');
-      expect(result.model).toBe('MiniMax-M2.7');
+      expect(result.model).toBe('MiniMax-M3');
     });
 
     it('should return null when no keys available', () => {


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to include the latest M3 model as the new default.

## Changes
- Add `MiniMax-M3` to the model selection list in `src-tauri/src/ai_models.yaml`
- Place `MiniMax-M3` first so it is auto-selected as the default when only the MiniMax key is configured
- Retain `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternatives
- Update the existing Rust (`ai.rs`) and TypeScript (`minimax.test.ts`, `settings.test.ts`) test assertions for the new default
- Update README provider section to reflect the new default

## Why
MiniMax-M3 is the new flagship model and is now generally available. This keeps Tabularis on the latest model by default while preserving access to the previous generation for users that prefer it.

## Testing
- TypeScript: `pnpm exec vitest run tests/utils/minimax.test.ts tests/utils/settings.test.ts` — all assertions pass with the new default
- YAML parse verified