### PR TITLE
Preserve user OFFSET in paginated queries (#273)

### DIFF
--- a/src-tauri/src/drivers/common.rs
+++ b/src-tauri/src/drivers/common.rs
@@ -10,7 +10,8 @@ pub use blob::{
     DEFAULT_MAX_BLOB_SIZE, MAX_BLOB_PREVIEW_SIZE,
 };
 pub use query::{
-    build_paginated_query, calculate_offset, extract_user_limit, is_explainable_query,
+    build_paginated_query, calculate_offset, extract_user_limit, extract_user_offset,
+    is_explainable_query,
     is_select_query, returns_result_set, strip_leading_sql_comments, strip_limit_offset,
 };
 pub use safe_int::{

--- a/src-tauri/src/drivers/common/query.rs
+++ b/src-tauri/src/drivers/common/query.rs
@@ -264,6 +264,23 @@ pub fn extract_user_limit(query: &str) -> Option<u32> {
     None
 }
 
+/// Extract the numeric value from a trailing OFFSET clause, if present.
+///
+/// Mirrors [`extract_user_limit`] and only recognises the `… OFFSET <n>`
+/// shape that [`strip_limit_offset`] removes (the common `LIMIT x OFFSET y`
+/// ordering). Uses a token-aware scan so `OFFSET` inside an identifier or
+/// string literal is never misidentified.
+pub fn extract_user_offset(query: &str) -> Option<u32> {
+    let tokens = tokenize_sql_with_pos(query.trim());
+    let end = tokens.len();
+
+    if end >= 2 && tokens[end - 2].0.to_uppercase() == "OFFSET" {
+        return tokens[end - 1].0.parse().ok();
+    }
+
+    None
+}
+
 /// Build a paginated query by stripping any user-supplied LIMIT/OFFSET and
 /// appending pagination clauses directly. ORDER BY is left in place so that
 /// table-qualified column references (e.g. `o.created_at`) remain valid —
@@ -271,20 +288,26 @@ pub fn extract_user_limit(query: &str) -> Option<u32> {
 /// of scope and cause "unknown column" errors.
 ///
 /// When the user wrote an explicit LIMIT, it is honoured as a cap on the total
-/// number of rows returned across all pages.
+/// number of rows returned across all pages. A user-supplied OFFSET is honoured
+/// too: it is added to the per-page offset so that pagination walks the result
+/// set the user actually asked for (the rows after their OFFSET). Discarding it
+/// silently collapsed `LIMIT 1 OFFSET 1` to `LIMIT 1 OFFSET 0` on page 1.
 pub fn build_paginated_query(query: &str, page_size: u32, page: u32) -> String {
-    let offset = calculate_offset(page, page_size);
+    let page_offset = calculate_offset(page, page_size);
     let user_limit = extract_user_limit(query);
+    let user_offset = extract_user_offset(query).unwrap_or(0);
     let base = strip_limit_offset(query);
 
     let fetch_count = match user_limit {
         Some(ul) => {
-            let remaining = ul.saturating_sub(offset);
+            let remaining = ul.saturating_sub(page_offset);
             // +1 for has_more detection, but capped by user's LIMIT
             remaining.min(page_size + 1)
         }
         None => page_size + 1,
     };
+
+    let offset = user_offset.saturating_add(page_offset);
 
     format!("{} LIMIT {} OFFSET {}", base, fetch_count, offset)
 }

--- a/src-tauri/src/drivers/common/tests.rs
+++ b/src-tauri/src/drivers/common/tests.rs
@@ -329,6 +329,57 @@ fn test_build_paginated_query_table_name_contains_limit_with_user_limit() {
 }
 
 #[test]
+fn test_extract_user_offset_present() {
+    assert_eq!(
+        super::extract_user_offset("SELECT * FROM t LIMIT 1 OFFSET 1"),
+        Some(1)
+    );
+}
+
+#[test]
+fn test_extract_user_offset_only_offset() {
+    assert_eq!(
+        super::extract_user_offset("SELECT * FROM t ORDER BY id OFFSET 5"),
+        Some(5)
+    );
+}
+
+#[test]
+fn test_extract_user_offset_absent() {
+    assert_eq!(
+        super::extract_user_offset("SELECT * FROM t LIMIT 50"),
+        None
+    );
+}
+
+#[test]
+fn test_build_paginated_query_preserves_user_offset() {
+    // Regression for #273: `LIMIT 1 OFFSET 1` must keep OFFSET 1 on page 1,
+    // not collapse to OFFSET 0 (which returned the 1st row instead of the 2nd).
+    let q = "SELECT DISTINCT salary FROM employees ORDER BY salary DESC LIMIT 1 OFFSET 1";
+    let result = build_paginated_query(q, 100, 1);
+    assert_eq!(
+        result,
+        "SELECT DISTINCT salary FROM employees ORDER BY salary DESC LIMIT 1 OFFSET 1"
+    );
+}
+
+#[test]
+fn test_build_paginated_query_user_offset_no_limit() {
+    let q = "SELECT * FROM t ORDER BY id OFFSET 5";
+    let result = build_paginated_query(q, 100, 1);
+    assert_eq!(result, "SELECT * FROM t ORDER BY id LIMIT 101 OFFSET 5");
+}
+
+#[test]
+fn test_build_paginated_query_user_offset_second_page() {
+    // page offset (100) is added on top of the user's OFFSET (5).
+    let q = "SELECT * FROM t ORDER BY id OFFSET 5";
+    let result = build_paginated_query(q, 100, 2);
+    assert_eq!(result, "SELECT * FROM t ORDER BY id LIMIT 101 OFFSET 105");
+}
+
+#[test]
 fn test_build_paginated_query_subquery_with_limit() {
     let q = "SELECT * FROM (SELECT id FROM t ORDER BY id LIMIT 100) sub ORDER BY id LIMIT 5";
     let result = build_paginated_query(q, 100, 1);


### PR DESCRIPTION
Fixes #273.

### The problem

When the grid paginates a `SELECT`, it rewrites the query: it strips the user's trailing `LIMIT`/`OFFSET`, then re-appends `LIMIT <fetch> OFFSET <page offset>`. The rewriter only read back the user's `LIMIT` — the `OFFSET` was dropped on the floor. On page 1 the per-page offset is `0`, so `LIMIT 1 OFFSET 1` effectively became `LIMIT 1 OFFSET 0` and the OFFSET was silently ignored.

The reason a trailing `--` "fixed" it: with the comment present, the stripper no longer recognised the trailing `OFFSET <n>` pattern and left the query untouched, and the appended pagination clause landed on the same line as the `--` and got swallowed as a comment. So the database ran the user's original query verbatim — correct result, but by accident.

This affected all three drivers (Postgres, MySQL, SQLite) since they share `build_paginated_query`.

### The fix

- Add `extract_user_offset`, mirroring `extract_user_limit` (token-aware, so `OFFSET` inside an identifier or string literal isn't misread).
- `build_paginated_query` now adds the user's OFFSET to the per-page offset, so pagination walks the rows the user actually asked for.

Behaviour for queries without an explicit OFFSET is unchanged (`user_offset` is `0`). Added regression tests including the exact case from the issue, plus OFFSET-without-LIMIT on pages 1 and 2.