### PR TITLE
Honor PostgreSQL TLS settings in pool key

### DIFF
--- a/src-tauri/src/pool_manager.rs
+++ b/src-tauri/src/pool_manager.rs
@@ -83,15 +83,24 @@ pub(crate) fn build_connection_key(
     params: &ConnectionParams,
     connection_id: Option<&str>,
 ) -> String {
-    let tls_key = (params.driver == "mysql").then(|| {
-        format!(
+    let tls_key = match params.driver.as_str() {
+        "mysql" => Some(format!(
             "ssl:{}:{}:{}:{}",
             params.ssl_mode.as_deref().unwrap_or("default"),
             params.ssl_ca.as_deref().unwrap_or(""),
             params.ssl_cert.as_deref().unwrap_or(""),
             params.ssl_key.as_deref().unwrap_or("")
-        )
-    });
+        )),
+        "postgres" => {
+            let ssl_mode = params.ssl_mode.as_deref().unwrap_or("prefer");
+            let ssl_ca = match ssl_mode {
+                "verify-ca" | "verify-full" => params.ssl_ca.as_deref().unwrap_or(""),
+                _ => "",
+            };
+            Some(format!("ssl:{ssl_mode}:{ssl_ca}"))
+        }
+        _ => None,
+    };
 
     let base_key = if let Some(conn_id) = connection_id {
         // Include database in key so different databases on the same connection use separate pools

--- a/src-tauri/src/pool_manager_tests.rs
+++ b/src-tauri/src/pool_manager_tests.rs
@@ -84,7 +84,7 @@ mod tests {
 
     #[test]
     fn postgres_pool_key_changes_when_ssl_mode_changes() {
-        let required = connection_params("postgres", Some("required"));
+        let required = connection_params("postgres", Some("require"));
         let disabled = connection_params("postgres", Some("disable"));
 
         assert_ne!(

--- a/src-tauri/src/pool_manager_tests.rs
+++ b/src-tauri/src/pool_manager_tests.rs
@@ -83,20 +83,33 @@ mod tests {
     }
 
     #[test]
-    fn postgres_pool_key_ignores_mysql_ssl_key_fields() {
+    fn postgres_pool_key_changes_when_ssl_mode_changes() {
         let required = connection_params("postgres", Some("required"));
-        let disabled = connection_params("postgres", Some("disabled"));
+        let disabled = connection_params("postgres", Some("disable"));
 
-        assert_eq!(
+        assert_ne!(
             build_connection_key(&required, Some("conn-1")),
             build_connection_key(&disabled, Some("conn-1"))
         );
     }
 
     #[test]
-    fn sqlite_pool_key_ignores_mysql_ssl_key_fields() {
+    fn postgres_pool_key_changes_when_ssl_ca_changes() {
+        let without_ca = connection_params("postgres", Some("verify-ca"));
+        let mut with_ca = connection_params("postgres", Some("verify-ca"));
+        with_ca.ssl_ca = Some("/tmp/postgres-ca.pem".to_string());
+
+        assert_ne!(
+            build_connection_key(&without_ca, Some("conn-1")),
+            build_connection_key(&with_ca, Some("conn-1"))
+        );
+    }
+
+    #[test]
+    fn sqlite_pool_key_ignores_tls_key_fields() {
         let required = connection_params("sqlite", Some("required"));
-        let disabled = connection_params("sqlite", Some("disabled"));
+        let mut disabled = connection_params("sqlite", Some("disabled"));
+        disabled.ssl_ca = Some("/tmp/sqlite-ca.pem".to_string());
 
         assert_eq!(
             build_connection_key(&required, Some("conn-1")),


### PR DESCRIPTION
## Summary

- Include PostgreSQL `ssl_mode` in the pool key so cached pools are scoped by the selected TLS mode.
- Include PostgreSQL `ssl_ca` in the pool key for `verify-ca` and `verify-full`, where the connector actually uses a CA file.
- Add regression coverage for PostgreSQL pool-key changes while keeping SQLite unaffected by TLS fields.

## Context

This is a follow-up to #263. PostgreSQL pool creation already honors `ssl_mode` and `ssl_ca`, but the shared pool key only varied by TLS settings for MySQL. After editing a PostgreSQL connection from one TLS mode or CA path to another, the main connection path could reuse an incompatible cached pool.

I did not find an existing open issue or PR for this exact PostgreSQL pool-key scoping bug. Related items checked:

- #263: MySQL SSL mode propagation and pool-key scoping
- #166 / #167: PostgreSQL rustls/CA handling in pool creation

This is intentionally scoped to PostgreSQL pool-key construction and does not change PostgreSQL TLS connector behavior.

## Validation

- `cargo test postgres_pool_key_changes_when_ssl` -> 2 passed
- `cargo test pool_manager` -> 23 passed
- `git diff --check` -> passed
- `npm --cache /tmp/gitnexus-npm-cache exec --yes gitnexus -- analyze` -> indexed successfully, 11,576 nodes / 21,769 edges / 300 flows
- `npm --cache /tmp/gitnexus-npm-cache exec --yes gitnexus -- impact build_connection_key --direction upstream` -> CRITICAL risk, 74 impacted symbols, 5 direct callers, 6 affected flows
- `npm --cache /tmp/gitnexus-npm-cache exec --yes gitnexus -- detect-changes --scope compare --base-ref main` -> medium risk, 6 changed symbols, 4 affected flows
