### PR TITLE
fix(mysql): multiply per-loop time by loops in Visual EXPLAIN

### DIFF
--- a/src-tauri/src/drivers/mysql/explain.rs
+++ b/src-tauri/src/drivers/mysql/explain.rs
@@ -905,7 +905,7 @@ fn has_analyze_data_recursive(node: &ExplainNode) -> bool {
 ///
 /// Each line looks like:
 /// `    -> Table scan on t1  (cost=1.25 rows=10) (actual time=0.045..0.145 rows=10 loops=1)`
-fn parse_mysql_analyze_text(text: &str, counter: &mut u32) -> ExplainNode {
+pub(super) fn parse_mysql_analyze_text(text: &str, counter: &mut u32) -> ExplainNode {
     let mut parsed_lines: Vec<AnalyzeParsedLine> = Vec::new();
 
     for line in text.lines() {
@@ -1077,7 +1077,15 @@ fn parse_analyze_estimated(s: &str) -> (Option<f64>, Option<f64>) {
 }
 
 /// Extract actual time, rows, loops from "(actual time=X..Y rows=Z loops=W)" section.
-fn parse_analyze_actual(s: &str) -> (Option<f64>, Option<f64>, Option<u64>) {
+///
+/// MySQL's tree-format `EXPLAIN ANALYZE` reports `time=first..last` as the
+/// *per-loop* (per-iteration) timing, averaged across all `loops`. To obtain the
+/// total wall-clock time spent in the node — which is what we display — the
+/// per-loop end time must be multiplied by the loop count. This mirrors how
+/// PostgreSQL's "Actual Total Time" relates to "Actual Loops". Without this,
+/// nodes executed many times (e.g. an index lookup driven by a join) report a
+/// tiny per-iteration figure instead of their real cost.
+pub(super) fn parse_analyze_actual(s: &str) -> (Option<f64>, Option<f64>, Option<u64>) {
     let idx = match s.find("(actual time=") {
         Some(i) => i,
         None => return (None, None, None),
@@ -1088,16 +1096,16 @@ fn parse_analyze_actual(s: &str) -> (Option<f64>, Option<f64>, Option<u64>) {
         None => return (None, None, None),
     };
     let inner = &section[1..end]; // "actual time=X..Y rows=Z loops=W"
-    let mut time_ms = None;
+    let mut per_loop_time_ms = None;
     let mut rows = None;
     let mut loops = None;
     for part in inner.split_whitespace() {
         if let Some(val) = part.strip_prefix("time=") {
-            // Use end time (after "..") as total time
+            // "time=first..last" — the end value is the per-loop time to read all rows
             if let Some(dot_pos) = val.find("..") {
-                time_ms = val[dot_pos + 2..].parse().ok();
+                per_loop_time_ms = val[dot_pos + 2..].parse().ok();
             } else {
-                time_ms = val.parse().ok();
+                per_loop_time_ms = val.parse().ok();
             }
         } else if let Some(val) = part.strip_prefix("rows=") {
             rows = val.parse().ok();
@@ -1105,6 +1113,11 @@ fn parse_analyze_actual(s: &str) -> (Option<f64>, Option<f64>, Option<u64>) {
             loops = val.parse().ok();
         }
     }
+    // Scale the per-loop time to the total time across all iterations.
+    let time_ms = match (per_loop_time_ms, loops) {
+        (Some(t), Some(l)) => Some(t * l as f64),
+        (t, _) => t,
+    };
     (time_ms, rows, loops)
 }
 

--- a/src-tauri/src/drivers/mysql/tests.rs
+++ b/src-tauri/src/drivers/mysql/tests.rs
@@ -1,4 +1,4 @@
-use super::explain::parse_mysql_query_block;
+use super::explain::{parse_analyze_actual, parse_mysql_analyze_text, parse_mysql_query_block};
 use super::MysqlDriver;
 use crate::drivers::driver_trait::DatabaseDriver;
 use crate::models::ExplainNode;
@@ -550,4 +550,54 @@ fn test_filesort_with_direct_table() {
     assert_eq!(table.node_type, "Full Table Scan");
     assert_eq!(table.relation.as_deref(), Some("t"));
     assert!((table.actual_rows.unwrap() - 100.0).abs() < 0.1);
+}
+
+#[test]
+fn parse_analyze_actual_multiplies_per_loop_time_by_loops() {
+    // MySQL tree-format EXPLAIN ANALYZE reports per-loop time. The total node
+    // time is the per-loop end time multiplied by the loop count.
+    // Regression for github issue #300.
+    let (time_ms, rows, loops) =
+        parse_analyze_actual("  (actual time=0.00773..0.00798 rows=1 loops=331603)");
+
+    assert_eq!(loops, Some(331603));
+    assert_eq!(rows, Some(1.0));
+    // 0.00798 * 331603 ≈ 2646.19 ms (not the bare 0.00798 ms per loop)
+    let total = time_ms.expect("time should be parsed");
+    assert!(
+        (total - 2646.19).abs() < 1.0,
+        "expected ~2646ms total, got {total}"
+    );
+}
+
+#[test]
+fn parse_analyze_actual_single_loop_is_unchanged() {
+    let (time_ms, _, loops) =
+        parse_analyze_actual("  (actual time=0.10..0.42 rows=5 loops=1)");
+    assert_eq!(loops, Some(1));
+    assert!((time_ms.unwrap() - 0.42).abs() < 1e-9);
+}
+
+#[test]
+fn parse_analyze_actual_missing_loops_keeps_per_loop_time() {
+    let (time_ms, _, loops) = parse_analyze_actual("  (actual time=0.10..0.42 rows=5)");
+    assert_eq!(loops, None);
+    assert!((time_ms.unwrap() - 0.42).abs() < 1e-9);
+}
+
+#[test]
+fn parse_mysql_analyze_text_reports_total_time_for_looped_node() {
+    let text = "-> Nested loop inner join  (cost=10.00 rows=5) (actual time=0.50..1.20 rows=5 loops=1)\n    -> Index lookup on ms using <auto_key0>  (cost=0.35 rows=1) (actual time=0.00773..0.00798 rows=1 loops=331603)";
+    let mut counter = 0;
+    let root = parse_mysql_analyze_text(text, &mut counter);
+
+    assert_eq!(root.node_type, "Nested Loop");
+    let lookup = &root.children[0];
+    assert_eq!(lookup.node_type, "Index Lookup");
+    assert_eq!(lookup.actual_loops, Some(331603));
+    let total = lookup.actual_time_ms.expect("looped node has a time");
+    assert!(
+        (total - 2646.19).abs() < 1.0,
+        "expected ~2646ms total for index lookup, got {total}"
+    );
 }


### PR DESCRIPTION
## Problem

In the Visual EXPLAIN Table view for MySQL, the **Time** column showed the per-loop time of a node instead of its total time. A node executed many times (e.g. an index lookup driven by a join) reported a tiny per-iteration figure rather than its real cost.

Example from #300:

```
-> Index lookup on ms using <auto_key0>
   (actual time=0.00773..0.00798 rows=1 loops=331603)
```

- Displayed: `8 us` (per-loop)
- Expected: `0.00798 ms × 331603 ≈ 2646 ms` (total)

## Root cause

MySQL's tree-format `EXPLAIN ANALYZE` reports `time=first..last` as the **per-loop** (per-iteration) timing, averaged across all `loops`. `parse_analyze_actual` stored that per-loop end time directly in `actual_time_ms`, which the Table view renders as-is.

## Fix

Scale the per-loop end time by the loop count in `parse_analyze_actual`, so `actual_time_ms` holds the total wall-clock time for the node — matching how PostgreSQL's "Actual Total Time" relates to "Actual Loops". Single-loop nodes (`loops=1`) and nodes without a loop count are unchanged.

The MariaDB path is untouched: it uses `ANALYZE FORMAT=JSON`, whose `r_total_time_ms` is already a total across loops.

## Tests

Added regression tests in `drivers/mysql/tests.rs`, including the exact case from the issue (`0.00798 × 331603 ≈ 2646 ms`), a single-loop case, a missing-loops case, and a full tree-text parse. All MySQL driver tests pass.

Fixes #300