### PR TITLE
ci: sign and notarize macOS release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,12 +112,29 @@ jobs:
         if: matrix.platform == 'ubuntu-24.04'
         run: cargo install tauri-cli --git https://github.com/tauri-apps/tauri --branch feat/truly-portable-appimage --force
 
+      # Notarization needs the App Store Connect API key on disk. The .p8 is stored
+      # base64-encoded in APPLE_API_KEY_CONTENT and decoded into a temp file (macOS only).
+      - name: Prepare Apple API key (macOS only)
+        if: startsWith(matrix.platform, 'macos')
+        shell: bash
+        run: |
+          echo "${{ secrets.APPLE_API_KEY_CONTENT }}" | base64 --decode > "$RUNNER_TEMP/apple_api_key.p8"
+          echo "APPLE_API_KEY_PATH=$RUNNER_TEMP/apple_api_key.p8" >> "$GITHUB_ENV"
+
       - uses: tauri-apps/tauri-action@v0.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_BUNDLER_NEW_APPIMAGE_FORMAT: "true"
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+          # macOS code signing (Developer ID Application certificate)
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          # macOS notarization (App Store Connect API key)
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_PATH: ${{ env.APPLE_API_KEY_PATH }}
         with:
           tagName: ${{ steps.meta.outputs.tag }}
           releaseName: "v__VERSION__"


### PR DESCRIPTION
## What

macOS release builds are now code-signed with a Developer ID Application certificate and notarized through App Store Connect, so users no longer hit Gatekeeper warnings when opening the app.

## How

`tauri-action` already handles signing and notarization when the right environment variables are present, so this wires them up:

- A new macOS-only step decodes the App Store Connect API key (`.p8`) from a base64 secret into a temp file and exports its path.
- The signing identity, certificate, and API key credentials are passed to `tauri-action` via `env`.

Notarization uses an App Store Connect API key rather than an Apple ID app-specific password, since the key doesn't expire and is easier to rotate in CI.

The Apple variables are set for every matrix entry but only take effect on the macOS jobs — tauri ignores them when bundling for Linux and Windows.

## Required secrets

These must be added in repo settings before the next tagged release:

| Secret | Description |
|--------|-------------|
| `APPLE_CERTIFICATE` | base64 of the Developer ID Application `.p12` |
| `APPLE_CERTIFICATE_PASSWORD` | password for the `.p12` |
| `APPLE_SIGNING_IDENTITY` | e.g. `Developer ID Application: Name (TEAMID)` |
| `APPLE_API_ISSUER` | App Store Connect issuer ID |
| `APPLE_API_KEY` | API key ID |
| `APPLE_API_KEY_CONTENT` | base64 of the `.p8` key file |

## Testing

Not exercisable from a PR — needs a tagged release (or a `workflow_dispatch` run) once the secrets are in place. After a build, the DMG can be verified with `spctl -a -t install` and `xcrun stapler validate`.
