### PR TITLE
Focus editor when opening a new console tab

### DIFF
--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -2091,6 +2091,9 @@ export const Editor = () => {
   ) => {
     editorsRef.current[tabId] = editor;
     setMonacoInstance(monaco);
+    // Focus the editor when a console tab is opened (Ctrl+T / new console)
+    const mountedTab = tabsRef.current.find((t) => t.id === tabId);
+    if (mountedTab?.type === "console") editor.focus();
     editor.addAction({
       id: "run-selection",
       label: "Execute Selection",


### PR DESCRIPTION
Closes #274

When opening a new console tab (Ctrl/Cmd+T, the + button, or the quick navigator action), the Monaco editor now receives focus right away, so you can start typing the query immediately.

Each tab mounts its own editor instance exactly once (keyed by tab id, with `onMount` only wired for the active tab), so a single `editor.focus()` in `handleEditorMount` covers all the creation paths without touching the individual handlers. The check on the `console` tab type avoids stealing focus when table or query builder tabs are opened.

Side effect worth noting: the active console tab restored on startup also gets focused, which seems consistent with the intent of the issue.