### PR TITLE
fix(postgres): read EXPLAIN JSON output as json column

### DIFF
--- a/src-tauri/src/drivers/postgres/explain.rs
+++ b/src-tauri/src/drivers/postgres/explain.rs
@@ -29,8 +29,15 @@ pub async fn explain_query(
         return Err("EXPLAIN returned no output".into());
     }
 
-    // PostgreSQL returns a single row with a single text column containing JSON
-    let plan_json_str: String = rows[0].try_get(0).map_err(|e| format_pg_error(&e))?;
+    // `EXPLAIN (FORMAT JSON)` on real PostgreSQL returns a column of type
+    // `json` (not `text`), so reading it as `String` fails with
+    // "error deserializing column 0". Read it as a `serde_json::Value` and
+    // re-serialize. Some Postgres-compatible engines hand back a plain `text`
+    // column instead, so fall back to reading the raw string in that case.
+    let plan_json_str = match rows[0].try_get::<_, serde_json::Value>(0) {
+        Ok(value) => value.to_string(),
+        Err(_) => rows[0].try_get::<_, String>(0).map_err(|e| format_pg_error(&e))?,
+    };
 
     let mut plan = parse_postgres_json(&plan_json_str)?;
     plan.original_query = query.to_string();

--- a/src-tauri/src/drivers/postgres/explain.rs
+++ b/src-tauri/src/drivers/postgres/explain.rs
@@ -36,7 +36,10 @@ pub async fn explain_query(
     // column instead, so fall back to reading the raw string in that case.
     let plan_json_str = match rows[0].try_get::<_, serde_json::Value>(0) {
         Ok(value) => value.to_string(),
-        Err(_) => rows[0].try_get::<_, String>(0).map_err(|e| format_pg_error(&e))?,
+		Err(json_err) => rows[0].try_get::<_, String>(0).map_err(|e| {
+    	log::debug!("EXPLAIN json read failed ({json_err}); text read also failed");
+    	format_pg_error(&e)
+	})?,
     };
 
     let mut plan = parse_postgres_json(&plan_json_str)?;


### PR DESCRIPTION
## What

Fixes the "Explain Plan" feature for Postgres, which always failed with `error deserializing column 0` (#276).

## Why it broke

`EXPLAIN (FORMAT JSON) ...` returns the plan in a single column, and on Postgres that column is typed as `json` (OID 114), not `text`. The code read it straight into a `String`:

```rust
let plan_json_str: String = rows[0].try_get(0)...;
```

`tokio-postgres` refuses to deserialize a `json` column into a `String`, so the call errored out before the plan was ever parsed. This is server-side behaviour that's been stable since the `FORMAT` option landed in PG 9.0, so the feature never worked on any Postgres version — matching the report against PG 16 and 18.

## Fix

Read the column as a `serde_json::Value` (the `with-serde_json-1` feature is already enabled) and re-serialize it for the existing parser. Postgres-compatible engines that hand the plan back as a plain `text` column are covered by a `String` fallback.

## Testing

- `cargo check` passes.
- Verified Explain Plan now renders against Postgres locally, with and without Analyze.
