### PR TITLE
fix(grid): truncate large JSON/text cell previews to avoid UI freeze

### DIFF
--- a/demo/init/mysql/03-json-demo.sql
+++ b/demo/init/mysql/03-json-demo.sql
@@ -43,3 +43,36 @@ INSERT INTO json_demo (label, payload, notes_text) VALUES
   ('unicode + emoji',
    '{"greeting":"こんにちは","emoji":"🦊🐾","math":"∑(α+β)²"}',
    '{"emoji":"⚙️"}');
+
+-- -------------------------------------------------------------
+-- Large payload — reproduces grid lag with big JSON cells (#283).
+-- ~3000 nested objects build a multi-hundred-KB / ~1MB JSON blob.
+-- The grid must stay responsive: only a truncated preview renders
+-- inline, the full value opens in the JSON viewer on demand.
+-- -------------------------------------------------------------
+SET SESSION cte_max_recursion_depth = 100000;
+
+INSERT INTO json_demo (label, payload, notes_text)
+SELECT
+  'large payload (perf stress, 3000 items)',
+  JSON_OBJECT('generated', TRUE, 'count', 3000, 'items', items.arr),
+  'large JSON blob — see issue #283 (grid must not freeze)'
+FROM (
+  WITH RECURSIVE seq (n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT n + 1 FROM seq WHERE n < 3000
+  )
+  SELECT JSON_ARRAYAGG(
+    JSON_OBJECT(
+      'id', n,
+      'name', CONCAT('item-', n),
+      'description', REPEAT('lorem ipsum dolor sit amet consectetur ', 4),
+      'value', n * 1.5,
+      'active', (n % 2 = 0),
+      'tags', JSON_ARRAY('alpha', 'beta', 'gamma', 'delta'),
+      'nested', JSON_OBJECT('a', n, 'b', CONCAT('x-', n), 'c', JSON_ARRAY(n, n + 1, n + 2))
+    )
+  ) AS arr
+  FROM seq
+) AS items;

--- a/demo/init/postgres/03-json-demo.sql
+++ b/demo/init/postgres/03-json-demo.sql
@@ -44,3 +44,32 @@ INSERT INTO json_demo (label, payload, notes_text) VALUES
   ('unicode + emoji',
    '{"greeting":"こんにちは","emoji":"🦊🐾","math":"∑(α+β)²"}'::jsonb,
    '{"emoji":"⚙️"}');
+
+-- -------------------------------------------------------------
+-- Large payload — reproduces grid lag with big JSON cells (#283).
+-- ~3000 nested objects build a multi-hundred-KB / ~1MB JSON blob.
+-- The grid must stay responsive: only a truncated preview renders
+-- inline, the full value opens in the JSON viewer on demand.
+-- -------------------------------------------------------------
+INSERT INTO json_demo (label, payload, notes_text)
+SELECT
+  'large payload (perf stress, 3000 items)',
+  jsonb_build_object(
+    'generated', true,
+    'count', 3000,
+    'items', (
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'id', i,
+          'name', 'item-' || i,
+          'description', repeat('lorem ipsum dolor sit amet consectetur ', 4),
+          'value', i * 1.5,
+          'active', (i % 2 = 0),
+          'tags', jsonb_build_array('alpha', 'beta', 'gamma', 'delta'),
+          'nested', jsonb_build_object('a', i, 'b', 'x-' || i, 'c', jsonb_build_array(i, i + 1, i + 2))
+        )
+      )
+      FROM generate_series(1, 3000) AS i
+    )
+  ),
+  'large JSON blob — see issue #283 (grid must not freeze)';

--- a/src/components/ui/DataGrid.tsx
+++ b/src/components/ui/DataGrid.tsx
@@ -50,7 +50,7 @@ import {
 import { isGeometricType, formatGeometricValue } from "../../utils/geometry";
 import { isBlobColumn, isBlobWireFormat } from "../../utils/blob";
 import { isJsonColumn, isJsonContent } from "../../utils/json";
-import { isLongTextCellTarget } from "../../utils/text";
+import { isLongTextCellTarget, truncateCellPreview } from "../../utils/text";
 import {
   pickPrimaryForeignKeyByColumn,
   getForeignKeyForPreview,
@@ -1369,12 +1369,14 @@ export const DataGrid = React.memo(
                             className={`px-4 py-1.5 text-sm border-b border-r border-default last:border-r-0 font-mono ${isEditing ? "relative" : "whitespace-nowrap truncate max-w-[300px]"} ${fkForPreview ? "cursor-pointer" : "cursor-text"} ${stateClass} ${isFocused ? "ring-2 ring-inset ring-blue-400" : ""}`}
                             title={
                               !isEditing
-                                ? formatCellValue(
-                                    displayValue,
-                                    t("dataGrid.null"),
-                                    colTypeForCell,
-                                    columnLengthMap?.get(colName),
-                                  )
+                                ? truncateCellPreview(
+                                    formatCellValue(
+                                      displayValue,
+                                      t("dataGrid.null"),
+                                      colTypeForCell,
+                                      columnLengthMap?.get(colName),
+                                    ),
+                                  ).text
                                 : ""
                             }
                           >

--- a/src/components/ui/JsonCell.tsx
+++ b/src/components/ui/JsonCell.tsx
@@ -2,6 +2,7 @@ import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Braces, ChevronRight } from "lucide-react";
 import { tokenizeJsonDisplay, type JsonToken } from "../../utils/jsonHighlight";
+import { truncateCellPreview } from "../../utils/text";
 
 interface JsonCellProps {
   value: unknown;
@@ -32,24 +33,35 @@ export const JsonCell = ({
 }: JsonCellProps) => {
   const { t } = useTranslation();
   const textRef = useRef<HTMLSpanElement>(null);
-  const [isTruncated, setIsTruncated] = useState(false);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+
+  // Only ever tokenize/render a bounded preview. Large JSON values (often
+  // megabytes) would otherwise explode into thousands of DOM nodes per cell and
+  // freeze the grid, despite being clipped to ~300px. The full value stays
+  // available through the expander / viewer below.
+  const { text: previewText, truncated } = useMemo(
+    () => truncateCellPreview(displayText),
+    [displayText],
+  );
 
   useLayoutEffect(() => {
     const el = textRef.current;
     if (!el) return;
-    setIsTruncated(el.scrollWidth > el.clientWidth);
-  }, [displayText]);
+    setIsOverflowing(el.scrollWidth > el.clientWidth);
+  }, [previewText]);
 
   const tokens = useMemo(() => {
     try {
-      return tokenizeJsonDisplay(displayText);
+      return tokenizeJsonDisplay(previewText);
     } catch {
-      return [{ type: "string" as const, text: displayText }];
+      return [{ type: "string" as const, text: previewText }];
     }
-  }, [displayText]);
+  }, [previewText]);
 
   const isNullish = value === null || value === undefined;
   const showIcons = !isNullish && !isPendingDelete;
+  // Truncated content always has more to reveal, so surface the affordances.
+  const isTruncated = isOverflowing || truncated;
   const iconVisibilityClass = isTruncated
     ? "opacity-100"
     : "opacity-0 group-hover/jsoncell:opacity-100";
@@ -59,7 +71,7 @@ export const JsonCell = ({
       className={`flex items-center gap-1 group/jsoncell w-full ${
         isTruncated ? "json-cell-truncated" : ""
       }`}
-      title={displayText}
+      title={truncated ? `${previewText}…` : previewText}
     >
       <span ref={textRef} className="truncate flex-1">
         {tokens.map((tok, idx) => (
@@ -71,6 +83,7 @@ export const JsonCell = ({
             {tok.text}
           </span>
         ))}
+        {truncated && <span className="text-muted">…</span>}
       </span>
       {showIcons && (
         <>

--- a/src/components/ui/TextCell.tsx
+++ b/src/components/ui/TextCell.tsx
@@ -1,6 +1,7 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronRight } from "lucide-react";
+import { truncateCellPreview } from "../../utils/text";
 
 interface TextCellProps {
   value: unknown;
@@ -19,31 +20,41 @@ export const TextCell = ({
 }: TextCellProps) => {
   const { t } = useTranslation();
   const textRef = useRef<HTMLSpanElement>(null);
-  const [isTruncated, setIsTruncated] = useState(false);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+
+  // Cap the inline preview before any per-character work. Multi-megabyte text
+  // values would otherwise stringify, newline-replace and render in full on
+  // every pass; the full value remains available via the inline expander.
+  const { text: previewText, truncated } = useMemo(
+    () => truncateCellPreview(displayText),
+    [displayText],
+  );
 
   useLayoutEffect(() => {
     const el = textRef.current;
     if (!el) return;
-    setIsTruncated(el.scrollWidth > el.clientWidth);
-  }, [displayText]);
+    setIsOverflowing(el.scrollWidth > el.clientWidth);
+  }, [previewText]);
 
   const isNullish = value === null || value === undefined;
   const showChevron = !isNullish && !isPendingDelete;
+  const isTruncated = isOverflowing || truncated;
   const iconVisibilityClass = isTruncated
     ? "opacity-100"
     : "opacity-0 group-hover/textcell:opacity-100";
 
-  const preview = displayText.includes("\n")
-    ? displayText.replace(/\n/g, " ⏎ ")
-    : displayText;
+  const preview = previewText.includes("\n")
+    ? previewText.replace(/\n/g, " ⏎ ")
+    : previewText;
 
   return (
     <span
       className="flex items-center gap-1 group/textcell w-full"
-      title={displayText}
+      title={truncated ? `${previewText}…` : displayText}
     >
       <span ref={textRef} className="truncate flex-1">
         {preview}
+        {truncated && "…"}
       </span>
       {showChevron && (
         <button

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -16,6 +16,37 @@ const TEXT_TYPES = [
 
 export const LONG_TEXT_THRESHOLD = 80;
 
+/**
+ * Maximum number of characters rendered inline in a data-grid cell preview.
+ *
+ * Grid cells are CSS-truncated to ~300px, so anything past a few hundred
+ * characters is never visible. Tokenizing/rendering megabyte-sized values
+ * (e.g. large MySQL `JSON` columns) into the cell freezes the UI, even though
+ * none of it can be read inline. Capping the preview keeps rendering cheap; the
+ * full value stays reachable via the inline expander and the JSON viewer.
+ */
+export const CELL_PREVIEW_LIMIT = 300;
+
+export interface CellPreview {
+  /** The (possibly shortened) string safe to render inline. */
+  text: string;
+  /** Whether the source string was longer than the limit. */
+  truncated: boolean;
+}
+
+/**
+ * Shortens a display string to a cheap inline preview. Returns the original
+ * string untouched (with `truncated: false`) when it is already within the
+ * limit, so short cells incur no allocation.
+ */
+export function truncateCellPreview(
+  text: string,
+  limit: number = CELL_PREVIEW_LIMIT,
+): CellPreview {
+  if (text.length <= limit) return { text, truncated: false };
+  return { text: text.slice(0, limit), truncated: true };
+}
+
 // Substring match so parameterised forms like "VARCHAR(255)" or
 // "CHARACTER VARYING(50)" still resolve as text.
 export function isTextColumn(dataType: string | undefined): boolean {

--- a/tests/components/ui/JsonCell.test.tsx
+++ b/tests/components/ui/JsonCell.test.tsx
@@ -81,6 +81,30 @@ describe("JsonCell", () => {
     expect(cell.className).toMatch(/json-cell-truncated/);
   });
 
+  it("renders only a bounded preview for very large JSON values", () => {
+    // A multi-megabyte stringified value must not explode into the DOM.
+    const huge = `{"items":[${Array.from({ length: 5000 }, (_, i) => `{"id":${i},"name":"item-${i}"}`).join(",")}]}`;
+    const { container } = render(
+      <JsonCell {...baseProps} value={{ big: true }} displayText={huge} />,
+    );
+    const previewSpan = container.querySelector(".truncate") as HTMLElement;
+    // Rendered text stays bounded regardless of the source size.
+    expect(previewSpan.textContent!.length).toBeLessThan(huge.length);
+    expect(previewSpan.textContent!.length).toBeLessThan(400);
+    // The trailing ellipsis signals there is more behind the viewer.
+    expect(previewSpan.textContent).toContain("…");
+  });
+
+  it("keeps expand/viewer affordances visible when the preview is truncated", () => {
+    setScrollDims(100, 200); // not visually overflowing…
+    const huge = `"${"x".repeat(10000)}"`; // …but truncated by the length cap
+    const { container } = render(
+      <JsonCell {...baseProps} value={"x".repeat(10000)} displayText={huge} />,
+    );
+    const cell = container.firstChild as HTMLElement;
+    expect(cell.className).toMatch(/json-cell-truncated/);
+  });
+
   it("hides icons when isPendingDelete is true", () => {
     render(<JsonCell {...baseProps} isPendingDelete={true} />);
     expect(screen.queryByRole("button", { name: /expand/i })).toBeNull();

--- a/tests/utils/text.test.ts
+++ b/tests/utils/text.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect } from "vitest";
 import {
+  CELL_PREVIEW_LIMIT,
   LONG_TEXT_THRESHOLD,
   formatTextForEditor,
   isLongTextCellTarget,
   isLongTextValue,
   isTextColumn,
+  truncateCellPreview,
 } from "../../src/utils/text";
 
 describe("text", () => {
@@ -100,6 +102,38 @@ describe("text", () => {
       expect(isLongTextCellTarget("TEXT", null)).toBe(false);
       expect(isLongTextCellTarget("TEXT", undefined)).toBe(false);
       expect(isLongTextCellTarget("TEXT", 12345)).toBe(false);
+    });
+  });
+
+  describe("truncateCellPreview", () => {
+    it("returns short strings untouched without flagging truncation", () => {
+      const result = truncateCellPreview("hello");
+      expect(result.text).toBe("hello");
+      expect(result.truncated).toBe(false);
+    });
+
+    it("returns the original reference at exactly the limit", () => {
+      const exact = "a".repeat(CELL_PREVIEW_LIMIT);
+      const result = truncateCellPreview(exact);
+      expect(result.text).toBe(exact);
+      expect(result.truncated).toBe(false);
+    });
+
+    it("slices to the limit and flags truncation beyond it", () => {
+      const long = "a".repeat(CELL_PREVIEW_LIMIT + 5000);
+      const result = truncateCellPreview(long);
+      expect(result.text).toHaveLength(CELL_PREVIEW_LIMIT);
+      expect(result.truncated).toBe(true);
+    });
+
+    it("honours a custom limit", () => {
+      const result = truncateCellPreview("abcdef", 3);
+      expect(result.text).toBe("abc");
+      expect(result.truncated).toBe(true);
+    });
+
+    it("treats an empty string as untruncated", () => {
+      expect(truncateCellPreview("")).toEqual({ text: "", truncated: false });
     });
   });
 


### PR DESCRIPTION
Large JSON column values (e.g. MySQL `JSON`) froze the grid: each visible cell tokenized and rendered its **full** stringified value into thousands of DOM nodes — despite cells being clipped to ~300px and the full value already being reachable on demand.

**Fix:** cap the inline preview (`truncateCellPreview`, 300 chars) before tokenization/render in `JsonCell` and `TextCell`, and cap the native `<td>` tooltip. The full value stays available via the inline expander and JSON viewer, which read the raw row value (not `displayText`) — so the cap is lossless.

Adds a ~1 MB big-JSON row to the MySQL and Postgres JSON demos to reproduce.

Verified: `tsc --noEmit`, `eslint`, 154 UI + utils tests green (incl. new `truncateCellPreview` and bounded-preview cases).

Closes #283