### PR TITLE
Accept postgresql:// and mariadb:// connection string aliases

### DIFF
--- a/src/components/modals/NewConnectionModal.tsx
+++ b/src/components/modals/NewConnectionModal.tsx
@@ -41,7 +41,6 @@ import { isMultiDatabaseCapable } from "../../utils/database";
 import { fetchConnectionWithCredentials } from "../../utils/credentials";
 import { getDriverIcon, getDriverColorStyle } from "../../utils/driverUI";
 import {
-  looksLikeConnectionString,
   parseConnectionString,
   toConnectionParams,
 } from "../../utils/connectionStringParser";
@@ -726,43 +725,41 @@ export const NewConnectionModal = ({
       capabilities: item.capabilities,
     }));
 
-    if (looksLikeConnectionString(value, parserDrivers)) {
-      const result = parseConnectionString(value, parserDrivers);
-      if (result.success) {
-        const parsed = toConnectionParams(result.params);
-        const newDriver = parsed.driver || driver;
-        const parsedDriver = drivers.find((item) => item.id === newDriver);
-        const parsedIsMultiDb = isMultiDatabaseCapable(
-          parsedDriver?.capabilities,
-        );
+    const result = parseConnectionString(value, parserDrivers);
+    if (result.success) {
+      const parsed = toConnectionParams(result.params);
+      const newDriver = parsed.driver || driver;
+      const parsedDriver = drivers.find((item) => item.id === newDriver);
+      const parsedIsMultiDb = isMultiDatabaseCapable(
+        parsedDriver?.capabilities,
+      );
 
-        const parsedFields: Partial<ConnectionParams> = {
-          driver: newDriver,
-          host: parsed.host || "localhost",
-          port: parsed.port,
-          username: parsed.username || "",
-          password: parsed.password || "",
-          database: parsed.database || "",
-        };
+      const parsedFields: Partial<ConnectionParams> = {
+        driver: newDriver,
+        host: parsed.host || "localhost",
+        port: parsed.port,
+        username: parsed.username || "",
+        password: parsed.password || "",
+        database: parsed.database || "",
+      };
 
-        if (parsedIsMultiDb && parsed.database) {
-          setSelectedDatabasesState([parsed.database]);
-          setActiveTab("databases");
-        }
-
-        if (newDriver !== driver) {
-          setDriver(newDriver);
-        }
-
-        setFormData((prev) => ({
-          ...prev,
-          ...parsedFields,
-        }));
-
-        void loadDatabases(parsedFields);
-      } else {
-        setConnectionStringError(result.error);
+      if (parsedIsMultiDb && parsed.database) {
+        setSelectedDatabasesState([parsed.database]);
+        setActiveTab("databases");
       }
+
+      if (newDriver !== driver) {
+        setDriver(newDriver);
+      }
+
+      setFormData((prev) => ({
+        ...prev,
+        ...parsedFields,
+      }));
+
+      void loadDatabases(parsedFields);
+    } else {
+      setConnectionStringError(result.error);
     }
   };
 

--- a/src/utils/connectionStringParser.ts
+++ b/src/utils/connectionStringParser.ts
@@ -41,6 +41,25 @@ interface ResolvedDriver {
   local: boolean;
 }
 
+/**
+ * Groups of interchangeable URI schemes. When a driver registers any
+ * protocol of a group, the other members become aliases for the same
+ * driver (e.g. `postgresql://` works wherever `postgres://` does).
+ */
+const PROTOCOL_ALIAS_GROUPS: ReadonlyArray<ReadonlyArray<string>> = [
+  ["postgres", "postgresql"],
+  ["mysql", "mariadb"],
+  ["sqlite", "sqlite3"],
+];
+
+function getProtocolAliases(protocol: string): string[] {
+  const group = PROTOCOL_ALIAS_GROUPS.find((aliases) =>
+    aliases.includes(protocol),
+  );
+  if (!group) return [];
+  return group.filter((alias) => alias !== protocol);
+}
+
 function normalizeProtocol(protocol: string): string {
   return protocol.replace(/:$/, "").trim().toLowerCase();
 }
@@ -96,6 +115,16 @@ function buildProtocolRegistry(
 
     if (exampleProtocol) {
       registry.set(exampleProtocol, { id: driver.id, local });
+    }
+  }
+
+  // Second pass: expand well-known aliases without overriding protocols
+  // explicitly registered by another driver.
+  for (const [protocol, resolved] of Array.from(registry.entries())) {
+    for (const alias of getProtocolAliases(protocol)) {
+      if (!registry.has(alias)) {
+        registry.set(alias, resolved);
+      }
     }
   }
 

--- a/tests/utils/connectionStringParser.test.ts
+++ b/tests/utils/connectionStringParser.test.ts
@@ -3,6 +3,7 @@ import {
   parseConnectionString,
   toConnectionParams,
   looksLikeConnectionString,
+  getSupportedConnectionStringProtocols,
   type ParsedConnectionString,
   type ConnectionStringDriver,
 } from "../../src/utils/connectionStringParser";
@@ -27,9 +28,12 @@ function createRemoteDriver(
   };
 }
 
+// Mirrors the real builtin driver capabilities (postgres:// and mysql://
+// examples) so alias coverage below exercises the alias expansion, not the
+// example-derived protocol.
 const CAPABILITY_DRIVERS: ConnectionStringDriver[] = [
-  createRemoteDriver("postgres", "postgresql://user:pass@localhost:5432/db"),
-  createRemoteDriver("mysql", "mariadb://user:pass@localhost:3306/db"),
+  createRemoteDriver("postgres", "postgres://user:pass@localhost:5432/db"),
+  createRemoteDriver("mysql", "mysql://user:pass@localhost:3306/db"),
   {
     id: "sqlite",
     capabilities: {
@@ -110,18 +114,23 @@ describe("connectionStringParser", () => {
       }
     });
 
-    it("should parse postgresql:// as postgres using capabilities", () => {
+    it("should parse postgresql:// as postgres via protocol alias", () => {
       const result = parseConnectionString(
-        "postgresql://user@host/db",
+        "postgresql://user:pass@localhost:5432/mydb",
         CAPABILITY_DRIVERS,
       );
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.params.driver).toBe("postgres");
+        expect(result.params.host).toBe("localhost");
+        expect(result.params.port).toBe(5432);
+        expect(result.params.username).toBe("user");
+        expect(result.params.password).toBe("pass");
+        expect(result.params.database).toBe("mydb");
       }
     });
 
-    it("should parse mariadb:// as mysql using capabilities", () => {
+    it("should parse mariadb:// as mysql via protocol alias", () => {
       const result = parseConnectionString(
         "mariadb://user@host/db",
         CAPABILITY_DRIVERS,
@@ -129,6 +138,50 @@ describe("connectionStringParser", () => {
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.params.driver).toBe("mysql");
+      }
+    });
+
+    it("should resolve aliases against builtin drivers when no drivers are provided", () => {
+      const postgresql = parseConnectionString(
+        "postgresql://user@host/db",
+      );
+      expect(postgresql.success).toBe(true);
+      if (postgresql.success) {
+        expect(postgresql.params.driver).toBe("postgres");
+      }
+
+      const mariadb = parseConnectionString("mariadb://user@host/db");
+      expect(mariadb.success).toBe(true);
+      if (mariadb.success) {
+        expect(mariadb.params.driver).toBe("mysql");
+      }
+    });
+
+    it("should parse sqlite3:// as sqlite via protocol alias", () => {
+      const result = parseConnectionString(
+        "sqlite3:///path/to/database.db",
+        CAPABILITY_DRIVERS,
+      );
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.params.driver).toBe("sqlite");
+        expect(result.params.database).toBe("path/to/database.db");
+      }
+    });
+
+    it("should not let an alias override an explicitly registered protocol", () => {
+      const drivers: ConnectionStringDriver[] = [
+        createRemoteDriver("mysql", "mysql://user:pass@localhost:3306/db"),
+        createRemoteDriver(
+          "mariadb-plugin",
+          "mariadb://user:pass@localhost:3306/db",
+        ),
+      ];
+
+      const result = parseConnectionString("mariadb://user@host/db", drivers);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.params.driver).toBe("mariadb-plugin");
       }
     });
 
@@ -362,6 +415,19 @@ describe("connectionStringParser", () => {
       ).toBe(false);
     });
 
+    it("should accept aliases for drivers whose example uses the canonical protocol", () => {
+      const realisticDrivers: ConnectionStringDriver[] = [
+        createRemoteDriver("postgres", "postgres://user:pass@localhost:5432/db"),
+      ];
+
+      expect(
+        looksLikeConnectionString(
+          "postgresql://user@host/db",
+          realisticDrivers,
+        ),
+      ).toBe(true);
+    });
+
     it("should use provided driver capabilities to validate protocols", () => {
       const restrictedDrivers: ConnectionStringDriver[] = [
         createRemoteDriver(
@@ -381,6 +447,12 @@ describe("connectionStringParser", () => {
       ).toBe(false);
     });
 
+    it("should return true for sqlite3:// alias", () => {
+      expect(
+        looksLikeConnectionString("sqlite3:///path/to/db", CAPABILITY_DRIVERS),
+      ).toBe(true);
+    });
+
     it("should be case insensitive for protocol", () => {
       expect(
         looksLikeConnectionString("MYSQL://user@host/db", CAPABILITY_DRIVERS),
@@ -391,6 +463,26 @@ describe("connectionStringParser", () => {
           CAPABILITY_DRIVERS,
         ),
       ).toBe(true);
+    });
+  });
+
+  describe("getSupportedConnectionStringProtocols", () => {
+    it("should include aliases alongside canonical protocols", () => {
+      const protocols = getSupportedConnectionStringProtocols(
+        CAPABILITY_DRIVERS,
+      );
+      expect(protocols).toContain("postgres");
+      expect(protocols).toContain("postgresql");
+      expect(protocols).toContain("mysql");
+      expect(protocols).toContain("mariadb");
+      expect(protocols).toContain("sqlite");
+      expect(protocols).toContain("sqlite3");
+    });
+
+    it("should include aliases for builtin drivers when no drivers are provided", () => {
+      const protocols = getSupportedConnectionStringProtocols();
+      expect(protocols).toContain("postgresql");
+      expect(protocols).toContain("mariadb");
     });
   });
 });


### PR DESCRIPTION
Fixes #260

The connection string protocol registry was built only from the driver id and the `connection_string_example`, so for PostgreSQL only `postgres` ended up registered. Pasting a `postgresql://` string was silently ignored: no fields populated, no error set, and the success indicator still rendered because it only checked for a non-empty input without an error.

Changes:

- `connectionStringParser.ts`: the registry now expands well-known scheme aliases — `postgresql` ↔ `postgres`, `mariadb` ↔ `mysql`, `sqlite3` ↔ `sqlite`. Aliases are added in a second pass and never override a protocol explicitly registered by another driver, so a dedicated `mariadb` plugin would still take precedence over the alias. Aliases are also listed by `getSupportedConnectionStringProtocols`, so they show up in the "Supported: …" hint.
- `NewConnectionModal.tsx`: removed the `looksLikeConnectionString` pre-filter — the input now always goes through `parseConnectionString`, and a failed parse sets the error (e.g. `Unsupported database driver: oracle. Supported: mariadb, mysql, postgres, postgresql, sqlite, sqlite3`). The green check now only appears when the string was actually parsed and the form populated.
- Tests: fixtures previously used `postgresql://`/`mariadb://` as driver examples, which is why the existing alias tests passed while the real app failed. They now mirror the actual builtin capabilities, with new coverage for alias expansion, the builtin fallback path, and the no-override rule.