### PR TITLE
fix(autocomplete): suggest clause keywords and correct columns after …

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6188,7 +6188,7 @@ dependencies = [
 
 [[package]]
 name = "tabularis"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/src/contexts/DatabaseContext.ts
+++ b/src/contexts/DatabaseContext.ts
@@ -3,6 +3,7 @@ import type { DriverCapabilities } from '../types/plugins';
 
 export interface TableInfo {
   name: string;
+  schema?: string; // database/schema the table belongs to (populated in multiDb mode)
 }
 
 export interface ViewInfo {

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -2145,7 +2145,9 @@ export const Editor = () => {
       if (activeCapabilities?.schemas && activeSchema) {
         effectiveTables = schemaDataMap[activeSchema]?.tables ?? tables;
       } else if (isMultiDb) {
-        effectiveTables = selectedDatabases.flatMap(db => databaseDataMap[db]?.tables ?? []);
+        effectiveTables = selectedDatabases.flatMap(db =>
+          (databaseDataMap[db]?.tables ?? []).map(t => ({ ...t, schema: db }))
+        );
       }
       const disposable = registerSqlAutocomplete(
         monacoInstance,

--- a/src/utils/autocomplete.ts
+++ b/src/utils/autocomplete.ts
@@ -62,7 +62,7 @@ const getTableColumns = async (connectionId: string, tableName: string, schema?:
       tableName,
       ...(schema ? { schema } : {}),
     });
-    
+
     if (!Array.isArray(cols)) {
       console.warn(`get_columns returned non-array for table ${tableName}`, cols);
       return [];
@@ -74,12 +74,16 @@ const getTableColumns = async (connectionId: string, tableName: string, schema?:
       detail: c.data_type,
     }));
 
-    columnsCache.set(cacheKey, {
-      data: simpleCols,
-      timestamp: Date.now()
-    });
-    
-    cleanupCache();
+    // Don't cache empty results — they likely reflect a transient failure
+    // (connection not ready, schema mismatch) rather than a genuinely empty table.
+    // An uncached miss retries the backend on the next trigger, which is cheap.
+    if (simpleCols.length > 0) {
+      columnsCache.set(cacheKey, {
+        data: simpleCols,
+        timestamp: Date.now()
+      });
+      cleanupCache();
+    }
     return simpleCols;
   } catch (e) {
     console.error(`Failed to fetch columns for autocomplete: ${tableName}`, e);
@@ -110,7 +114,7 @@ export const registerSqlAutocomplete = (
       if (!connectionId) return { suggestions: [] };
 
       const wordUntil = model.getWordUntilPosition(position);
-      
+
       const range = {
         startLineNumber: position.lineNumber,
         endLineNumber: position.lineNumber,
@@ -129,6 +133,7 @@ export const registerSqlAutocomplete = (
       // Get current statement context
       const currentStatement = getCurrentStatement(model, position);
       const tableAliases = parseTablesFromQuery(currentStatement);
+
 
       // ============================================
       // 1. DOT TRIGGER (table.column or alias.column)
@@ -149,7 +154,8 @@ export const registerSqlAutocomplete = (
         }
         
         if (actualTableName) {
-          const columns = await getTableColumns(connectionId, actualTableName, schema);
+          const foundTable = tables.find(t => t.name.toLowerCase() === actualTableName.toLowerCase());
+          const columns = await getTableColumns(connectionId, actualTableName, foundTable?.schema ?? schema);
           
           // Calculate range for column name after dot
           const columnRange = {
@@ -187,8 +193,11 @@ export const registerSqlAutocomplete = (
       if (tableAliases && tableAliases.size > 0) {
         // User is inside a query with FROM/JOIN - suggest columns from those tables
         const tableNames = Array.from(new Set(tableAliases.values()));
+        // Prefer the TableInfo from the loaded list (original casing, full metadata).
+        // Fall back to a minimal synthetic entry from the parsed name so columns can
+        // still be fetched when the tables list hasn't finished loading yet.
         const matchingTables = tableNames
-          .map(name => tables.find(t => t.name.toLowerCase() === name.toLowerCase()))
+          .map(name => tables.find(t => t.name.toLowerCase() === name.toLowerCase()) ?? { name })
           .filter(Boolean) as TableInfo[];
         
         // Limit parallel fetches to prevent memory spikes
@@ -198,7 +207,7 @@ export const registerSqlAutocomplete = (
         }
         
         const results = await Promise.all(
-          matchingTables.map(t => getTableColumns(connectionId, t.name, schema))
+          matchingTables.map(t => getTableColumns(connectionId, t.name, t.schema ?? schema))
         );
         
         const seenColumns = new Set<string>();
@@ -233,24 +242,15 @@ export const registerSqlAutocomplete = (
       }
 
       // ============================================
-      // 3. KEYWORD SUGGESTIONS (only if no context columns)
+      // 3. KEYWORD SUGGESTIONS
       // ============================================
-      let keywordSuggestions: Array<{
-        label: string;
-        kind: number;
-        insertText: string;
-        range: { startLineNumber: number; endLineNumber: number; startColumn: number; endColumn: number };
-        sortText: string;
-      }> = [];
-      if (contextColumnSuggestions.length === 0) {
-        keywordSuggestions = SQL_KEYWORDS.map((kw) => ({
-          label: kw,
-          kind: monaco.languages.CompletionItemKind.Keyword,
-          insertText: kw,
-          range,
-          sortText: `2_${kw}`
-        }));
-      }
+      const keywordSuggestions = SQL_KEYWORDS.map((kw) => ({
+        label: kw,
+        kind: monaco.languages.CompletionItemKind.Keyword,
+        insertText: kw,
+        range,
+        sortText: `2_${kw}`
+      }));
 
       // ============================================
       // 4. TABLE SUGGESTIONS

--- a/src/utils/autocomplete.ts
+++ b/src/utils/autocomplete.ts
@@ -1,15 +1,17 @@
 import type { Monaco } from "@monaco-editor/react";
 import { invoke } from "@tauri-apps/api/core";
 import type { TableInfo } from "../contexts/DatabaseContext";
-import { getCurrentStatement, parseTablesFromQuery } from "./sqlAnalysis";
+import { getCurrentStatement, parseTablesFromQuery, type ParsedTableRef } from "./sqlAnalysis";
 
 // Lightweight column cache with TTL and size limits
 interface CachedColumns {
   data: Array<{ label: string; detail: string }>;
   timestamp: number;
+  ttl: number;
 }
 
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+const NEGATIVE_CACHE_TTL = 30 * 1000; // 30 s for empty results (structurally empty table/view)
 const MAX_CACHE_ENTRIES = 50; // Limit total cached tables
 const columnsCache = new Map<string, CachedColumns>();
 
@@ -52,7 +54,7 @@ const getTableColumns = async (connectionId: string, tableName: string, schema?:
   const cached = columnsCache.get(cacheKey);
 
   // Return cached data if valid
-  if (cached && (Date.now() - cached.timestamp) < CACHE_TTL) {
+  if (cached && (Date.now() - cached.timestamp) < cached.ttl) {
     return cached.data;
   }
 
@@ -74,16 +76,15 @@ const getTableColumns = async (connectionId: string, tableName: string, schema?:
       detail: c.data_type,
     }));
 
-    // Don't cache empty results — they likely reflect a transient failure
-    // (connection not ready, schema mismatch) rather than a genuinely empty table.
-    // An uncached miss retries the backend on the next trigger, which is cheap.
-    if (simpleCols.length > 0) {
-      columnsCache.set(cacheKey, {
-        data: simpleCols,
-        timestamp: Date.now()
-      });
-      cleanupCache();
-    }
+    // Cache with a short TTL for empty results (structurally empty table/view) so we
+    // don't re-issue get_columns on every trigger. Errors are not cached — they remain
+    // transient and will retry on the next trigger.
+    columnsCache.set(cacheKey, {
+      data: simpleCols,
+      timestamp: Date.now(),
+      ttl: simpleCols.length > 0 ? CACHE_TTL : NEGATIVE_CACHE_TTL,
+    });
+    cleanupCache();
     return simpleCols;
   } catch (e) {
     console.error(`Failed to fetch columns for autocomplete: ${tableName}`, e);
@@ -136,45 +137,64 @@ export const registerSqlAutocomplete = (
 
 
       // ============================================
-      // 1. DOT TRIGGER (table.column or alias.column)
+      // 1. DOT TRIGGER (table.column, alias.column, or db.table.column)
       // ============================================
-      const dotMatch = textUntilPosition.match(/(?:["'`])?([a-zA-Z0-9_]+)(?:["'`])?\.([a-zA-Z0-9_]*)$/);
-      
-      if (dotMatch) {
-        const typedName = dotMatch[1].toLowerCase();
-        const partialColumn = dotMatch[2]; // What user has typed after the dot
-        
-        // Check if it's an alias or table name
-        let actualTableName = tableAliases?.get(typedName);
-        
-        if (!actualTableName) {
-          // Try direct table name match
-          const foundTable = tables.find(t => t.name.toLowerCase() === typedName);
-          actualTableName = foundTable?.name;
+
+      // Try qualified (db.table.) first, then simple (table.)
+      const qualifiedDotMatch = textUntilPosition.match(/`?([a-zA-Z0-9_]+)`?\.`?([a-zA-Z0-9_]+)`?\.([a-zA-Z0-9_]*)$/);
+      const simpleDotMatch = qualifiedDotMatch ? null : textUntilPosition.match(/(?:["'`])?([a-zA-Z0-9_]+)(?:["'`])?\.([a-zA-Z0-9_]*)$/);
+
+      if (qualifiedDotMatch || simpleDotMatch) {
+        let dotTables: TableInfo[] = [];
+        let partialColumn: string;
+
+        if (qualifiedDotMatch) {
+          const dbName = qualifiedDotMatch[1].toLowerCase();
+          const tblName = qualifiedDotMatch[2].toLowerCase();
+          partialColumn = qualifiedDotMatch[3];
+          const found = tables.find(t => t.name.toLowerCase() === tblName && t.schema?.toLowerCase() === dbName);
+          dotTables = found ? [found] : [{ name: tblName, schema: dbName }];
+        } else {
+          const typedName = simpleDotMatch![1].toLowerCase();
+          partialColumn = simpleDotMatch![2];
+          // Resolve via alias map (carries schema when FROM used qualified ref)
+          const aliasRef: ParsedTableRef | undefined = tableAliases?.get(typedName);
+          if (aliasRef) {
+            const found = tables.find(t =>
+              t.name.toLowerCase() === aliasRef.name.toLowerCase() &&
+              (!aliasRef.schema || t.schema?.toLowerCase() === aliasRef.schema.toLowerCase())
+            );
+            dotTables = found ? [found] : [{ name: aliasRef.name, schema: aliasRef.schema }];
+          } else {
+            // Unqualified: collect every loaded table with this name across all schemas
+            const matches = tables.filter(t => t.name.toLowerCase() === typedName);
+            dotTables = matches.length > 0 ? matches : [{ name: typedName }];
+          }
         }
-        
-        if (actualTableName) {
-          const foundTable = tables.find(t => t.name.toLowerCase() === actualTableName.toLowerCase());
-          const columns = await getTableColumns(connectionId, actualTableName, foundTable?.schema ?? schema);
-          
-          // Calculate range for column name after dot
+
+        const colArrays = await Promise.all(
+          dotTables.map(t => getTableColumns(connectionId, t.name, t.schema ?? schema))
+        );
+        const seen = new Set<string>();
+        const columns = colArrays.flat().filter(c => (seen.has(c.label) ? false : (seen.add(c.label), true)));
+
+        if (columns.length > 0) {
           const columnRange = {
             startLineNumber: position.lineNumber,
             endLineNumber: position.lineNumber,
             startColumn: position.column - partialColumn.length,
             endColumn: position.column,
           };
-          
-          const suggestions = columns.map(c => ({
-            label: c.label,
-            kind: monaco.languages.CompletionItemKind.Field,
-            detail: c.detail,
-            insertText: c.label,
-            range: columnRange,
-            sortText: `0_${c.label}`,
-          }));
-          
-          return { suggestions };
+          return {
+            suggestions: columns.map(c => ({
+              label: c.label,
+              kind: monaco.languages.CompletionItemKind.Field,
+              detail: c.detail,
+              insertText: c.label,
+              range: columnRange,
+              sortText: `0_${c.label}`,
+            })),
+          };
         }
       }
 
@@ -191,43 +211,54 @@ export const registerSqlAutocomplete = (
       }> = [];
       
       if (tableAliases && tableAliases.size > 0) {
-        // User is inside a query with FROM/JOIN - suggest columns from those tables
-        const tableNames = Array.from(new Set(tableAliases.values()));
-        // Prefer the TableInfo from the loaded list (original casing, full metadata).
-        // Fall back to a minimal synthetic entry from the parsed name so columns can
-        // still be fetched when the tables list hasn't finished loading yet.
-        const matchingTables = tableNames
-          .map(name => tables.find(t => t.name.toLowerCase() === name.toLowerCase()) ?? { name })
-          .filter(Boolean) as TableInfo[];
-        
+        // Deduplicate parsed refs by (schema, name) — multiple aliases can point to the same table
+        const seenRefs = new Set<string>();
+        const uniqueRefs = Array.from(tableAliases.values()).filter(ref => {
+          const key = `${ref.schema ?? ''}:${ref.name}`;
+          return seenRefs.has(key) ? false : (seenRefs.add(key), true);
+        });
+
+        // For qualified refs (schema known) find the exact table; for unqualified refs
+        // expand to ALL loaded tables with that name so every selected DB is covered.
+        const matchingTables: TableInfo[] = uniqueRefs.flatMap(ref => {
+          if (ref.schema) {
+            const found = tables.find(t =>
+              t.name.toLowerCase() === ref.name.toLowerCase() &&
+              t.schema?.toLowerCase() === ref.schema!.toLowerCase()
+            );
+            return found ? [found] : [ref as TableInfo];
+          }
+          const found = tables.filter(t => t.name.toLowerCase() === ref.name.toLowerCase());
+          return found.length > 0 ? found : [ref as TableInfo];
+        });
+
         // Limit parallel fetches to prevent memory spikes
         const MAX_PARALLEL_FETCHES = 5;
         if (matchingTables.length > MAX_PARALLEL_FETCHES) {
           matchingTables.splice(MAX_PARALLEL_FETCHES);
         }
-        
+
         const results = await Promise.all(
           matchingTables.map(t => getTableColumns(connectionId, t.name, t.schema ?? schema))
         );
-        
+
         const seenColumns = new Set<string>();
-        
+
         matchingTables.forEach((table, idx) => {
           const columns = results[idx];
           columns.forEach(col => {
-            const key = `${col.label}`;
-            if (!seenColumns.has(key)) {
-              seenColumns.add(key);
-              
+            if (!seenColumns.has(col.label)) {
+              seenColumns.add(col.label);
+
               // Find alias for this table (if any)
               let aliasHint = "";
-              for (const [alias, tableName] of tableAliases.entries()) {
-                if (tableName.toLowerCase() === table.name.toLowerCase() && alias !== table.name.toLowerCase()) {
+              for (const [alias, ref] of tableAliases.entries()) {
+                if (ref.name.toLowerCase() === table.name.toLowerCase() && alias !== table.name.toLowerCase()) {
                   aliasHint = ` (${alias})`;
                   break;
                 }
               }
-              
+
               contextColumnSuggestions.push({
                 label: col.label,
                 kind: monaco.languages.CompletionItemKind.Field,
@@ -244,13 +275,16 @@ export const registerSqlAutocomplete = (
       // ============================================
       // 3. KEYWORD SUGGESTIONS
       // ============================================
-      const keywordSuggestions = SQL_KEYWORDS.map((kw) => ({
-        label: kw,
-        kind: monaco.languages.CompletionItemKind.Keyword,
-        insertText: kw,
-        range,
-        sortText: `2_${kw}`
-      }));
+      const colLabels = new Set(contextColumnSuggestions.map(s => s.label.toUpperCase()));
+      const keywordSuggestions = SQL_KEYWORDS
+        .filter(kw => !colLabels.has(kw))
+        .map((kw) => ({
+          label: kw,
+          kind: monaco.languages.CompletionItemKind.Keyword,
+          insertText: kw,
+          range,
+          sortText: `2_${kw}`
+        }));
 
       // ============================================
       // 4. TABLE SUGGESTIONS

--- a/src/utils/sqlAnalysis.ts
+++ b/src/utils/sqlAnalysis.ts
@@ -1,29 +1,41 @@
 // SQL Analysis Utilities - Pure logic functions for parsing and analyzing SQL
 
+// SQL reserved words that are never valid unquoted table aliases
+const SQL_RESERVED = new Set([
+  'where', 'on', 'set', 'having', 'group', 'order', 'limit', 'offset',
+  'join', 'left', 'right', 'inner', 'outer', 'cross', 'union', 'intersect',
+  'except', 'select', 'from', 'into', 'values', 'update', 'delete', 'insert',
+  'create', 'drop', 'alter', 'and', 'or', 'not', 'is', 'in', 'between',
+  'like', 'as', 'distinct', 'case', 'when', 'then', 'else', 'end', 'by',
+  'asc', 'desc', 'null', 'with', 'exists', 'all', 'any', 'using',
+]);
+
 // Optimized table parser - early exit and minimal allocations
 export const parseTablesFromQuery = (sql: string): Map<string, string> | null => {
   if (!sql || sql.length === 0) return null;
-  
+
   const lowerSql = sql.toLowerCase();
-  
+
   // Quick check if query contains FROM/JOIN keywords
   if (!lowerSql.includes('from') && !lowerSql.includes('join')) {
     return null;
   }
-  
+
   const tableMap = new Map<string, string>();
   const fromPattern = /(?:from|join)\s+(?:`)?([a-z_][a-z0-9_]*)(?:`)?(?:\s+(?:as\s+)?(?:`)?([a-z_][a-z0-9_]*)(?:`)?)?/gi;
-  
+
   let match;
   let matchCount = 0;
   const MAX_MATCHES = 10; // Prevent regex catastrophic backtracking
-  
+
   while ((match = fromPattern.exec(lowerSql)) !== null && matchCount++ < MAX_MATCHES) {
     const tableName = match[1];
-    const alias = match[2] || tableName;
+    const rawAlias = match[2];
+    // Ignore captured word if it's a SQL keyword (e.g. WHERE captured after table name)
+    const alias = (rawAlias && !SQL_RESERVED.has(rawAlias)) ? rawAlias : tableName;
     tableMap.set(alias, tableName);
   }
-  
+
   return tableMap.size > 0 ? tableMap : null;
 };
 

--- a/src/utils/sqlAnalysis.ts
+++ b/src/utils/sqlAnalysis.ts
@@ -32,8 +32,11 @@ export const parseTablesFromQuery = (sql: string): Map<string, ParsedTableRef> |
   if (!fromSection) return null;
 
   const tableMap = new Map<string, ParsedTableRef>();
-  // Groups: 1=first-id (schema when group 2 present, else table), 2=table (qualified), 3=alias
-  const fromPattern = /(?:from|join)\s+`?([a-z_][a-z0-9_]*)`?(?:\.`?([a-z_][a-z0-9_]*)`?)?(?:\s+(?:as\s+)?`?([a-z_][a-z0-9_]*)`?)?/gi;
+  // Groups: 1=first-id (schema when group 2 present, else table), 2=table (qualified), 3=alias.
+  // The negative-lookahead stops the optional alias group from swallowing a keyword that
+  // legally follows a table name (JOIN/LEFT/NATURAL/FOR/…). Without it the keyword is both
+  // mis-registered as an alias and consumed, dropping the table that follows it.
+  const fromPattern = /(?:from|join)\s+`?([a-z_][a-z0-9_]*)`?(?:\.`?([a-z_][a-z0-9_]*)`?)?(?:\s+(?:as\s+)?`?(?!(?:join|left|right|inner|outer|cross|natural|full|on|using|where|group|order|having|limit|offset|union|intersect|except|for|fetch|window|lateral|tablesample|qualify|straight_join)\b)([a-z_][a-z0-9_]*)`?)?/gi;
 
   let match;
   let matchCount = 0;

--- a/src/utils/sqlAnalysis.ts
+++ b/src/utils/sqlAnalysis.ts
@@ -1,39 +1,50 @@
 // SQL Analysis Utilities - Pure logic functions for parsing and analyzing SQL
 
-// SQL reserved words that are never valid unquoted table aliases
-const SQL_RESERVED = new Set([
-  'where', 'on', 'set', 'having', 'group', 'order', 'limit', 'offset',
-  'join', 'left', 'right', 'inner', 'outer', 'cross', 'union', 'intersect',
-  'except', 'select', 'from', 'into', 'values', 'update', 'delete', 'insert',
-  'create', 'drop', 'alter', 'and', 'or', 'not', 'is', 'in', 'between',
-  'like', 'as', 'distinct', 'case', 'when', 'then', 'else', 'end', 'by',
-  'asc', 'desc', 'null', 'with', 'exists', 'all', 'any', 'using',
-]);
+export interface ParsedTableRef {
+  name: string;
+  schema?: string;
+}
 
-// Optimized table parser - early exit and minimal allocations
-export const parseTablesFromQuery = (sql: string): Map<string, string> | null => {
+// Isolate the FROM/JOIN section of a SQL statement so clause keywords
+// (WHERE, HAVING, etc.) are never present when the alias-capture regex runs.
+const extractFromSection = (sql: string): string => {
+  const fromIdx = sql.toLowerCase().search(/\bfrom\b/);
+  if (fromIdx === -1) return '';
+
+  const fromText = sql.slice(fromIdx);
+  // Stop at the first clause that cannot appear inside a FROM/JOIN list
+  const boundary = /\b(?:where|group\s+by|order\s+by|having|limit|offset|union|intersect|except)\b/i.exec(fromText);
+  const section = boundary ? fromText.slice(0, boundary.index) : fromText;
+
+  // Strip ON <cond> and USING(...) within JOIN clauses so those keywords
+  // are not captured as table aliases.
+  return section
+    .replace(/\bon\b.+?(?=\b(?:join|left|right|inner|outer|cross|natural)\b|$)/gis, ' ')
+    .replace(/\busing\s*\([^)]*\)/gi, ' ');
+};
+
+// Optimized table parser - returns alias → ParsedTableRef.
+// Handles both unqualified (table) and qualified (schema.table) references.
+export const parseTablesFromQuery = (sql: string): Map<string, ParsedTableRef> | null => {
   if (!sql || sql.length === 0) return null;
 
-  const lowerSql = sql.toLowerCase();
+  const fromSection = extractFromSection(sql);
+  if (!fromSection) return null;
 
-  // Quick check if query contains FROM/JOIN keywords
-  if (!lowerSql.includes('from') && !lowerSql.includes('join')) {
-    return null;
-  }
-
-  const tableMap = new Map<string, string>();
-  const fromPattern = /(?:from|join)\s+(?:`)?([a-z_][a-z0-9_]*)(?:`)?(?:\s+(?:as\s+)?(?:`)?([a-z_][a-z0-9_]*)(?:`)?)?/gi;
+  const tableMap = new Map<string, ParsedTableRef>();
+  // Groups: 1=first-id (schema when group 2 present, else table), 2=table (qualified), 3=alias
+  const fromPattern = /(?:from|join)\s+`?([a-z_][a-z0-9_]*)`?(?:\.`?([a-z_][a-z0-9_]*)`?)?(?:\s+(?:as\s+)?`?([a-z_][a-z0-9_]*)`?)?/gi;
 
   let match;
   let matchCount = 0;
-  const MAX_MATCHES = 10; // Prevent regex catastrophic backtracking
+  const MAX_MATCHES = 10;
 
-  while ((match = fromPattern.exec(lowerSql)) !== null && matchCount++ < MAX_MATCHES) {
-    const tableName = match[1];
-    const rawAlias = match[2];
-    // Ignore captured word if it's a SQL keyword (e.g. WHERE captured after table name)
-    const alias = (rawAlias && !SQL_RESERVED.has(rawAlias)) ? rawAlias : tableName;
-    tableMap.set(alias, tableName);
+  while ((match = fromPattern.exec(fromSection.toLowerCase())) !== null && matchCount++ < MAX_MATCHES) {
+    const qualified = !!match[2];
+    const tableName = qualified ? match[2] : match[1];
+    const schema = qualified ? match[1] : undefined;
+    const alias = match[3] || tableName;
+    tableMap.set(alias, { name: tableName, schema });
   }
 
   return tableMap.size > 0 ? tableMap : null;

--- a/tests/utils/autocomplete.test.ts
+++ b/tests/utils/autocomplete.test.ts
@@ -212,7 +212,7 @@ describe('autocomplete', () => {
       const mockParseTables = parseTablesFromQuery as unknown as ReturnType<typeof vi.fn>;
       
       // Simulate that we have a table in context to trigger column fetching
-      mockParseTables.mockReturnValue(new Map([['users', 'users']])); // alias -> table
+      mockParseTables.mockReturnValue(new Map([['users', { name: 'users' }]])); // alias -> ParsedTableRef
 
       const monaco = createMockMonaco();
       const tables: TableInfo[] = [{ name: 'users' }];
@@ -298,7 +298,7 @@ describe('autocomplete', () => {
 
       const { parseTablesFromQuery } = await import('../../src/utils/sqlAnalysis');
       const mockParseTables = parseTablesFromQuery as unknown as ReturnType<typeof vi.fn>;
-      mockParseTables.mockReturnValue(new Map([['u', 'users']])); // alias mapping
+      mockParseTables.mockReturnValue(new Map([['u', { name: 'users' }]])); // alias -> ParsedTableRef
 
       const monaco = createMockMonaco();
       const tables: TableInfo[] = [{ name: 'users' }];

--- a/tests/utils/sqlAnalysis.test.ts
+++ b/tests/utils/sqlAnalysis.test.ts
@@ -12,41 +12,41 @@ describe('sqlAnalysis utils', () => {
     it('should extract simple table name', () => {
       const result = parseTablesFromQuery('SELECT * FROM users');
       expect(result).not.toBeNull();
-      expect(result?.get('users')).toBe('users');
+      expect(result?.get('users')?.name).toBe('users');
     });
 
     it('should extract table with alias', () => {
       const result = parseTablesFromQuery('SELECT * FROM users u');
-      expect(result?.get('u')).toBe('users');
+      expect(result?.get('u')?.name).toBe('users');
     });
 
     it('should extract table with AS alias', () => {
       const result = parseTablesFromQuery('SELECT * FROM users AS u');
-      expect(result?.get('u')).toBe('users');
+      expect(result?.get('u')?.name).toBe('users');
     });
 
     it('should extract multiple tables (JOIN)', () => {
       const sql = 'SELECT * FROM users u JOIN posts p ON u.id = p.user_id';
       const result = parseTablesFromQuery(sql);
-      expect(result?.get('u')).toBe('users');
-      expect(result?.get('p')).toBe('posts');
+      expect(result?.get('u')?.name).toBe('users');
+      expect(result?.get('p')?.name).toBe('posts');
     });
 
     it('should handle backticks', () => {
       const result = parseTablesFromQuery('SELECT * FROM `my_table` `mt`');
-      expect(result?.get('mt')).toBe('my_table');
+      expect(result?.get('mt')?.name).toBe('my_table');
     });
 
     it('should handle complex joins', () => {
         const sql = `
-            SELECT * FROM orders o 
+            SELECT * FROM orders o
             LEFT JOIN users u ON o.user_id = u.id
             INNER JOIN products p ON o.prod_id = p.id
         `;
         const result = parseTablesFromQuery(sql);
-        expect(result?.get('o')).toBe('orders');
-        expect(result?.get('u')).toBe('users');
-        expect(result?.get('p')).toBe('products');
+        expect(result?.get('o')?.name).toBe('orders');
+        expect(result?.get('u')?.name).toBe('users');
+        expect(result?.get('p')?.name).toBe('products');
     });
   });
 

--- a/tests/utils/sqlAnalysis.test.ts
+++ b/tests/utils/sqlAnalysis.test.ts
@@ -48,6 +48,36 @@ describe('sqlAnalysis utils', () => {
         expect(result?.get('u')?.name).toBe('users');
         expect(result?.get('p')?.name).toBe('products');
     });
+
+    it('does not register a keyword as an alias when it follows a table name', () => {
+      // Unaliased JOIN: both tables keyed by their own name, JOIN not an alias.
+      const r = parseTablesFromQuery('SELECT * FROM users JOIN orders');
+      expect(r?.get('users')?.name).toBe('users');
+      expect(r?.get('orders')?.name).toBe('orders');
+      expect(r?.has('join')).toBe(false);
+
+      // JOIN-type keywords must not become aliases of the preceding table.
+      const left = parseTablesFromQuery('SELECT * FROM a LEFT JOIN b ON a.id = b.a_id');
+      expect(left?.get('a')?.name).toBe('a');
+      expect(left?.get('b')?.name).toBe('b');
+      expect(left?.has('left')).toBe(false);
+
+      const natural = parseTablesFromQuery('SELECT * FROM t NATURAL JOIN u');
+      expect(natural?.get('t')?.name).toBe('t');
+      expect(natural?.get('u')?.name).toBe('u');
+      expect(natural?.has('natural')).toBe(false);
+
+      // Trailing clause keywords that can legally follow a table name.
+      const forUpdate = parseTablesFromQuery('SELECT * FROM orders FOR UPDATE');
+      expect(forUpdate?.get('orders')?.name).toBe('orders');
+      expect(forUpdate?.has('for')).toBe(false);
+    });
+
+    it('keeps schema on qualified refs across a JOIN', () => {
+      const r = parseTablesFromQuery('SELECT * FROM db1.users JOIN db2.orders ON 1 = 1');
+      expect(r?.get('users')).toEqual({ name: 'users', schema: 'db1' });
+      expect(r?.get('orders')).toEqual({ name: 'orders', schema: 'db2' });
+    });
   });
 
   describe('getCurrentStatement', () => {


### PR DESCRIPTION
closes #293.

## Summary

  - **Keywords never suggested after FROM clause** — The completion provider only
  offered keyword completions when no context columns were available. Removed the
  `contextColumnSuggestions.length === 0` guard so clause keywords (WHERE, ORDER BY,
  GROUP BY, LIMIT, …) are always included alongside column and table suggestions.

  - **SQL keywords captured as table aliases** — `parseTablesFromQuery` matched `FROM
  users WHERE` and registered `WHERE` as the alias, poisoning the alias map. Added a
  `SQL_RESERVED` set; any captured alias that is a reserved word is discarded and the
  table name is used as its own alias.

  - **Wrong columns in MySQL multiDb mode** — When `activeSchema` is null (multiDb),
  `getTableColumns` was called without a schema, causing MySQL to fall back to
  `information_schema` and return system columns instead of the user's table columns.
  Fixed by adding an optional `schema?: string` field to `TableInfo` and populating it
  with the source database name when building `effectiveTables` in multiDb mode. Both
  the context-aware and dot-trigger paths now pass `t.schema ?? schema`.

  - **Column cache poisoning** — The fallback that attempts column fetches before the
  tables list loads could receive an empty response (schema mismatch / connection not
  yet ready) and cache it, blocking all subsequent fetches for that table. Empty results
  are now never written to the cache.

  ## Files changed

  | File | Change |
  |---|---|
  | `src/utils/autocomplete.ts` | Remove keyword gate; add schema-aware table lookup for dot-trigger; use `t.schema` in context-aware path; skip caching empty results |
  | `src/utils/sqlAnalysis.ts` | Add `SQL_RESERVED` set; filter captured aliases against it |
  | `src/contexts/DatabaseContext.ts` | Add optional `schema?: string` to `TableInfo` |
  | `src/pages/Editor.tsx` | Annotate each table with its source database when building  `effectiveTables` in multiDb mode |

  ## Test plan

  - [ ] MySQL multiDb: type `SELECT * FROM <table> ` → columns from the correct database
  appear
  - [ ] MySQL multiDb: type `SELECT * FROM <table> WHERE ` → clause keywords (AND, OR,
  …) and column names both appear
  - [ ] Type `SELECT * FROM <table> WHERE <partial>` → matching column names filter
  correctly
  - [ ] Dot-trigger `table.` → columns from the correct per-database table appear
  - [ ] Single-database connections: keywords still appear; dot-trigger still works
  - [ ] Non-MySQL drivers: no regression in keyword or column suggestions