### PR TITLE
Add IBM Informix plugin to registry

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -236,6 +236,23 @@
           }
         }
       ]
+    },
+    {
+      "id": "informix",
+      "name": "IBM Informix",
+      "description": "IBM Informix 11.70+ driver plugin for Tabularis (ODBC; requires the Informix Client SDK)",
+      "author": "Daniel Núñez <https://github.com/danielnuld>",
+      "homepage": "https://github.com/danielnuld/tabularis-informix-plugin",
+      "latest_version": "0.1.0",
+      "releases": [
+        {
+          "version": "0.1.0",
+          "min_tabularis_version": "0.9.17",
+          "assets": {
+            "win-x64": "https://github.com/danielnuld/tabularis-informix-plugin/releases/download/v0.1.0/tabularis-informix-plugin-win-x64-v0.1.0.zip"
+          }
+        }
+      ]
     }
   ]
 }

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -243,13 +243,13 @@
       "description": "IBM Informix 11.70+ driver plugin for Tabularis (ODBC; requires the Informix Client SDK)",
       "author": "Daniel Núñez <https://github.com/danielnuld>",
       "homepage": "https://github.com/danielnuld/tabularis-informix-plugin",
-      "latest_version": "0.1.0",
+      "latest_version": "0.1.1",
       "releases": [
         {
-          "version": "0.1.0",
+          "version": "0.1.1",
           "min_tabularis_version": "0.9.17",
           "assets": {
-            "win-x64": "https://github.com/danielnuld/tabularis-informix-plugin/releases/download/v0.1.0/tabularis-informix-plugin-win-x64-v0.1.0.zip"
+            "win-x64": "https://github.com/danielnuld/tabularis-informix-plugin/releases/download/v0.1.1/tabularis-informix-plugin-win-x64-v0.1.1.zip"
           }
         }
       ]

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -243,13 +243,14 @@
       "description": "IBM Informix 11.70+ driver plugin for Tabularis (ODBC; requires the Informix Client SDK)",
       "author": "Daniel Núñez <https://github.com/danielnuld>",
       "homepage": "https://github.com/danielnuld/tabularis-informix-plugin",
-      "latest_version": "0.1.1",
+      "latest_version": "0.1.2",
       "releases": [
         {
-          "version": "0.1.1",
+          "version": "0.1.2",
           "min_tabularis_version": "0.9.17",
           "assets": {
-            "win-x64": "https://github.com/danielnuld/tabularis-informix-plugin/releases/download/v0.1.1/tabularis-informix-plugin-win-x64-v0.1.1.zip"
+            "linux-x64": "https://github.com/danielnuld/tabularis-informix-plugin/releases/download/v0.1.2/tabularis-informix-plugin-linux-x64-v0.1.2.zip",
+            "win-x64": "https://github.com/danielnuld/tabularis-informix-plugin/releases/download/v0.1.2/tabularis-informix-plugin-win-x64-v0.1.2.zip"
           }
         }
       ]


### PR DESCRIPTION
Adds the **IBM Informix** driver plugin to `plugins/registry.json`.

- **Repo:** https://github.com/danielnuld/tabularis-informix-plugin (Apache-2.0)
- **What it does:** connects Tabularis to IBM Informix 11.70+ via the IBM Informix ODBC driver (`odbc-api`). Covers metadata (tables, columns, indexes, foreign keys, views, routines), query execution with `SKIP`/`FIRST` pagination, row CRUD (with a composite-PK safety guard), and DDL generation. 44 unit tests for the pure logic; validated end-to-end against a real Informix 11.70 server.
- **Runtime requirement:** the IBM Informix Client SDK (CSDK) must be installed on the host (provides the ODBC driver). Documented in the README.
- **Platforms:** Windows for now (`win-x64`). The plugin's bitness must match the installed Informix ODBC driver; a 32-bit build (`win-x86`) is also published on the GitHub Release for the common 32-bit CSDK, and the README explains how to pick it.

Release assets verified downloadable (HTTP 200). Modeled the entry on the existing `db2` plugin.