### PR TITLE
Kubernetes Selection Dialog Improvements

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1555,6 +1555,22 @@ pub async fn get_k8s_resources_cmd<R: Runtime>(
     crate::k8s_tunnel::get_k8s_resources(&context, &namespace, &resource_type)
 }
 
+#[tauri::command]
+pub async fn get_k8s_resource_ports_cmd<R: Runtime>(
+    _app: AppHandle<R>,
+    context: String,
+    namespace: String,
+    resource_type: String,
+    resource_name: String,
+) -> Result<Vec<u16>, String> {
+    crate::k8s_tunnel::get_k8s_resource_ports(
+        &context,
+        &namespace,
+        &resource_type,
+        &resource_name,
+    )
+}
+
 /// Expand K8s connection params by loading saved config and creating/reusing a tunnel.
 pub async fn expand_k8s_connection_params<R: Runtime>(
     app: &AppHandle<R>,

--- a/src-tauri/src/k8s_tunnel.rs
+++ b/src-tauri/src/k8s_tunnel.rs
@@ -367,6 +367,52 @@ pub fn get_k8s_resources(
     Ok(resources)
 }
 
+/// List exposed service ports in a given context and namespace.
+pub fn get_k8s_resource_ports(
+    context: &str,
+    namespace: &str,
+    resource_type: &str,
+    resource_name: &str,
+) -> Result<Vec<u16>, String> {
+    if resource_type != "service" {
+        return Err(format!(
+            "Unsupported resource type '{}'. Only 'service' is supported.",
+            resource_type
+        ));
+    }
+
+    let output = Command::new("kubectl")
+        .args([
+            "--context",
+            context,
+            "--namespace",
+            namespace,
+            "get",
+            resource_type,
+            resource_name,
+            "-o",
+            "jsonpath={.spec.ports[*].port}",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("Failed to execute kubectl: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "Failed to list ports for {} '{}' in context '{}' namespace '{}': {}",
+            resource_type,
+            resource_name,
+            context,
+            namespace,
+            stderr.trim()
+        ));
+    }
+
+    Ok(parse_resource_ports(&String::from_utf8_lossy(&output.stdout)))
+}
+
 /// Parse newline-separated output into a list of trimmed, non-empty strings.
 fn parse_lines(output: &str) -> Vec<String> {
     output
@@ -384,6 +430,13 @@ fn parse_lines_with_prefix(output: &str, prefix: &str) -> Vec<String> {
         .map(|l| l.trim().strip_prefix(prefix).unwrap_or(l.trim()))
         .filter(|l| !l.is_empty())
         .map(String::from)
+        .collect()
+}
+
+fn parse_resource_ports(output: &str) -> Vec<u16> {
+    output
+        .split_whitespace()
+        .filter_map(|value| value.parse::<u16>().ok())
         .collect()
 }
 
@@ -498,6 +551,34 @@ mod tests {
         #[test]
         fn test_empty_output() {
             let result = parse_lines_with_prefix("", "namespace/");
+            assert!(result.is_empty());
+        }
+    }
+
+    mod parse_resource_ports_tests {
+        use super::*;
+
+        #[test]
+        fn test_single_port() {
+            let result = parse_resource_ports("5432");
+            assert_eq!(result, vec![5432]);
+        }
+
+        #[test]
+        fn test_multiple_ports() {
+            let result = parse_resource_ports("80 443 5432");
+            assert_eq!(result, vec![80, 443, 5432]);
+        }
+
+        #[test]
+        fn test_ignores_invalid_values() {
+            let result = parse_resource_ports("abc 3306 70000 8123");
+            assert_eq!(result, vec![3306, 8123]);
+        }
+
+        #[test]
+        fn test_empty_output() {
+            let result = parse_resource_ports("");
             assert!(result.is_empty());
         }
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -278,6 +278,7 @@ pub fn run() {
             commands::get_k8s_contexts_cmd,
             commands::get_k8s_namespaces_cmd,
             commands::get_k8s_resources_cmd,
+            commands::get_k8s_resource_ports_cmd,
             // Connection Groups
             commands::get_connection_groups,
             commands::get_connections_with_groups,

--- a/src/components/modals/K8sConnectionsModal.tsx
+++ b/src/components/modals/K8sConnectionsModal.tsx
@@ -55,8 +55,9 @@ export function K8sConnectionsModal({
   const [namespace, setNamespace] = useState("");
   const [resourceType, setResourceType] = useState<string>("service");
   const [resourceName, setResourceName] = useState("");
-  const effectiveDefaultPort = defaultPort ?? 3306;
-  const [port, setPort] = useState<number>(effectiveDefaultPort);
+  const effectiveDefaultPort = defaultPort ?? undefined;
+  const [port, setPort] = useState<number | undefined>(undefined);
+  const effectivePort = port ?? effectiveDefaultPort;
   const [isPortOverridden, setIsPortOverridden] = useState(false);
 
   // Discovery state
@@ -145,7 +146,7 @@ export function K8sConnectionsModal({
           resourceName,
         );
         if (!cancelled && ports.length === 1) {
-          setPort(ports[0]);
+          setPort((prev) => (prev === ports[0] ? prev : ports[0]));
         }
       } catch {
         // Best-effort convenience only: keep the current/default port.
@@ -163,7 +164,7 @@ export function K8sConnectionsModal({
     setNamespace("");
     setResourceType("service");
     setResourceName("");
-    setPort(effectiveDefaultPort);
+    setPort(undefined);
     setIsPortOverridden(false);
     setTestStatus("idle");
     setTestMessage("");
@@ -198,22 +199,31 @@ export function K8sConnectionsModal({
   };
 
   const handleSave = async () => {
-    const input: K8sConnectionInput = {
+    const validation = validateK8sConnection({
       name,
       context,
       namespace,
       resource_type: resourceType,
       resource_name: resourceName,
-      port,
-    };
-
-    const validation = validateK8sConnection(input);
+      port: effectivePort,
+    });
     if (!validation.isValid) {
       setValidationError(
         validation.error ?? t("k8sConnections.validationFailed"),
       );
       return;
     }
+
+    if (effectivePort == null) return;
+
+    const input: K8sConnectionInput = {
+      name,
+      context,
+      namespace,
+      resource_type: resourceType,
+      resource_name: resourceName,
+      port: effectivePort,
+    };
 
     try {
       if (isCreating) {
@@ -304,9 +314,9 @@ export function K8sConnectionsModal({
                   setResourceType={setResourceType}
                   resourceName={resourceName}
                   setResourceName={setResourceName}
-                  port={port}
+                  port={effectivePort}
                   setPort={(value) => {
-                    setIsPortOverridden(true);
+                    setIsPortOverridden(value != null);
                     setPort(value);
                   }}
                   defaultPort={effectiveDefaultPort}
@@ -366,9 +376,9 @@ export function K8sConnectionsModal({
                 setResourceType={setResourceType}
                 resourceName={resourceName}
                 setResourceName={setResourceName}
-                port={port}
+                port={effectivePort}
                 setPort={(value) => {
-                  setIsPortOverridden(true);
+                  setIsPortOverridden(value != null);
                   setPort(value);
                 }}
                 defaultPort={effectiveDefaultPort}
@@ -413,9 +423,9 @@ interface EditFormProps {
   setResourceType: (v: string) => void;
   resourceName: string;
   setResourceName: (v: string) => void;
-  port: number;
-  setPort: (v: number) => void;
-  defaultPort: number;
+  port: number | undefined;
+  setPort: (v: number | undefined) => void;
+  defaultPort?: number;
   contexts: string[];
   namespaces: string[];
   resources: string[];
@@ -524,10 +534,12 @@ function EditForm({
         <label className={LabelClass}>{t("k8sConnections.port")}</label>
         <input
           type="number"
-          value={port}
-          onChange={(e) => setPort(Number(e.target.value))}
+          value={port ?? ""}
+          onChange={(e) =>
+            setPort(e.target.value === "" ? undefined : Number(e.target.value))
+          }
           className={InputClass}
-          placeholder={String(defaultPort)}
+          placeholder={defaultPort != null ? String(defaultPort) : undefined}
         />
       </div>
 

--- a/src/components/modals/K8sConnectionsModal.tsx
+++ b/src/components/modals/K8sConnectionsModal.tsx
@@ -213,9 +213,6 @@ export function K8sConnectionsModal({
       );
       return;
     }
-
-    if (effectivePort == null) return;
-
     const input: K8sConnectionInput = {
       name,
       context,

--- a/src/components/modals/K8sConnectionsModal.tsx
+++ b/src/components/modals/K8sConnectionsModal.tsx
@@ -19,6 +19,7 @@ import {
   getK8sContexts,
   getK8sNamespaces,
   getK8sResources,
+  getK8sResourcePorts,
   validateK8sConnection,
   type K8sConnection,
   type K8sConnectionInput,
@@ -31,6 +32,7 @@ import clsx from "clsx";
 interface K8sConnectionsModalProps {
   isOpen: boolean;
   onClose: () => void;
+  defaultPort?: number | null;
 }
 
 const InputClass =
@@ -40,6 +42,7 @@ const LabelClass = "block text-xs uppercase font-bold text-muted mb-1";
 export function K8sConnectionsModal({
   isOpen,
   onClose,
+  defaultPort,
 }: K8sConnectionsModalProps) {
   const { t } = useTranslation();
   const [connections, setConnections] = useState<K8sConnection[]>([]);
@@ -52,7 +55,9 @@ export function K8sConnectionsModal({
   const [namespace, setNamespace] = useState("");
   const [resourceType, setResourceType] = useState<string>("service");
   const [resourceName, setResourceName] = useState("");
-  const [port, setPort] = useState<number>(3306);
+  const effectiveDefaultPort = defaultPort ?? 3306;
+  const [port, setPort] = useState<number>(effectiveDefaultPort);
+  const [isPortOverridden, setIsPortOverridden] = useState(false);
 
   // Discovery state
   const [contexts, setContexts] = useState<string[]>([]);
@@ -119,13 +124,47 @@ export function K8sConnectionsModal({
     })();
   }, [context, namespace, resourceType]);
 
+  useEffect(() => {
+    if (
+      !context ||
+      !namespace ||
+      resourceType !== "service" ||
+      !resourceName ||
+      isPortOverridden
+    ) {
+      return;
+    }
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const ports = await getK8sResourcePorts(
+          context,
+          namespace,
+          resourceType,
+          resourceName,
+        );
+        if (!cancelled && ports.length === 1) {
+          setPort(ports[0]);
+        }
+      } catch {
+        // Best-effort convenience only: keep the current/default port.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [context, namespace, resourceType, resourceName, isPortOverridden]);
+
   const resetForm = () => {
     setName("");
     setContext("");
     setNamespace("");
     setResourceType("service");
     setResourceName("");
-    setPort(3306);
+    setPort(effectiveDefaultPort);
+    setIsPortOverridden(false);
     setTestStatus("idle");
     setTestMessage("");
     setValidationError(null);
@@ -144,6 +183,7 @@ export function K8sConnectionsModal({
     setResourceType(conn.resource_type);
     setResourceName(conn.resource_name);
     setPort(conn.port);
+    setIsPortOverridden(true);
     setEditingId(conn.id);
     setIsCreating(false);
     setTestStatus("idle");
@@ -265,7 +305,11 @@ export function K8sConnectionsModal({
                   resourceName={resourceName}
                   setResourceName={setResourceName}
                   port={port}
-                  setPort={setPort}
+                  setPort={(value) => {
+                    setIsPortOverridden(true);
+                    setPort(value);
+                  }}
+                  defaultPort={effectiveDefaultPort}
                   contexts={contexts}
                   namespaces={namespaces}
                   resources={resources}
@@ -323,7 +367,11 @@ export function K8sConnectionsModal({
                 resourceName={resourceName}
                 setResourceName={setResourceName}
                 port={port}
-                setPort={setPort}
+                setPort={(value) => {
+                  setIsPortOverridden(true);
+                  setPort(value);
+                }}
+                defaultPort={effectiveDefaultPort}
                 contexts={contexts}
                 namespaces={namespaces}
                 resources={resources}
@@ -367,6 +415,7 @@ interface EditFormProps {
   setResourceName: (v: string) => void;
   port: number;
   setPort: (v: number) => void;
+  defaultPort: number;
   contexts: string[];
   namespaces: string[];
   resources: string[];
@@ -391,6 +440,7 @@ function EditForm({
   setResourceName,
   port,
   setPort,
+  defaultPort,
   contexts,
   namespaces,
   resources,
@@ -421,7 +471,8 @@ function EditForm({
           options={contexts}
           onChange={(val) => setContext(val)}
           placeholder={t("k8sConnections.chooseContext")}
-          searchable={false}
+          searchPlaceholder={t("common.search")}
+          noResultsLabel={t("common.noResults")}
         />
       </div>
 
@@ -432,7 +483,8 @@ function EditForm({
           options={namespaces}
           onChange={(val) => setNamespace(val)}
           placeholder={t("k8sConnections.chooseNamespace")}
-          searchable={false}
+          searchPlaceholder={t("common.search")}
+          noResultsLabel={t("common.noResults")}
         />
       </div>
 
@@ -462,7 +514,8 @@ function EditForm({
             options={resources}
             onChange={(val) => setResourceName(val)}
             placeholder={t("k8sConnections.chooseResource")}
-            searchable={false}
+            searchPlaceholder={t("common.search")}
+            noResultsLabel={t("common.noResults")}
           />
         </div>
       </div>
@@ -474,7 +527,7 @@ function EditForm({
           value={port}
           onChange={(e) => setPort(Number(e.target.value))}
           className={InputClass}
-          placeholder="3306"
+          placeholder={String(defaultPort)}
         />
       </div>
 

--- a/src/components/modals/K8sConnectionsModal.tsx
+++ b/src/components/modals/K8sConnectionsModal.tsx
@@ -208,19 +208,10 @@ export function K8sConnectionsModal({
       port: effectivePort,
     });
     if (!validation.isValid) {
-      setValidationError(
-        validation.error ?? t("k8sConnections.validationFailed"),
-      );
+      setValidationError(t(validation.errorKey));
       return;
     }
-    const input: K8sConnectionInput = {
-      name,
-      context,
-      namespace,
-      resource_type: resourceType,
-      resource_name: resourceName,
-      port: effectivePort,
-    };
+    const input: K8sConnectionInput = validation.value;
 
     try {
       if (isCreating) {

--- a/src/components/modals/NewConnectionModal.tsx
+++ b/src/components/modals/NewConnectionModal.tsx
@@ -199,6 +199,13 @@ export const NewConnectionModal = ({
   const [isK8sModalOpen, setIsK8sModalOpen] = useState(false);
   const [k8sMode, setK8sMode] = useState<"existing" | "inline">("existing");
   const [isK8sPortOverridden, setIsK8sPortOverridden] = useState(false);
+  const [k8sAutoPort, setK8sAutoPort] = useState<{
+    context: string;
+    namespace: string;
+    resourceType: string;
+    resourceName: string;
+    port: number;
+  } | null>(null);
   const [k8sContexts, setK8sContexts] = useState<string[]>([]);
   const [k8sNamespaces, setK8sNamespaces] = useState<string[]>([]);
   const [k8sResources, setK8sResources] = useState<string[]>([]);
@@ -288,6 +295,19 @@ export const NewConnectionModal = ({
     activeDriver?.capabilities?.file_based === false &&
     !activeDriver?.capabilities?.folder_based;
   const k8sDefaultPort = activeDriver?.default_port ?? undefined;
+  const getK8sAutoPort = (params: Partial<ConnectionParams>) =>
+    k8sAutoPort &&
+    params.k8s_context === k8sAutoPort.context &&
+    params.k8s_namespace === k8sAutoPort.namespace &&
+    params.k8s_resource_type === k8sAutoPort.resourceType &&
+    params.k8s_resource_name === k8sAutoPort.resourceName
+      ? k8sAutoPort.port
+      : undefined;
+  const resolveK8sPort = (params: Partial<ConnectionParams>) =>
+    params.k8s_enabled && k8sMode === "inline"
+      ? params.k8s_port ?? getK8sAutoPort(params) ?? k8sDefaultPort
+      : params.k8s_port;
+  const effectiveK8sPort = resolveK8sPort(formData);
   const connectionStringEnabled =
     activeDriver?.capabilities?.connection_string ??
     activeDriver?.capabilities?.connectionString ??
@@ -381,35 +401,16 @@ export const NewConnectionModal = ({
   }, [formData.k8s_context, formData.k8s_namespace, formData.k8s_resource_type]);
 
   useEffect(() => {
-    if (
-      !formData.k8s_enabled ||
-      k8sMode !== "inline" ||
-      isK8sPortOverridden ||
-      formData.k8s_port != null ||
-      k8sDefaultPort == null
-    ) {
-      return;
-    }
-
-    setFormData((prev) =>
-      prev.k8s_port != null ? prev : { ...prev, k8s_port: k8sDefaultPort },
-    );
-  }, [
-    formData.k8s_enabled,
-    formData.k8s_port,
-    isK8sPortOverridden,
-    k8sDefaultPort,
-    k8sMode,
-  ]);
-
-  useEffect(() => {
+    const context = formData.k8s_context;
+    const namespace = formData.k8s_namespace;
+    const resourceType = formData.k8s_resource_type;
     const resourceName = formData.k8s_resource_name;
     if (
       !formData.k8s_enabled ||
       k8sMode !== "inline" ||
-      !formData.k8s_context ||
-      !formData.k8s_namespace ||
-      formData.k8s_resource_type !== "service" ||
+      !context ||
+      !namespace ||
+      resourceType !== "service" ||
       !resourceName ||
       isK8sPortOverridden
     ) {
@@ -420,16 +421,16 @@ export const NewConnectionModal = ({
     void (async () => {
       try {
         const ports = await getK8sResourcePorts(
-          formData.k8s_context!,
-          formData.k8s_namespace!,
-          formData.k8s_resource_type!,
+          context,
+          namespace,
+          resourceType,
           resourceName,
         );
-        if (!cancelled && ports.length === 1) {
-          setFormData((prev) =>
-            prev.k8s_resource_name === resourceName
-              ? { ...prev, k8s_port: ports[0] }
-              : prev,
+        if (!cancelled) {
+          setK8sAutoPort(
+            ports.length === 1
+              ? { context, namespace, resourceType, resourceName, port: ports[0] }
+              : null,
           );
         }
       } catch {
@@ -471,7 +472,7 @@ export const NewConnectionModal = ({
     setLoadingDatabases(true);
     setDatabaseLoadError(null);
     try {
-      const listParams: Partial<ConnectionParams> = {
+      const listParamsBase: Partial<ConnectionParams> = {
         ...formData,
         ...overrides,
         driver: effectiveDriver,
@@ -481,6 +482,10 @@ export const NewConnectionModal = ({
             : formData.port != null
               ? Number(formData.port)
               : undefined,
+      };
+      const listParams: Partial<ConnectionParams> = {
+        ...listParamsBase,
+        k8s_port: resolveK8sPort(listParamsBase),
       };
       const databases = await invoke<string[]>("list_databases", {
         request: {
@@ -654,6 +659,7 @@ export const NewConnectionModal = ({
         driver,
         ...formData,
         port: formData.port != null ? Number(formData.port) : undefined,
+        k8s_port: effectiveK8sPort,
         database: isMultiDb
           ? (selectedDatabasesState[0] ??
             (typeof formData.database === "string" ? formData.database : ""))
@@ -728,6 +734,7 @@ export const NewConnectionModal = ({
         driver,
         ...formData,
         port: formData.port != null ? Number(formData.port) : undefined,
+        k8s_port: effectiveK8sPort,
         database: isMultiDb
           ? selectedDatabasesState.length === 1
             ? selectedDatabasesState[0]
@@ -1639,9 +1646,6 @@ export const NewConnectionModal = ({
           onChange={(e) => {
             const enabled = e.target.checked;
             updateField("k8s_enabled", enabled);
-            if (enabled && k8sMode === "inline" && !formData.k8s_port && k8sDefaultPort != null) {
-              updateField("k8s_port", k8sDefaultPort);
-            }
             // Mutual exclusion with SSH
             if (enabled && formData.ssh_enabled) {
               updateField("ssh_enabled", false);
@@ -1675,9 +1679,6 @@ export const NewConnectionModal = ({
                     setIsK8sPortOverridden(false);
                   } else {
                     updateField("k8s_connection_id", undefined);
-                    if (!formData.k8s_port && k8sDefaultPort != null) {
-                      updateField("k8s_port", k8sDefaultPort);
-                    }
                   }
                 }}
                 className={clsx(
@@ -1859,10 +1860,11 @@ export const NewConnectionModal = ({
                 label={t("newConnection.k8sPort", {
                   defaultValue: "Container Port",
                 })}
-                value={formData.k8s_port ?? ""}
+                value={effectiveK8sPort ?? ""}
+                type="number"
                 onChange={(v) => {
-                  setIsK8sPortOverridden(true);
-                  updateField("k8s_port", Number(v));
+                  setIsK8sPortOverridden(v !== "");
+                  updateField("k8s_port", v === "" ? undefined : Number(v));
                 }}
                 placeholder={k8sDefaultPort != null ? String(k8sDefaultPort) : undefined}
               />

--- a/src/components/modals/NewConnectionModal.tsx
+++ b/src/components/modals/NewConnectionModal.tsx
@@ -295,6 +295,7 @@ export const NewConnectionModal = ({
     activeDriver?.capabilities?.file_based === false &&
     !activeDriver?.capabilities?.folder_based;
   const k8sDefaultPort = activeDriver?.default_port ?? undefined;
+  // Derive K8s ports instead of seeding formData so edit flows with no saved port are covered.
   const getK8sAutoPort = (params: Partial<ConnectionParams>) =>
     k8sAutoPort &&
     params.k8s_context === k8sAutoPort.context &&

--- a/src/components/modals/NewConnectionModal.tsx
+++ b/src/components/modals/NewConnectionModal.tsx
@@ -35,6 +35,7 @@ import {
   getK8sContexts,
   getK8sNamespaces,
   getK8sResources,
+  getK8sResourcePorts,
   type K8sConnection,
 } from "../../utils/k8s";
 import { isMultiDatabaseCapable } from "../../utils/database";
@@ -197,6 +198,7 @@ export const NewConnectionModal = ({
   const [k8sConnections, setK8sConnections] = useState<K8sConnection[]>([]);
   const [isK8sModalOpen, setIsK8sModalOpen] = useState(false);
   const [k8sMode, setK8sMode] = useState<"existing" | "inline">("existing");
+  const [isK8sPortOverridden, setIsK8sPortOverridden] = useState(false);
   const [k8sContexts, setK8sContexts] = useState<string[]>([]);
   const [k8sNamespaces, setK8sNamespaces] = useState<string[]>([]);
   const [k8sResources, setK8sResources] = useState<string[]>([]);
@@ -285,6 +287,7 @@ export const NewConnectionModal = ({
     !noConnectionRequired &&
     activeDriver?.capabilities?.file_based === false &&
     !activeDriver?.capabilities?.folder_based;
+  const k8sDefaultPort = activeDriver?.default_port ?? undefined;
   const connectionStringEnabled =
     activeDriver?.capabilities?.connection_string ??
     activeDriver?.capabilities?.connectionString ??
@@ -377,6 +380,76 @@ export const NewConnectionModal = ({
     }
   }, [formData.k8s_context, formData.k8s_namespace, formData.k8s_resource_type]);
 
+  useEffect(() => {
+    if (
+      !formData.k8s_enabled ||
+      k8sMode !== "inline" ||
+      isK8sPortOverridden ||
+      formData.k8s_port != null ||
+      k8sDefaultPort == null
+    ) {
+      return;
+    }
+
+    setFormData((prev) =>
+      prev.k8s_port != null ? prev : { ...prev, k8s_port: k8sDefaultPort },
+    );
+  }, [
+    formData.k8s_enabled,
+    formData.k8s_port,
+    isK8sPortOverridden,
+    k8sDefaultPort,
+    k8sMode,
+  ]);
+
+  useEffect(() => {
+    const resourceName = formData.k8s_resource_name;
+    if (
+      !formData.k8s_enabled ||
+      k8sMode !== "inline" ||
+      !formData.k8s_context ||
+      !formData.k8s_namespace ||
+      formData.k8s_resource_type !== "service" ||
+      !resourceName ||
+      isK8sPortOverridden
+    ) {
+      return;
+    }
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const ports = await getK8sResourcePorts(
+          formData.k8s_context!,
+          formData.k8s_namespace!,
+          formData.k8s_resource_type!,
+          resourceName,
+        );
+        if (!cancelled && ports.length === 1) {
+          setFormData((prev) =>
+            prev.k8s_resource_name === resourceName
+              ? { ...prev, k8s_port: ports[0] }
+              : prev,
+          );
+        }
+      } catch {
+        // Best-effort convenience only: keep the current/default port.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    formData.k8s_enabled,
+    formData.k8s_context,
+    formData.k8s_namespace,
+    formData.k8s_resource_type,
+    formData.k8s_resource_name,
+    isK8sPortOverridden,
+    k8sMode,
+  ]);
+
   const updateField = (
     field: keyof ConnectionParams,
     value: string | number | boolean | undefined,
@@ -460,6 +533,7 @@ export const NewConnectionModal = ({
       setConnectionStringError(null);
       setNameError(false);
       setDatabasesTabError(false);
+      setIsK8sPortOverridden(false);
 
       if (initialConnection) {
         setName(initialConnection.name);
@@ -486,6 +560,7 @@ export const NewConnectionModal = ({
           // fallback: use params without secrets (backend will retrieve from keychain)
         }
 
+        setIsK8sPortOverridden(params.k8s_port != null);
         if (Array.isArray(db)) {
           setSelectedDatabasesState(db);
           setFormData({ ...params, database: db[0] ?? "" });
@@ -515,6 +590,8 @@ export const NewConnectionModal = ({
         });
         setSelectedDatabasesState([]);
         setSshMode("existing");
+        setK8sMode("existing");
+        setIsK8sPortOverridden(false);
         setDetectJsonInTextColumns(false);
         setAppearance({});
       }
@@ -554,6 +631,7 @@ export const NewConnectionModal = ({
       k8s_resource_name: undefined,
       k8s_port: undefined,
     });
+    setIsK8sPortOverridden(false);
     setSelectedDatabasesState([]);
     setDbSearchQuery("");
     setAvailableDatabases([]);
@@ -1561,6 +1639,9 @@ export const NewConnectionModal = ({
           onChange={(e) => {
             const enabled = e.target.checked;
             updateField("k8s_enabled", enabled);
+            if (enabled && k8sMode === "inline" && !formData.k8s_port && k8sDefaultPort != null) {
+              updateField("k8s_port", k8sDefaultPort);
+            }
             // Mutual exclusion with SSH
             if (enabled && formData.ssh_enabled) {
               updateField("ssh_enabled", false);
@@ -1591,8 +1672,12 @@ export const NewConnectionModal = ({
                     updateField("k8s_resource_type", undefined);
                     updateField("k8s_resource_name", undefined);
                     updateField("k8s_port", undefined);
+                    setIsK8sPortOverridden(false);
                   } else {
                     updateField("k8s_connection_id", undefined);
+                    if (!formData.k8s_port && k8sDefaultPort != null) {
+                      updateField("k8s_port", k8sDefaultPort);
+                    }
                   }
                 }}
                 className={clsx(
@@ -1634,6 +1719,8 @@ export const NewConnectionModal = ({
                       ]),
                     )}
                     onChange={(val) => updateField("k8s_connection_id", val)}
+                    searchPlaceholder={t("common.search")}
+                    noResultsLabel={t("common.noResults")}
                     placeholder={
                       k8sConnections.length === 0
                         ? t("newConnection.noK8sConnections", {
@@ -1643,7 +1730,6 @@ export const NewConnectionModal = ({
                             defaultValue: "Choose a connection...",
                           })
                     }
-                    searchable={false}
                   />
                   <button
                     type="button"
@@ -1674,6 +1760,8 @@ export const NewConnectionModal = ({
                   onChange={(val) => {
                     updateField("k8s_context", val);
                   }}
+                  searchPlaceholder={t("common.search")}
+                  noResultsLabel={t("common.noResults")}
                   placeholder={
                     k8sContexts.length === 0
                       ? t("newConnection.noK8sContexts", {
@@ -1683,7 +1771,6 @@ export const NewConnectionModal = ({
                           defaultValue: "Choose a context...",
                         })
                   }
-                  searchable={false}
                 />
               </div>
 
@@ -1699,6 +1786,8 @@ export const NewConnectionModal = ({
                   onChange={(val) => {
                     updateField("k8s_namespace", val);
                   }}
+                  searchPlaceholder={t("common.search")}
+                  noResultsLabel={t("common.noResults")}
                   placeholder={
                     k8sNamespaces.length === 0
                       ? t("newConnection.selectContextFirst", {
@@ -1708,7 +1797,6 @@ export const NewConnectionModal = ({
                           defaultValue: "Choose a namespace...",
                         })
                   }
-                  searchable={false}
                 />
               </div>
 
@@ -1752,6 +1840,8 @@ export const NewConnectionModal = ({
                     onChange={(val) =>
                       updateField("k8s_resource_name", val)
                     }
+                    searchPlaceholder={t("common.search")}
+                    noResultsLabel={t("common.noResults")}
                     placeholder={
                       k8sResources.length === 0
                         ? t("newConnection.selectTypeFirst", {
@@ -1761,7 +1851,6 @@ export const NewConnectionModal = ({
                             defaultValue: "Choose a resource...",
                           })
                     }
-                    searchable={false}
                   />
                 </div>
               </div>
@@ -1771,8 +1860,11 @@ export const NewConnectionModal = ({
                   defaultValue: "Container Port",
                 })}
                 value={formData.k8s_port ?? ""}
-                onChange={(v) => updateField("k8s_port", Number(v))}
-                placeholder="3306"
+                onChange={(v) => {
+                  setIsK8sPortOverridden(true);
+                  updateField("k8s_port", Number(v));
+                }}
+                placeholder={k8sDefaultPort != null ? String(k8sDefaultPort) : undefined}
               />
             </div>
           )}
@@ -2037,6 +2129,7 @@ export const NewConnectionModal = ({
           setIsK8sModalOpen(false);
           await loadK8sConnectionsList();
         }}
+        defaultPort={k8sDefaultPort}
       />
     </Modal>
   );

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1542,6 +1542,14 @@
     "port": "Container-Port",
     "test": "Testen",
     "testing": "Wird getestet...",
-    "validationFailed": "Validierung fehlgeschlagen"
+    "validationFailed": "Validierung fehlgeschlagen",
+    "errors": {
+      "nameRequired": "Der Verbindungsname ist erforderlich",
+      "contextRequired": "Der Kubernetes-Kontext ist erforderlich",
+      "namespaceRequired": "Der Namespace ist erforderlich",
+      "resourceTypeInvalid": "Der Ressourcentyp muss \"service\" oder \"pod\" sein",
+      "resourceNameRequired": "Der Ressourcenname ist erforderlich",
+      "portInvalid": "Der Port muss zwischen 1 und 65535 liegen"
+    }
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1603,6 +1603,14 @@
     "port": "Container Port",
     "test": "Test",
     "testing": "Testing...",
-    "validationFailed": "Validation failed"
+    "validationFailed": "Validation failed",
+    "errors": {
+      "nameRequired": "Connection name is required",
+      "contextRequired": "Kubernetes context is required",
+      "namespaceRequired": "Namespace is required",
+      "resourceTypeInvalid": "Resource type must be \"service\" or \"pod\"",
+      "resourceNameRequired": "Resource name is required",
+      "portInvalid": "Port must be between 1 and 65535"
+    }
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1499,6 +1499,14 @@
     "port": "Puerto del contenedor",
     "test": "Probar",
     "testing": "Probando...",
-    "validationFailed": "Error de validación"
+    "validationFailed": "Error de validación",
+    "errors": {
+      "nameRequired": "El nombre de la conexión es obligatorio",
+      "contextRequired": "El contexto de Kubernetes es obligatorio",
+      "namespaceRequired": "El namespace es obligatorio",
+      "resourceTypeInvalid": "El tipo de recurso debe ser \"service\" o \"pod\"",
+      "resourceNameRequired": "El nombre del recurso es obligatorio",
+      "portInvalid": "El puerto debe estar entre 1 y 65535"
+    }
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1542,6 +1542,14 @@
     "port": "Port du conteneur",
     "test": "Tester",
     "testing": "Test en cours...",
-    "validationFailed": "Échec de la validation"
+    "validationFailed": "Échec de la validation",
+    "errors": {
+      "nameRequired": "Le nom de la connexion est requis",
+      "contextRequired": "Le contexte Kubernetes est requis",
+      "namespaceRequired": "Le namespace est requis",
+      "resourceTypeInvalid": "Le type de ressource doit être \"service\" ou \"pod\"",
+      "resourceNameRequired": "Le nom de la ressource est requis",
+      "portInvalid": "Le port doit être compris entre 1 et 65535"
+    }
   }
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1525,6 +1525,14 @@
     "port": "Porta container",
     "test": "Test",
     "testing": "Test in corso...",
-    "validationFailed": "Validazione fallita"
+    "validationFailed": "Validazione fallita",
+    "errors": {
+      "nameRequired": "Il nome della connessione è obbligatorio",
+      "contextRequired": "Il contesto Kubernetes è obbligatorio",
+      "namespaceRequired": "Il namespace è obbligatorio",
+      "resourceTypeInvalid": "Il tipo di risorsa deve essere \"service\" o \"pod\"",
+      "resourceNameRequired": "Il nome della risorsa è obbligatorio",
+      "portInvalid": "La porta deve essere compresa tra 1 e 65535"
+    }
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1561,6 +1561,14 @@
     "port": "コンテナポート",
     "test": "テスト",
     "testing": "テスト中...",
-    "validationFailed": "検証に失敗しました"
+    "validationFailed": "検証に失敗しました",
+    "errors": {
+      "nameRequired": "接続名は必須です",
+      "contextRequired": "Kubernetes コンテキストは必須です",
+      "namespaceRequired": "ネームスペースは必須です",
+      "resourceTypeInvalid": "リソースタイプは \"service\" または \"pod\" である必要があります",
+      "resourceNameRequired": "リソース名は必須です",
+      "portInvalid": "ポートは 1 から 65535 の範囲で指定してください"
+    }
   }
 }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1614,6 +1614,14 @@
     "port": "Порт контейнера",
     "test": "Проверить",
     "testing": "Проверка...",
-    "validationFailed": "Ошибка проверки"
+    "validationFailed": "Ошибка проверки",
+    "errors": {
+      "nameRequired": "Имя подключения обязательно",
+      "contextRequired": "Контекст Kubernetes обязателен",
+      "namespaceRequired": "Пространство имён обязательно",
+      "resourceTypeInvalid": "Тип ресурса должен быть \"service\" или \"pod\"",
+      "resourceNameRequired": "Имя ресурса обязательно",
+      "portInvalid": "Порт должен быть в диапазоне от 1 до 65535"
+    }
   }
 }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1483,6 +1483,14 @@
     "port": "容器端口",
     "test": "测试",
     "testing": "测试中...",
-    "validationFailed": "验证失败"
+    "validationFailed": "验证失败",
+    "errors": {
+      "nameRequired": "连接名称为必填项",
+      "contextRequired": "Kubernetes 上下文为必填项",
+      "namespaceRequired": "命名空间为必填项",
+      "resourceTypeInvalid": "资源类型必须为 \"service\" 或 \"pod\"",
+      "resourceNameRequired": "资源名称为必填项",
+      "portInvalid": "端口必须介于 1 和 65535 之间"
+    }
   }
 }

--- a/src/utils/k8s.ts
+++ b/src/utils/k8s.ts
@@ -102,6 +102,23 @@ export async function getK8sResources(
 }
 
 /**
+ * List exposed ports for a Kubernetes resource.
+ */
+export async function getK8sResourcePorts(
+  context: string,
+  namespace: string,
+  resourceType: string,
+  resourceName: string,
+): Promise<number[]> {
+  return await invoke<number[]>("get_k8s_resource_ports_cmd", {
+    context,
+    namespace,
+    resourceType,
+    resourceName,
+  });
+}
+
+/**
  * Format a K8s connection for display
  */
 export function formatK8sConnectionString(k8s: K8sConnection): string {

--- a/src/utils/k8s.ts
+++ b/src/utils/k8s.ts
@@ -128,10 +128,17 @@ export function formatK8sConnectionString(k8s: K8sConnection): string {
 /**
  * Validation result for K8s connection params
  */
-export interface K8sValidationResult {
-  isValid: boolean;
-  error?: string;
-}
+export type K8sValidationErrorKey =
+  | "k8sConnections.errors.nameRequired"
+  | "k8sConnections.errors.contextRequired"
+  | "k8sConnections.errors.namespaceRequired"
+  | "k8sConnections.errors.resourceTypeInvalid"
+  | "k8sConnections.errors.resourceNameRequired"
+  | "k8sConnections.errors.portInvalid";
+
+export type K8sValidationResult =
+  | { isValid: true; value: K8sConnectionInput; errorKey?: undefined }
+  | { isValid: false; errorKey: K8sValidationErrorKey; value?: undefined };
 
 /**
  * Validate K8s connection parameters
@@ -140,28 +147,38 @@ export function validateK8sConnection(
   k8s: Partial<K8sConnectionInput>
 ): K8sValidationResult {
   if (!k8s.name || k8s.name.trim() === "") {
-    return { isValid: false, error: "Connection name is required" };
+    return { isValid: false, errorKey: "k8sConnections.errors.nameRequired" };
   }
 
   if (!k8s.context || k8s.context.trim() === "") {
-    return { isValid: false, error: "Kubernetes context is required" };
+    return { isValid: false, errorKey: "k8sConnections.errors.contextRequired" };
   }
 
   if (!k8s.namespace || k8s.namespace.trim() === "") {
-    return { isValid: false, error: "Namespace is required" };
+    return { isValid: false, errorKey: "k8sConnections.errors.namespaceRequired" };
   }
 
   if (!k8s.resource_type || (k8s.resource_type !== "service" && k8s.resource_type !== "pod")) {
-    return { isValid: false, error: "Resource type must be 'service' or 'pod'" };
+    return { isValid: false, errorKey: "k8sConnections.errors.resourceTypeInvalid" };
   }
 
   if (!k8s.resource_name || k8s.resource_name.trim() === "") {
-    return { isValid: false, error: "Resource name is required" };
+    return { isValid: false, errorKey: "k8sConnections.errors.resourceNameRequired" };
   }
 
   if (!k8s.port || k8s.port < 1 || k8s.port > 65535) {
-    return { isValid: false, error: "Port must be between 1 and 65535" };
+    return { isValid: false, errorKey: "k8sConnections.errors.portInvalid" };
   }
 
-  return { isValid: true };
+  return {
+    isValid: true,
+    value: {
+      name: k8s.name,
+      context: k8s.context,
+      namespace: k8s.namespace,
+      resource_type: k8s.resource_type,
+      resource_name: k8s.resource_name,
+      port: k8s.port,
+    },
+  };
 }

--- a/tests/components/modals/K8sConnectionsModal.test.tsx
+++ b/tests/components/modals/K8sConnectionsModal.test.tsx
@@ -1,0 +1,167 @@
+import type { ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { K8sConnectionsModal } from "../../../src/components/modals/K8sConnectionsModal";
+
+interface MockSelectProps {
+  value: string | null;
+  options: string[];
+  onChange: (value: string) => void;
+  placeholder?: string;
+  labels?: Record<string, string>;
+}
+
+interface K8sValidationInput {
+  port?: number;
+}
+
+const k8sMocks = vi.hoisted(() => ({
+  loadK8sConnections: vi.fn(),
+  saveK8sConnection: vi.fn(),
+  updateK8sConnection: vi.fn(),
+  deleteK8sConnection: vi.fn(),
+  testK8sConnection: vi.fn(),
+  getK8sContexts: vi.fn(),
+  getK8sNamespaces: vi.fn(),
+  getK8sResources: vi.fn(),
+  getK8sResourcePorts: vi.fn(),
+  validateK8sConnection: vi.fn(),
+}));
+
+vi.mock("../../../src/components/ui/Modal", () => ({
+  Modal: ({ isOpen, children }: { isOpen: boolean; children: ReactNode }) =>
+    isOpen ? <div data-testid="modal">{children}</div> : null,
+}));
+
+vi.mock("../../../src/components/ui/Select", () => ({
+  Select: ({ value, options, onChange, placeholder, labels }: MockSelectProps) => (
+    <select
+      aria-label={placeholder ?? "select"}
+      value={value ?? ""}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      <option value="">{placeholder ?? "Select option"}</option>
+      {options.map((option) => (
+        <option key={option} value={option}>
+          {labels?.[option] ?? option}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+vi.mock("../../../src/utils/k8s", () => ({
+  loadK8sConnections: k8sMocks.loadK8sConnections,
+  saveK8sConnection: k8sMocks.saveK8sConnection,
+  updateK8sConnection: k8sMocks.updateK8sConnection,
+  deleteK8sConnection: k8sMocks.deleteK8sConnection,
+  testK8sConnection: k8sMocks.testK8sConnection,
+  getK8sContexts: k8sMocks.getK8sContexts,
+  getK8sNamespaces: k8sMocks.getK8sNamespaces,
+  getK8sResources: k8sMocks.getK8sResources,
+  getK8sResourcePorts: k8sMocks.getK8sResourcePorts,
+  validateK8sConnection: k8sMocks.validateK8sConnection,
+}));
+
+function renderModal(defaultPort: number | null) {
+  return render(
+    <K8sConnectionsModal
+      isOpen={true}
+      onClose={vi.fn()}
+      defaultPort={defaultPort}
+    />,
+  );
+}
+
+async function fillRequiredFields() {
+  fireEvent.change(screen.getByPlaceholderText("k8sConnections.namePlaceholder"), {
+    target: { value: "cluster" },
+  });
+  await waitFor(() => {
+    expect(screen.getByRole("option", { name: "ctx" })).toBeInTheDocument();
+  });
+  fireEvent.change(screen.getByLabelText("k8sConnections.chooseContext"), {
+    target: { value: "ctx" },
+  });
+
+  await waitFor(() => {
+    expect(screen.getByRole("option", { name: "db" })).toBeInTheDocument();
+  });
+  fireEvent.change(screen.getByLabelText("k8sConnections.chooseNamespace"), {
+    target: { value: "db" },
+  });
+
+  await waitFor(() => {
+    expect(screen.getByRole("option", { name: "mysql-svc" })).toBeInTheDocument();
+  });
+  fireEvent.change(screen.getByLabelText("k8sConnections.chooseResource"), {
+    target: { value: "mysql-svc" },
+  });
+}
+
+describe("K8sConnectionsModal port defaults", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    k8sMocks.loadK8sConnections.mockResolvedValue([]);
+    k8sMocks.saveK8sConnection.mockResolvedValue({ id: "new" });
+    k8sMocks.updateK8sConnection.mockResolvedValue({ id: "existing" });
+    k8sMocks.deleteK8sConnection.mockResolvedValue(undefined);
+    k8sMocks.testK8sConnection.mockResolvedValue("ok");
+    k8sMocks.getK8sContexts.mockResolvedValue(["ctx"]);
+    k8sMocks.getK8sNamespaces.mockResolvedValue(["db"]);
+    k8sMocks.getK8sResources.mockResolvedValue(["mysql-svc"]);
+    k8sMocks.getK8sResourcePorts.mockResolvedValue([]);
+    k8sMocks.validateK8sConnection.mockImplementation(
+      ({ port }: K8sValidationInput) =>
+        port != null && port >= 1 && port <= 65535
+          ? { isValid: true }
+          : { isValid: false, error: "Port must be between 1 and 65535" },
+    );
+  });
+
+  it("does not fall back to MySQL port when the driver has no default port", () => {
+    renderModal(null);
+
+    fireEvent.click(screen.getByText("k8sConnections.add"));
+
+    const portInput = screen.getByRole("spinbutton") as HTMLInputElement;
+    expect(portInput.value).toBe("");
+    expect(portInput).not.toHaveAttribute("placeholder", "3306");
+  });
+
+  it("tracks the current driver default port while the field is not overridden", () => {
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <K8sConnectionsModal isOpen={true} onClose={onClose} defaultPort={3306} />,
+    );
+
+    fireEvent.click(screen.getByText("k8sConnections.add"));
+    const portInput = screen.getByRole("spinbutton") as HTMLInputElement;
+    expect(portInput.value).toBe("3306");
+
+    rerender(
+      <K8sConnectionsModal isOpen={true} onClose={onClose} defaultPort={5432} />,
+    );
+    expect(portInput.value).toBe("5432");
+  });
+
+  it("clearing a manual port falls back to the provided driver default instead of 0", async () => {
+    renderModal(15432);
+
+    fireEvent.click(screen.getByText("k8sConnections.add"));
+    await fillRequiredFields();
+
+    const portInput = screen.getByRole("spinbutton") as HTMLInputElement;
+    expect(portInput.value).toBe("15432");
+
+    fireEvent.change(portInput, { target: { value: "7777" } });
+    fireEvent.change(portInput, { target: { value: "" } });
+    fireEvent.click(screen.getByText("common.save"));
+
+    await waitFor(() => {
+      expect(k8sMocks.saveK8sConnection).toHaveBeenCalledWith(
+        expect.objectContaining({ port: 15432 }),
+      );
+    });
+  });
+});

--- a/tests/components/modals/K8sConnectionsModal.test.tsx
+++ b/tests/components/modals/K8sConnectionsModal.test.tsx
@@ -12,6 +12,11 @@ interface MockSelectProps {
 }
 
 interface K8sValidationInput {
+  name?: string;
+  context?: string;
+  namespace?: string;
+  resource_type?: string;
+  resource_name?: string;
   port?: number;
 }
 
@@ -112,10 +117,20 @@ describe("K8sConnectionsModal port defaults", () => {
     k8sMocks.getK8sResources.mockResolvedValue(["mysql-svc"]);
     k8sMocks.getK8sResourcePorts.mockResolvedValue([]);
     k8sMocks.validateK8sConnection.mockImplementation(
-      ({ port }: K8sValidationInput) =>
-        port != null && port >= 1 && port <= 65535
-          ? { isValid: true }
-          : { isValid: false, error: "Port must be between 1 and 65535" },
+      (input: K8sValidationInput) =>
+        input.port != null && input.port >= 1 && input.port <= 65535
+          ? {
+              isValid: true,
+              value: {
+                name: input.name ?? "",
+                context: input.context ?? "",
+                namespace: input.namespace ?? "",
+                resource_type: input.resource_type ?? "service",
+                resource_name: input.resource_name ?? "",
+                port: input.port,
+              },
+            }
+          : { isValid: false, errorKey: "k8sConnections.errors.portInvalid" },
     );
   });
 

--- a/tests/components/modals/NewConnectionModal.test.tsx
+++ b/tests/components/modals/NewConnectionModal.test.tsx
@@ -1,0 +1,223 @@
+import type { ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { invoke } from "@tauri-apps/api/core";
+import { NewConnectionModal } from "../../../src/components/modals/NewConnectionModal";
+
+interface MockSelectProps {
+  value: string | null;
+  options: string[];
+  onChange: (value: string) => void;
+  placeholder?: string;
+  labels?: Record<string, string>;
+}
+
+const driverState = vi.hoisted(() => ({
+  defaultPort: 15432 as number | null,
+}));
+
+const k8sMocks = vi.hoisted(() => ({
+  loadK8sConnections: vi.fn(),
+  getK8sContexts: vi.fn(),
+  getK8sNamespaces: vi.fn(),
+  getK8sResources: vi.fn(),
+  getK8sResourcePorts: vi.fn(),
+}));
+
+const sshMocks = vi.hoisted(() => ({
+  loadSshConnections: vi.fn(),
+}));
+
+vi.mock("../../../src/components/ui/Modal", () => ({
+  Modal: ({ isOpen, children }: { isOpen: boolean; children: ReactNode }) =>
+    isOpen ? <div data-testid="modal">{children}</div> : null,
+}));
+
+vi.mock("../../../src/components/ui/Select", () => ({
+  Select: ({ value, options, onChange, placeholder, labels }: MockSelectProps) => (
+    <select
+      aria-label={placeholder ?? "select"}
+      value={value ?? ""}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      <option value="">{placeholder ?? "Select option"}</option>
+      {options.map((option) => (
+        <option key={option} value={option}>
+          {labels?.[option] ?? option}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+vi.mock("../../../src/hooks/useDrivers", () => ({
+  useDrivers: () => ({
+    drivers: [
+      {
+        id: "mysql",
+        name: "MySQL",
+        version: "1.0.0",
+        default_port: driverState.defaultPort,
+        is_builtin: true,
+        capabilities: {
+          file_based: false,
+          folder_based: false,
+          connection_string: true,
+          supports_ssl: false,
+        },
+      },
+    ],
+    allDrivers: [],
+    installedPlugins: [],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("../../../src/hooks/usePluginSlotRegistry", () => ({
+  usePluginSlotRegistry: () => ({
+    getSlotContributions: () => [],
+  }),
+}));
+
+vi.mock("../../../src/utils/ssh", () => ({
+  loadSshConnections: sshMocks.loadSshConnections,
+}));
+
+vi.mock("../../../src/utils/k8s", () => ({
+  loadK8sConnections: k8sMocks.loadK8sConnections,
+  getK8sContexts: k8sMocks.getK8sContexts,
+  getK8sNamespaces: k8sMocks.getK8sNamespaces,
+  getK8sResources: k8sMocks.getK8sResources,
+  getK8sResourcePorts: k8sMocks.getK8sResourcePorts,
+}));
+
+vi.mock("../../../src/components/modals/NewConnectionModal/AppearanceSection", () => ({
+  AppearanceSection: () => null,
+}));
+
+vi.mock("../../../src/components/modals/SshConnectionsModal", () => ({
+  SshConnectionsModal: () => null,
+}));
+
+vi.mock("../../../src/components/modals/K8sConnectionsModal", () => ({
+  K8sConnectionsModal: () => null,
+}));
+
+function renderModal() {
+  return render(
+    <NewConnectionModal isOpen={true} onClose={vi.fn()} onSave={vi.fn()} />,
+  );
+}
+
+async function openInlineK8s() {
+  renderModal();
+  fireEvent.click(screen.getByText("Kubernetes"));
+  fireEvent.click(screen.getByLabelText("newConnection.useK8s"));
+  fireEvent.click(screen.getByText("newConnection.createInlineK8s"));
+
+  await waitFor(() => {
+    expect(screen.getByRole("option", { name: "ctx" })).toBeInTheDocument();
+  });
+}
+
+async function chooseServiceResource() {
+  fireEvent.change(screen.getByLabelText("newConnection.chooseContext"), {
+    target: { value: "ctx" },
+  });
+
+  await waitFor(() => {
+    expect(screen.getByRole("option", { name: "db" })).toBeInTheDocument();
+  });
+  fireEvent.change(screen.getByLabelText("newConnection.chooseNamespace"), {
+    target: { value: "db" },
+  });
+
+  fireEvent.change(screen.getByLabelText("newConnection.k8sSelectType"), {
+    target: { value: "service" },
+  });
+
+  await waitFor(() => {
+    expect(screen.getByRole("option", { name: "mysql-svc" })).toBeInTheDocument();
+  });
+  fireEvent.change(screen.getByLabelText("newConnection.chooseResource"), {
+    target: { value: "mysql-svc" },
+  });
+}
+
+describe("NewConnectionModal K8s port defaults", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    driverState.defaultPort = 15432;
+    vi.mocked(invoke).mockResolvedValue("ok");
+    sshMocks.loadSshConnections.mockResolvedValue([]);
+    k8sMocks.loadK8sConnections.mockResolvedValue([]);
+    k8sMocks.getK8sContexts.mockResolvedValue(["ctx"]);
+    k8sMocks.getK8sNamespaces.mockResolvedValue(["db"]);
+    k8sMocks.getK8sResources.mockResolvedValue(["mysql-svc"]);
+    k8sMocks.getK8sResourcePorts.mockResolvedValue([6543]);
+  });
+
+  it("uses the active driver default as the effective inline K8s port", async () => {
+    await openInlineK8s();
+
+    const portInput = screen.getByPlaceholderText("15432");
+    expect(portInput).toHaveAttribute("type", "number");
+    expect(portInput).toHaveValue(15432);
+
+    fireEvent.click(screen.getByText("newConnection.testConnection"));
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith(
+        "test_connection",
+        expect.objectContaining({
+          request: expect.objectContaining({
+            params: expect.objectContaining({
+              k8s_enabled: true,
+              k8s_port: 15432,
+            }),
+          }),
+        }),
+      );
+    });
+  });
+
+  it("clearing a manual K8s port re-enables single-port auto-prefill", async () => {
+    await openInlineK8s();
+
+    const portInput = screen.getByPlaceholderText("15432");
+    fireEvent.change(portInput, { target: { value: "9999" } });
+    await chooseServiceResource();
+
+    expect(k8sMocks.getK8sResourcePorts).not.toHaveBeenCalled();
+    expect(portInput).toHaveValue(9999);
+
+    fireEvent.change(portInput, { target: { value: "" } });
+
+    await waitFor(() => {
+      expect(k8sMocks.getK8sResourcePorts).toHaveBeenCalledWith(
+        "ctx",
+        "db",
+        "service",
+        "mysql-svc",
+      );
+      expect(portInput).toHaveValue(6543);
+    });
+
+    fireEvent.click(screen.getByText("newConnection.testConnection"));
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith(
+        "test_connection",
+        expect.objectContaining({
+          request: expect.objectContaining({
+            params: expect.objectContaining({
+              k8s_port: 6543,
+            }),
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/tests/utils/k8s.test.ts
+++ b/tests/utils/k8s.test.ts
@@ -39,19 +39,19 @@ describe("k8s", () => {
       it("should fail when name is missing", () => {
         const result = validateK8sConnection({ ...validInput, name: "" });
         expect(result.isValid).toBe(false);
-        expect(result.error).toBe("Connection name is required");
+        expect(result.errorKey).toBe("k8sConnections.errors.nameRequired");
       });
 
       it("should fail when name is whitespace", () => {
         const result = validateK8sConnection({ ...validInput, name: "   " });
         expect(result.isValid).toBe(false);
-        expect(result.error).toBe("Connection name is required");
+        expect(result.errorKey).toBe("k8sConnections.errors.nameRequired");
       });
 
       it("should fail when context is missing", () => {
         const result = validateK8sConnection({ ...validInput, context: "" });
         expect(result.isValid).toBe(false);
-        expect(result.error).toBe("Kubernetes context is required");
+        expect(result.errorKey).toBe("k8sConnections.errors.contextRequired");
       });
 
       it("should fail when namespace is missing", () => {
@@ -60,7 +60,7 @@ describe("k8s", () => {
           namespace: "",
         });
         expect(result.isValid).toBe(false);
-        expect(result.error).toBe("Namespace is required");
+        expect(result.errorKey).toBe("k8sConnections.errors.namespaceRequired");
       });
 
       it("should fail when resource_name is missing", () => {
@@ -69,7 +69,7 @@ describe("k8s", () => {
           resource_name: "",
         });
         expect(result.isValid).toBe(false);
-        expect(result.error).toBe("Resource name is required");
+        expect(result.errorKey).toBe("k8sConnections.errors.resourceNameRequired");
       });
     });
 
@@ -80,8 +80,8 @@ describe("k8s", () => {
           resource_type: "deployment",
         });
         expect(result.isValid).toBe(false);
-        expect(result.error).toBe(
-          "Resource type must be 'service' or 'pod'",
+        expect(result.errorKey).toBe(
+          "k8sConnections.errors.resourceTypeInvalid",
         );
       });
 
@@ -106,7 +106,7 @@ describe("k8s", () => {
       it("should fail when port is 0", () => {
         const result = validateK8sConnection({ ...validInput, port: 0 });
         expect(result.isValid).toBe(false);
-        expect(result.error).toBe("Port must be between 1 and 65535");
+        expect(result.errorKey).toBe("k8sConnections.errors.portInvalid");
       });
 
       it("should fail when port is > 65535", () => {
@@ -115,7 +115,7 @@ describe("k8s", () => {
           port: 70000,
         });
         expect(result.isValid).toBe(false);
-        expect(result.error).toBe("Port must be between 1 and 65535");
+        expect(result.errorKey).toBe("k8sConnections.errors.portInvalid");
       });
 
       it("should succeed with port 1", () => {

--- a/tests/utils/k8s.test.ts
+++ b/tests/utils/k8s.test.ts
@@ -6,6 +6,7 @@ import {
   getK8sContexts,
   getK8sNamespaces,
   getK8sResources,
+  getK8sResourcePorts,
   loadK8sConnections,
   saveK8sConnection,
   updateK8sConnection,
@@ -238,6 +239,28 @@ describe("k8s", () => {
         resourceType: "service",
       });
       expect(result).toEqual(["mysql-svc", "postgres-svc"]);
+    });
+  });
+
+  describe("getK8sResourcePorts", () => {
+    it("should call invoke with all parameters", async () => {
+      const { invoke } = await import("@tauri-apps/api/core");
+      vi.mocked(invoke).mockResolvedValue([5432]);
+
+      const result = await getK8sResourcePorts(
+        "minikube",
+        "database",
+        "service",
+        "postgres-svc",
+      );
+
+      expect(invoke).toHaveBeenCalledWith("get_k8s_resource_ports_cmd", {
+        context: "minikube",
+        namespace: "database",
+        resourceType: "service",
+        resourceName: "postgres-svc",
+      });
+      expect(result).toEqual([5432]);
     });
   });
 


### PR DESCRIPTION

 ### Summary

 The Kubernetes connection dialogs had two usability issues:

 1. Non-searchable dropdowns — Context, namespace, and resource name selectors
    required scrolling through potentially long lists with no way to filter.
 2. Hard-coded MySQL port — The K8s "Container Port" always defaulted to 3306
    regardless of the selected database driver (Postgres 5432, ClickHouse 8123, etc.)
    or the service's actual exposed port.

 ### Changes

 Searchable dropdowns
 - Enabled search on K8s context, namespace, saved connection, and resource name
   selectors in both K8sConnectionsModal and the K8s tab of NewConnectionModal. Uses
   the existing Select component's built-in search with common.search /
   common.noResults i18n keys.
 - Resource type (service/pod) kept non-searchable since it only has two options.

 Driver-aware port defaults
 - Replaced hard-coded 3306 with activeDriver.default_port from the driver manifest,
   so:
     - MySQL → 3306, Postgres → 5432, plugins (e.g. ClickHouse) → their manifest
       default
 - K8sConnectionsModal accepts an optional defaultPort prop from the parent modal.
 - Port placeholder and initial value reflect the selected driver.

 Single-service-port auto-prefill
 - New additive Tauri command get_k8s_resource_ports_cmd discovers ports for a
   selected K8s service via kubectl get service -o jsonpath={.spec.ports[*].port}.
 - TypeScript utility getK8sResourcePorts() wraps the command.
 - When a service exposes exactly one port and the user hasn't manually edited the
   port, it is auto-prefilled.
 - Port auto-prefill is restricted to services only (pods skipped).
 - Guarded by isPortOverridden / isK8sPortOverridden flags so manual edits are never
   overwritten.
