### PR TITLE
feat(explain): show Actual Rows column in MariaDB Visual EXPLAIN table view

### DIFF
--- a/src/components/modals/visual-explain/ExplainTableView.tsx
+++ b/src/components/modals/visual-explain/ExplainTableView.tsx
@@ -62,6 +62,11 @@ export function ExplainTableView({
               <th className="text-right px-3 py-2 text-muted font-semibold whitespace-nowrap">
                 {t("editor.visualExplain.estRows")}
               </th>
+              {plan.has_analyze_data && (
+                <th className="text-right px-3 py-2 text-muted font-semibold whitespace-nowrap">
+                  {t("editor.visualExplain.actualRows")}
+                </th>
+              )}
               <th className="text-right px-3 py-2 text-muted font-semibold whitespace-nowrap">
                 {t("editor.visualExplain.time")}
               </th>
@@ -133,6 +138,10 @@ function TreeRows({
       : "-";
 
   const rowsStr = node.plan_rows != null ? formatRows(node.plan_rows) : "-";
+  const actualRowsStr =
+    hasAnalyzeData && node.actual_rows != null
+      ? formatRows(node.actual_rows)
+      : "-";
   const rowRatio = getRowEstimateRatio(node);
   const ratioStr =
     rowRatio != null
@@ -184,6 +193,11 @@ function TreeRows({
         <td className="px-3 py-1.5 text-right text-secondary font-mono whitespace-nowrap">
           {rowsStr}
         </td>
+        {hasAnalyzeData && (
+          <td className="px-3 py-1.5 text-right text-secondary font-mono whitespace-nowrap">
+            {actualRowsStr}
+          </td>
+        )}
         <td className="px-3 py-1.5 text-right text-secondary font-mono whitespace-nowrap">
           {timeStr}
         </td>


### PR DESCRIPTION
## Summary

Adds an **Actual Rows** column to the Visual EXPLAIN table view, next to **Est. Rows**.

The MariaDB `ANALYZE FORMAT=JSON` parser already extracts `r_rows` into `actual_rows`, and the graph/details panels already surfaced it — but the table view only showed estimated rows, so comparing estimated vs actual meant dropping back to the raw JSON.

## Behavior

- The column is rendered only when execution data is available (`has_analyze_data`), i.e. MariaDB `ANALYZE FORMAT=JSON` and Postgres `EXPLAIN ANALYZE`. A plain `EXPLAIN` keeps the table unchanged.
- Values are formatted with the same `formatRows` helper used by the details and graph node, so the three views stay consistent.

## Testing

On a MariaDB connection, run a query through Visual EXPLAIN in Analyze mode and confirm the Actual Rows column shows the `r_rows` values alongside the estimates.

Closes #298
