### PR TITLE
fix(editor): stop Monaco theme leaking across editor instances

### DIFF
--- a/src/components/explain/VisualExplainView.tsx
+++ b/src/components/explain/VisualExplainView.tsx
@@ -5,7 +5,7 @@ import MonacoEditor from "@monaco-editor/react";
 import type * as monaco from "monaco-editor";
 import type { ExplainPlan } from "../../types/explain";
 import { findExplainNode } from "../../utils/explainPlan";
-import { useTheme } from "../../hooks/useTheme";
+import { useEditorTheme } from "../../hooks/useEditorTheme";
 import { loadMonacoTheme } from "../../themes/themeUtils";
 import {
   ExplainSummaryBar,
@@ -43,7 +43,7 @@ export const VisualExplainView = ({
   aiEnabled,
 }: VisualExplainViewProps) => {
   const { t } = useTranslation();
-  const { currentTheme } = useTheme();
+  const editorTheme = useEditorTheme();
 
   const selectedNode = useMemo(
     () => (plan ? findExplainNode(plan.root, selectedNodeId) : null),
@@ -60,9 +60,9 @@ export const VisualExplainView = ({
 
   const handleBeforeMount = useCallback(
     (monacoInstance: typeof monaco) => {
-      loadMonacoTheme(currentTheme, monacoInstance);
+      loadMonacoTheme(editorTheme, monacoInstance);
     },
-    [currentTheme],
+    [editorTheme],
   );
 
   return (
@@ -96,7 +96,7 @@ export const VisualExplainView = ({
             <MonacoEditor
               height="100%"
               language={rawLanguage}
-              theme={currentTheme.id}
+              theme={editorTheme.id}
               value={plan.raw_output}
               beforeMount={handleBeforeMount}
               options={{

--- a/src/components/modals/AiApprovalModal.tsx
+++ b/src/components/modals/AiApprovalModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Check, ShieldAlert, X, Pencil, Maximize2, Minimize2 } from "lucide-react";
 import Editor from "@monaco-editor/react";
-import { useTheme } from "../../hooks/useTheme";
+import { useEditorTheme } from "../../hooks/useEditorTheme";
 import { loadMonacoTheme } from "../../themes/themeUtils";
 import type { ExplainPlan } from "../../types/explain";
 import type { PendingApproval } from "../../types/ai";
@@ -25,7 +25,7 @@ export function AiApprovalModal({
   onClose,
 }: AiApprovalModalProps) {
   const { t } = useTranslation();
-  const { currentTheme } = useTheme();
+  const editorTheme = useEditorTheme();
   const [editing, setEditing] = useState(false);
   const [editedQuery, setEditedQuery] = useState(approval.query);
   const [reason, setReason] = useState("");
@@ -156,10 +156,10 @@ export function AiApprovalModal({
               <Editor
                 height="180px"
                 defaultLanguage="sql"
-                theme={currentTheme.id}
+                theme={editorTheme.id}
                 value={editing ? editedQuery : approval.query}
                 onChange={(v) => setEditedQuery(v ?? "")}
-                beforeMount={(monaco) => loadMonacoTheme(currentTheme, monaco)}
+                beforeMount={(monaco) => loadMonacoTheme(editorTheme, monaco)}
                 options={{
                   readOnly: !editing,
                   minimap: { enabled: false },

--- a/src/components/modals/AiExplainModal.tsx
+++ b/src/components/modals/AiExplainModal.tsx
@@ -1,11 +1,13 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { X, Loader2, BookOpen } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { useSettings } from "../../hooks/useSettings";
-import { useTheme } from "../../hooks/useTheme";
+import { useEditorTheme } from "../../hooks/useEditorTheme";
 import { getAiExplanationLanguage } from "../../i18n/language";
 import { Modal } from "../ui/Modal";
-import MonacoEditor from "@monaco-editor/react";
+import MonacoEditor, { type BeforeMount } from "@monaco-editor/react";
+import type * as MonacoTypes from "monaco-editor";
+import { loadMonacoTheme } from "../../themes/themeUtils";
 
 interface AiExplainModalProps {
   isOpen: boolean;
@@ -15,10 +17,24 @@ interface AiExplainModalProps {
 
 export const AiExplainModal = ({ isOpen, onClose, query }: AiExplainModalProps) => {
   const { settings } = useSettings();
-  const { currentTheme } = useTheme();
+  const editorTheme = useEditorTheme();
+  const monacoRef = useRef<typeof MonacoTypes | null>(null);
   const [explanation, setExplanation] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Update Monaco theme when theme changes
+  useEffect(() => {
+    if (monacoRef.current) {
+      loadMonacoTheme(editorTheme, monacoRef.current);
+    }
+  }, [editorTheme]);
+
+  const handleBeforeMount: BeforeMount = (monaco) => {
+    monacoRef.current = monaco;
+    // Define the theme before the editor is created (Monaco themes are global)
+    loadMonacoTheme(editorTheme, monaco);
+  };
 
   useEffect(() => {
     if (isOpen && query) {
@@ -86,8 +102,9 @@ export const AiExplainModal = ({ isOpen, onClose, query }: AiExplainModalProps) 
                 <MonacoEditor
                     height="100%"
                     language="sql"
-                    theme={currentTheme.id}
+                    theme={editorTheme.id}
                     value={query}
+                    beforeMount={handleBeforeMount}
                     options={{
                         readOnly: true,
                         minimap: { enabled: false },

--- a/src/components/modals/ConfigJsonModal.tsx
+++ b/src/components/modals/ConfigJsonModal.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { FileJson, X, Loader2, RotateCcw } from "lucide-react";
 import MonacoEditor, { type OnMount } from "@monaco-editor/react";
 import { invoke } from "@tauri-apps/api/core";
-import { useTheme } from "../../hooks/useTheme";
+import { useEditorTheme } from "../../hooks/useEditorTheme";
 import { loadMonacoTheme } from "../../themes/themeUtils";
 import { Modal } from "../ui/Modal";
 import { ConfirmModal } from "./ConfirmModal";
@@ -15,7 +15,7 @@ interface ConfigJsonModalProps {
 
 export const ConfigJsonModal = ({ isOpen, onClose }: ConfigJsonModalProps) => {
   const { t } = useTranslation();
-  const { currentTheme } = useTheme();
+  const editorTheme = useEditorTheme();
   const [jsonValue, setJsonValue] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
@@ -35,7 +35,7 @@ export const ConfigJsonModal = ({ isOpen, onClose }: ConfigJsonModalProps) => {
 
   const handleEditorMount: OnMount = (editor, monaco) => {
     editorRef.current = editor;
-    loadMonacoTheme(currentTheme, monaco);
+    loadMonacoTheme(editorTheme, monaco);
   };
 
   const handleSave = async () => {
@@ -99,7 +99,7 @@ export const ConfigJsonModal = ({ isOpen, onClose }: ConfigJsonModalProps) => {
                 <MonacoEditor
                   height="500px"
                   defaultLanguage="json"
-                  theme={currentTheme.id}
+                  theme={editorTheme.id}
                   value={jsonValue}
                   onChange={(val) => {
                     setJsonValue(val ?? "");

--- a/src/components/modals/McpModal.tsx
+++ b/src/components/modals/McpModal.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { X, Check, Copy, Cpu, Terminal } from "lucide-react";
 import { useAlert } from "../../hooks/useAlert";
 import Editor from "@monaco-editor/react";
-import { useTheme } from "../../hooks/useTheme";
+import { useEditorTheme } from "../../hooks/useEditorTheme";
 import { loadMonacoTheme } from "../../themes/themeUtils";
 import { Modal } from "../ui/Modal";
 import {
@@ -57,7 +57,7 @@ const ClientIcon = ({
 
 export const McpModal = ({ isOpen, onClose }: McpModalProps) => {
   const { t } = useTranslation();
-  const { currentTheme } = useTheme();
+  const editorTheme = useEditorTheme();
   const { showAlert } = useAlert();
   const [clients, setClients] = useState<McpClientStatus[]>([]);
   const [loading, setLoading] = useState(true);
@@ -247,9 +247,9 @@ export const McpModal = ({ isOpen, onClose }: McpModalProps) => {
                         <Editor
                           height="160px"
                           defaultLanguage="json"
-                          theme={currentTheme.id}
+                          theme={editorTheme.id}
                           value={jsonValue}
-                          beforeMount={(monaco) => loadMonacoTheme(currentTheme, monaco)}
+                          beforeMount={(monaco) => loadMonacoTheme(editorTheme, monaco)}
                           options={{
                             readOnly: true,
                             minimap: { enabled: false },

--- a/src/components/modals/QueryModal.tsx
+++ b/src/components/modals/QueryModal.tsx
@@ -2,8 +2,7 @@ import { useState, useEffect } from 'react';
 import { X, Save } from 'lucide-react';
 import MonacoEditor, { type BeforeMount } from '@monaco-editor/react';
 import { useTranslation } from 'react-i18next';
-import { useTheme } from '../../hooks/useTheme';
-import { useSettings } from '../../hooks/useSettings';
+import { useEditorTheme } from '../../hooks/useEditorTheme';
 import { loadMonacoTheme } from '../../themes/themeUtils';
 import { Modal } from '../ui/Modal';
 import { Select } from '../ui/Select';
@@ -26,12 +25,7 @@ export const QueryModal = ({ isOpen, onClose, onSave, initialName = '', initialS
   const [database, setDatabase] = useState<string | null>(initialDatabase ?? null);
   const [error, setError] = useState('');
   const [isSaving, setIsSaving] = useState(false);
-  const { currentTheme, allThemes } = useTheme();
-  const { settings } = useSettings();
-
-  const editorTheme = settings.editorTheme
-    ? (allThemes.find((t) => t.id === settings.editorTheme) ?? currentTheme)
-    : currentTheme;
+  const editorTheme = useEditorTheme();
 
   const handleBeforeMount: BeforeMount = (monaco) => {
     loadMonacoTheme(editorTheme, monaco);

--- a/src/components/ui/CellCodeEditor.tsx
+++ b/src/components/ui/CellCodeEditor.tsx
@@ -1,10 +1,10 @@
-import { useContext, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import MonacoEditor, {
   type BeforeMount,
   type OnValidate,
 } from "@monaco-editor/react";
 import type * as MonacoTypes from "monaco-editor";
-import { ThemeContext } from "../../contexts/ThemeContext";
+import { useEditorTheme } from "../../hooks/useEditorTheme";
 import { loadMonacoTheme } from "../../themes/themeUtils";
 
 interface CellCodeEditorProps {
@@ -16,8 +16,6 @@ interface CellCodeEditorProps {
   language?: "json" | "plaintext";
 }
 
-const DEFAULT_THEME = "vs-dark";
-
 export const CellCodeEditor = ({
   value,
   onChange,
@@ -26,21 +24,18 @@ export const CellCodeEditor = ({
   readOnly = false,
   language = "json",
 }: CellCodeEditorProps) => {
-  const themeCtx = useContext(ThemeContext);
-  const currentTheme = themeCtx?.currentTheme;
+  const editorTheme = useEditorTheme();
   const monacoRef = useRef<typeof MonacoTypes | null>(null);
 
   useEffect(() => {
-    if (monacoRef.current && currentTheme) {
-      loadMonacoTheme(currentTheme, monacoRef.current);
+    if (monacoRef.current) {
+      loadMonacoTheme(editorTheme, monacoRef.current);
     }
-  }, [currentTheme]);
+  }, [editorTheme]);
 
   const handleBeforeMount: BeforeMount = (monaco) => {
     monacoRef.current = monaco;
-    if (currentTheme) {
-      loadMonacoTheme(currentTheme, monaco);
-    }
+    loadMonacoTheme(editorTheme, monaco);
   };
 
   const handleChange = (next: string | undefined) => {
@@ -55,7 +50,7 @@ export const CellCodeEditor = ({
     <MonacoEditor
       height={height}
       language={language}
-      theme={currentTheme?.id ?? DEFAULT_THEME}
+      theme={editorTheme.id}
       value={value}
       beforeMount={handleBeforeMount}
       onChange={handleChange}

--- a/src/components/ui/CellDiffEditor.tsx
+++ b/src/components/ui/CellDiffEditor.tsx
@@ -1,7 +1,7 @@
-import { useContext, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { DiffEditor, type DiffOnMount } from "@monaco-editor/react";
 import type * as MonacoTypes from "monaco-editor";
-import { ThemeContext } from "../../contexts/ThemeContext";
+import { useEditorTheme } from "../../hooks/useEditorTheme";
 import { loadMonacoTheme } from "../../themes/themeUtils";
 
 interface CellDiffEditorProps {
@@ -14,8 +14,6 @@ interface CellDiffEditorProps {
   language?: "json" | "plaintext";
 }
 
-const DEFAULT_THEME = "vs-dark";
-
 export const CellDiffEditor = ({
   original,
   modified,
@@ -25,25 +23,22 @@ export const CellDiffEditor = ({
   renderSideBySide = false,
   language = "json",
 }: CellDiffEditorProps) => {
-  const themeCtx = useContext(ThemeContext);
-  const currentTheme = themeCtx?.currentTheme;
+  const editorTheme = useEditorTheme();
   const monacoRef = useRef<typeof MonacoTypes | null>(null);
   const editorRef = useRef<MonacoTypes.editor.IStandaloneDiffEditor | null>(
     null,
   );
 
   useEffect(() => {
-    if (monacoRef.current && currentTheme) {
-      loadMonacoTheme(currentTheme, monacoRef.current);
+    if (monacoRef.current) {
+      loadMonacoTheme(editorTheme, monacoRef.current);
     }
-  }, [currentTheme]);
+  }, [editorTheme]);
 
   const handleMount: DiffOnMount = (editor, monaco) => {
     monacoRef.current = monaco;
     editorRef.current = editor;
-    if (currentTheme) {
-      loadMonacoTheme(currentTheme, monaco);
-    }
+    loadMonacoTheme(editorTheme, monaco);
 
     editor.getOriginalEditor().updateOptions({ readOnly: true });
     editor.getModifiedEditor().updateOptions({ readOnly });
@@ -59,7 +54,7 @@ export const CellDiffEditor = ({
       key={renderSideBySide ? "sbs" : "inline"}
       height={height}
       language={language}
-      theme={currentTheme?.id ?? DEFAULT_THEME}
+      theme={editorTheme.id}
       original={original}
       modified={modified}
       onMount={handleMount}

--- a/src/components/ui/SqlEditorWrapper.tsx
+++ b/src/components/ui/SqlEditorWrapper.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useCallback, useEffect } from "react";
 import MonacoEditor, { type OnMount, type BeforeMount } from "@monaco-editor/react";
 import type * as Monaco from "monaco-editor";
-import { useTheme } from "../../hooks/useTheme";
+import { useEditorTheme } from "../../hooks/useEditorTheme";
 import { loadMonacoTheme } from "../../themes/themeUtils";
 import { readText } from "@tauri-apps/plugin-clipboard-manager";
 import { useSettings } from "../../hooks/useSettings";
@@ -31,12 +31,8 @@ const SqlEditorInternal = ({
   const monacoRef = useRef<typeof Monaco | null>(null);
   const onRunRef = useRef(onRun);
   onRunRef.current = onRun;
-  const { currentTheme, allThemes } = useTheme();
+  const editorTheme = useEditorTheme();
   const { settings } = useSettings();
-
-  const editorTheme = settings.editorTheme
-    ? (allThemes.find((t) => t.id === settings.editorTheme) ?? currentTheme)
-    : currentTheme;
 
   // Dispose editor on unmount to prevent "domNode" errors from ResizeObserver
   // firing after the DOM container is removed (e.g., cell deletion/movement)

--- a/src/components/ui/SqlPreview.tsx
+++ b/src/components/ui/SqlPreview.tsx
@@ -1,7 +1,7 @@
 import { useRef, useEffect } from "react";
 import MonacoEditor, { type BeforeMount } from "@monaco-editor/react";
 import type * as MonacoTypes from "monaco-editor";
-import { useTheme } from "../../hooks/useTheme";
+import { useEditorTheme } from "../../hooks/useEditorTheme";
 import { loadMonacoTheme } from "../../themes/themeUtils";
 
 interface SqlPreviewProps {
@@ -17,20 +17,20 @@ export const SqlPreview = ({
   height = "120px",
   showLineNumbers = false,
 }: SqlPreviewProps) => {
-  const { currentTheme } = useTheme();
+  const editorTheme = useEditorTheme();
   const monacoRef = useRef<typeof MonacoTypes | null>(null);
 
   // Update Monaco theme when theme changes
   useEffect(() => {
     if (monacoRef.current) {
-      loadMonacoTheme(currentTheme, monacoRef.current);
+      loadMonacoTheme(editorTheme, monacoRef.current);
     }
-  }, [currentTheme]);
+  }, [editorTheme]);
 
   const handleBeforeMount: BeforeMount = (monaco) => {
     monacoRef.current = monaco;
     // Load Monaco theme before editor is created
-    loadMonacoTheme(currentTheme, monaco);
+    loadMonacoTheme(editorTheme, monaco);
   };
 
   return (
@@ -38,7 +38,7 @@ export const SqlPreview = ({
       <MonacoEditor
         height={height}
         language="sql"
-        theme={currentTheme.id}
+        theme={editorTheme.id}
         value={sql}
         beforeMount={handleBeforeMount}
         options={{

--- a/src/hooks/useEditorTheme.ts
+++ b/src/hooks/useEditorTheme.ts
@@ -1,0 +1,20 @@
+import { useTheme } from "./useTheme";
+import { useSettings } from "./useSettings";
+import type { Theme } from "../types/theme";
+
+/**
+ * Resolves the effective Monaco editor theme: the dedicated editor theme
+ * override from settings when set, otherwise the current UI theme.
+ *
+ * Monaco themes are global (one theme for every editor instance on the page),
+ * so every Monaco-based component must resolve its theme through this hook —
+ * otherwise mounting one editor switches the colors of all the others.
+ */
+export function useEditorTheme(): Theme {
+  const { currentTheme, allThemes } = useTheme();
+  const { settings } = useSettings();
+
+  return settings.editorTheme
+    ? (allThemes.find((t) => t.id === settings.editorTheme) ?? currentTheme)
+    : currentTheme;
+}

--- a/src/pages/McpPage.tsx
+++ b/src/pages/McpPage.tsx
@@ -21,7 +21,7 @@ import {
 import { AiActivityPanel } from "../components/settings/AiActivityPanel";
 import { McpSafetySection } from "../components/modals/mcp/McpSafetySection";
 import { useAlert } from "../hooks/useAlert";
-import { useTheme } from "../hooks/useTheme";
+import { useEditorTheme } from "../hooks/useEditorTheme";
 import { loadMonacoTheme } from "../themes/themeUtils";
 
 interface McpClientStatus {
@@ -126,7 +126,7 @@ export function McpPage() {
 
 function McpSetupPanel() {
   const { t } = useTranslation();
-  const { currentTheme } = useTheme();
+  const editorTheme = useEditorTheme();
   const { showAlert } = useAlert();
   const [clients, setClients] = useState<McpClientStatus[]>([]);
   const [loading, setLoading] = useState(true);
@@ -298,9 +298,9 @@ function McpSetupPanel() {
                 <Editor
                   height="220px"
                   defaultLanguage="json"
-                  theme={currentTheme.id}
+                  theme={editorTheme.id}
                   value={jsonValue}
-                  beforeMount={(monaco) => loadMonacoTheme(currentTheme, monaco)}
+                  beforeMount={(monaco) => loadMonacoTheme(editorTheme, monaco)}
                   options={{
                     readOnly: true,
                     minimap: { enabled: false },

--- a/tests/components/ui/CellCodeEditor.test.tsx
+++ b/tests/components/ui/CellCodeEditor.test.tsx
@@ -1,9 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { CellCodeEditor } from "../../../src/components/ui/CellCodeEditor";
-import { ThemeContext, type ThemeContextType } from "../../../src/contexts/ThemeContext";
 import type { Theme } from "../../../src/types/theme";
-import type { ReactNode } from "react";
 
 interface MonacoMockProps {
   value?: string;
@@ -49,29 +47,13 @@ const makeTheme = (id: string): Theme =>
     monacoTheme: { themeName: id },
   }) as unknown as Theme;
 
-const makeContextValue = (theme: Theme): ThemeContextType =>
-  ({
-    currentTheme: theme,
-    settings: {} as ThemeContextType["settings"],
-    allThemes: [theme],
-    isLoading: false,
-    setTheme: vi.fn(),
-    createCustomTheme: vi.fn(),
-    updateCustomTheme: vi.fn(),
-    deleteCustomTheme: vi.fn(),
-    duplicateTheme: vi.fn(),
-    importTheme: vi.fn(),
-    exportTheme: vi.fn(),
-    updateSettings: vi.fn(),
-  }) as unknown as ThemeContextType;
+const mockEditorTheme: { current: Theme } = {
+  current: makeTheme("tabularis-dark"),
+};
 
-const withTheme =
-  (theme: Theme) =>
-  ({ children }: { children: ReactNode }) => (
-    <ThemeContext.Provider value={makeContextValue(theme)}>
-      {children}
-    </ThemeContext.Provider>
-  );
+vi.mock("../../../src/hooks/useEditorTheme", () => ({
+  useEditorTheme: () => mockEditorTheme.current,
+}));
 
 describe("CellCodeEditor", () => {
   beforeEach(() => {
@@ -97,22 +79,24 @@ describe("CellCodeEditor", () => {
     ).toBe("plaintext");
   });
 
-  it("falls back to vs-dark when no ThemeContext is present", () => {
+  it("uses the theme resolved by useEditorTheme", () => {
     render(<CellCodeEditor value="" onChange={vi.fn()} />);
-
-    expect(screen.getByTestId("monaco-editor").getAttribute("data-theme")).toBe(
-      "vs-dark",
-    );
-  });
-
-  it("uses currentTheme.id when ThemeContext provides one", () => {
-    render(<CellCodeEditor value="" onChange={vi.fn()} />, {
-      wrapper: withTheme(makeTheme("tabularis-dark")),
-    });
 
     expect(screen.getByTestId("monaco-editor").getAttribute("data-theme")).toBe(
       "tabularis-dark",
     );
+  });
+
+  it("follows the editor theme when it changes", () => {
+    mockEditorTheme.current = makeTheme("custom-editor-theme");
+
+    render(<CellCodeEditor value="" onChange={vi.fn()} />);
+
+    expect(screen.getByTestId("monaco-editor").getAttribute("data-theme")).toBe(
+      "custom-editor-theme",
+    );
+
+    mockEditorTheme.current = makeTheme("tabularis-dark");
   });
 
   it("forwards edits through onChange", () => {

--- a/tests/components/ui/SqlPreview.test.tsx
+++ b/tests/components/ui/SqlPreview.test.tsx
@@ -11,11 +11,9 @@ vi.mock('@monaco-editor/react', () => ({
   )),
 }));
 
-// Mock useTheme hook
-vi.mock('../../../src/hooks/useTheme', () => ({
-  useTheme: vi.fn(() => ({
-    currentTheme: { id: 'tabularis-dark' },
-  })),
+// Mock useEditorTheme hook
+vi.mock('../../../src/hooks/useEditorTheme', () => ({
+  useEditorTheme: vi.fn(() => ({ id: 'tabularis-dark' })),
 }));
 
 // Mock themeUtils

--- a/tests/hooks/useEditorTheme.test.ts
+++ b/tests/hooks/useEditorTheme.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import React, { type ReactNode } from 'react';
+import { useEditorTheme } from '../../src/hooks/useEditorTheme';
+import { ThemeContext, type ThemeContextType } from '../../src/contexts/ThemeContext';
+import {
+  SettingsContext,
+  DEFAULT_SETTINGS,
+  type SettingsContextType,
+  type Settings,
+} from '../../src/contexts/SettingsContext';
+import type { Theme, ThemeSettings } from '../../src/types/theme';
+
+const makeTheme = (id: string): Theme => ({
+  id,
+  name: id,
+  isPreset: false,
+  isReadOnly: false,
+  colors: {} as Theme['colors'],
+  typography: {} as Theme['typography'],
+  layout: {} as Theme['layout'],
+  monacoTheme: { base: 'vs-dark', inherit: true },
+});
+
+const uiTheme = makeTheme('ui-theme');
+const dedicatedTheme = makeTheme('dedicated-editor-theme');
+
+const themeSettings: ThemeSettings = {
+  activeThemeId: 'ui-theme',
+  followSystemTheme: false,
+  lightThemeId: 'tabularis-light',
+  darkThemeId: 'tabularis-dark',
+  customThemes: [],
+};
+
+const makeThemeContext = (): ThemeContextType => ({
+  currentTheme: uiTheme,
+  settings: themeSettings,
+  allThemes: [uiTheme, dedicatedTheme],
+  isLoading: false,
+  setTheme: vi.fn(),
+  createCustomTheme: vi.fn(),
+  updateCustomTheme: vi.fn(),
+  deleteCustomTheme: vi.fn(),
+  duplicateTheme: vi.fn(),
+  importTheme: vi.fn(),
+  exportTheme: vi.fn(),
+  updateSettings: vi.fn(),
+});
+
+const makeSettingsContext = (settings: Settings): SettingsContextType => ({
+  settings,
+  updateSetting: vi.fn(),
+  isLoading: false,
+});
+
+const renderWithProviders = (settings: Settings) => {
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(
+      ThemeContext.Provider,
+      { value: makeThemeContext() },
+      React.createElement(
+        SettingsContext.Provider,
+        { value: makeSettingsContext(settings) },
+        children,
+      ),
+    );
+
+  return renderHook(() => useEditorTheme(), { wrapper });
+};
+
+describe('useEditorTheme', () => {
+  it('returns the current UI theme when no editor theme override is set', () => {
+    const { result } = renderWithProviders({ ...DEFAULT_SETTINGS, editorTheme: undefined });
+    expect(result.current.id).toBe('ui-theme');
+  });
+
+  it('returns the dedicated editor theme when the override is set', () => {
+    const { result } = renderWithProviders({
+      ...DEFAULT_SETTINGS,
+      editorTheme: 'dedicated-editor-theme',
+    });
+    expect(result.current.id).toBe('dedicated-editor-theme');
+  });
+
+  it('falls back to the current UI theme when the override points to a missing theme', () => {
+    const { result } = renderWithProviders({
+      ...DEFAULT_SETTINGS,
+      editorTheme: 'deleted-theme',
+    });
+    expect(result.current.id).toBe('ui-theme');
+  });
+
+  it('throws when used outside the providers', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => {
+      renderHook(() => useEditorTheme());
+    }).toThrow();
+
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Closes #281

Monaco themes are global to the page, so every editor instance has to agree on which theme is active. Until now each Monaco-based component resolved the theme on its own: most used the UI theme, the SQL editor and the save-query modal honored the `editorTheme` settings override, and the AI explain modal passed a theme id without ever registering it through `loadMonacoTheme`. Whichever editor mounted last won, so opening the AI explanation modal re-colored every other editor in the app.

## Changes

- New `useEditorTheme` hook that resolves the effective editor theme: the `editorTheme` settings override when set, otherwise the current UI theme (with fallback if the override points to a deleted theme)
- All Monaco usages now go through the hook: `SqlEditorWrapper`, `SqlPreview`, `QueryModal`, `AiExplainModal`, `AiApprovalModal`, `ConfigJsonModal`, `McpModal`, `McpPage`, `VisualExplainView`, `CellCodeEditor`, `CellDiffEditor`
- `AiExplainModal` now registers the theme in `beforeMount` and reacts to theme changes while open, like the other editors already did
- `CellCodeEditor`/`CellDiffEditor` dropped their optional ThemeContext handling (they always render inside the providers); tests updated accordingly
- Unit tests for the new hook in `tests/hooks/useEditorTheme.test.ts`

## Testing

- `npx tsc --noEmit` clean
- `npx vitest run`: 2494 passed, 0 failed
- ESLint clean on the touched files