### PR TITLE
fix(mcp): classify parenthesized SELECT/UNION as read-only

### DIFF
--- a/src-tauri/src/ai_activity.rs
+++ b/src-tauri/src/ai_activity.rs
@@ -378,8 +378,18 @@ pub fn classify_query_kind(sql: &str) -> &'static str {
     {
         return "unknown";
     }
-    let upper = trimmed.to_uppercase();
-    let first = first_keyword(&upper);
+    // Peel any leading `(` (and surrounding whitespace) before reading the
+    // first keyword. A parenthesized query expression such as
+    // `(SELECT ...) UNION ALL (SELECT ...)` — the shape you get when each
+    // UNION branch needs its own ORDER BY / LIMIT — starts with `(`, so the
+    // first keyword would otherwise come back empty and fall through to
+    // "unknown", needlessly tripping the read-only and approval gates for a
+    // pure read. Multi-statement payloads are already rejected above, so the
+    // inner leading keyword is a safe basis for classification.
+    let peeled_upper = trimmed
+        .trim_start_matches(|c: char| c == '(' || c.is_whitespace())
+        .to_uppercase();
+    let first = first_keyword(&peeled_upper);
 
     match first.as_str() {
         "SELECT" | "SHOW" | "EXPLAIN" | "DESCRIBE" | "DESC" | "PRAGMA" | "VALUES" => "select",
@@ -387,7 +397,7 @@ pub fn classify_query_kind(sql: &str) -> &'static str {
         "CREATE" | "DROP" | "ALTER" | "TRUNCATE" | "RENAME" | "GRANT" | "REVOKE" | "COMMENT" => {
             "ddl"
         }
-        "WITH" => classify_cte(&upper),
+        "WITH" => classify_cte(&peeled_upper),
         _ => "unknown",
     }
 }

--- a/src-tauri/src/ai_activity_tests.rs
+++ b/src-tauri/src/ai_activity_tests.rs
@@ -438,6 +438,70 @@ mod tests {
         );
     }
 
+    // -----------------------------------------------------------------------
+    // Parenthesized query expressions. A `(SELECT ...) UNION ALL (SELECT ...)`
+    // starts with `(`, so the first keyword would come back empty and fall
+    // through to "unknown" — needlessly tripping the read-only / approval
+    // gates for a pure read. The leading `(` (and whitespace) must be peeled
+    // before reading the first keyword.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn classify_parenthesized_union_all_is_select() {
+        assert_eq!(
+            classify_query_kind(
+                "(SELECT 'a' AS kw, content FROM t WHERE id IN (1, 2) ORDER BY id LIMIT 8) \
+                 UNION ALL \
+                 (SELECT 'b' AS kw, content FROM t WHERE id IN (3, 4) ORDER BY id LIMIT 8)"
+            ),
+            "select"
+        );
+    }
+
+    #[test]
+    fn classify_parenthesized_select_with_whitespace_is_select() {
+        assert_eq!(classify_query_kind("(  SELECT 1 )"), "select");
+        assert_eq!(classify_query_kind("( ( SELECT 1 ) )"), "select");
+    }
+
+    #[test]
+    fn classify_parenthesized_then_drop_is_unknown() {
+        // Peeling the leading `(` must not weaken multi-statement detection:
+        // an injected trailing statement still fails closed.
+        assert_eq!(
+            classify_query_kind("(SELECT 1); DROP TABLE users"),
+            "unknown"
+        );
+    }
+
+    #[test]
+    fn classify_empty_or_whitespace_parens_is_unknown() {
+        // Peeling all leading `(` and whitespace can leave no keyword at all;
+        // the classifier must fail closed rather than guess "select".
+        assert_eq!(classify_query_kind("()"), "unknown");
+        assert_eq!(classify_query_kind("(   )"), "unknown");
+        assert_eq!(classify_query_kind("((()))"), "unknown");
+    }
+
+    #[test]
+    fn classify_parenthesized_write_or_ddl_is_not_downgraded() {
+        // The peel is greedy, but the inner keyword still drives the result:
+        // a parenthesized write/DDL must never be downgraded to "select", or
+        // the read-only and approval gates would let it through.
+        assert_eq!(classify_query_kind("( DROP TABLE t )"), "ddl");
+        assert_eq!(classify_query_kind("( DELETE FROM users )"), "write");
+    }
+
+    #[test]
+    fn classify_parenthesized_cte_with_insert_is_write() {
+        // classify_cte scans the whole body, not just the start, so a CTE
+        // wrapped in parens whose tail writes is still classified "write".
+        assert_eq!(
+            classify_query_kind("(WITH x AS (SELECT 1) INSERT INTO t SELECT * FROM x)"),
+            "write"
+        );
+    }
+
     #[test]
     fn classify_handles_leading_comment_then_select() {
         assert_eq!(


### PR DESCRIPTION
## Problem
A parenthesized query expression like `(SELECT ...) UNION ALL (SELECT ...)` — the shape you get when each UNION branch needs its own ORDER BY / LIMIT — raised the MCP write-approval dialog even though it is a pure read. Under read-only mode the SELECT is blocked outright.

## Root cause
`classify_query_kind` (`src-tauri/src/ai_activity.rs`) classifies by the leading keyword, but `first_keyword` returns an empty string when the input starts with `(`, so the query fell through to `_ => "unknown"`. The approval gate (`src-tauri/src/mcp/mod.rs:929-934`) and the read-only check (`mod.rs:913`) both key off `kind != "select"`, so a SELECT was treated as a write.

## Fix
Peel the leading `(` and whitespace before reading the first keyword, so the inner SELECT is detected.

Safety:
- Multi-statement detection (`has_trailing_statements`) still runs before the peel, so `(SELECT 1); DROP ...` stays `unknown` and is blocked.
- The peel is greedy, but the inner keyword still drives the result: `( DROP TABLE t )` is `ddl` and `( DELETE ... )` is `write`. This does not loosen write classification.

## Tests
Added 6 regression tests for parenthesized queries (UNION, nested/whitespace parens, empty parens fail-closed, parenthesized DDL/DML, a writing CTE).
- `cargo test --lib classify`: 27 passed / 0 failed