### PR TITLE
fix(ai): refresh Anthropic and MiniMax models from their APIs

### DIFF
--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -68,6 +68,16 @@ struct OpenAiModel {
 }
 
 #[derive(Deserialize, Debug)]
+struct AnthropicModelList {
+    data: Vec<AnthropicModel>,
+}
+
+#[derive(Deserialize, Debug)]
+struct AnthropicModel {
+    id: String,
+}
+
+#[derive(Deserialize, Debug)]
 struct OpenRouterModelList {
     data: Vec<OpenRouterModel>,
 }
@@ -166,6 +176,53 @@ async fn fetch_openai_models(api_key: &str) -> Vec<String> {
                         .map(|m| m.id)
                         .filter(|id| id.starts_with("gpt") || id.starts_with("o1"))
                         .collect();
+                }
+            }
+            Vec::new()
+        }
+        Err(_) => Vec::new(),
+    }
+}
+
+async fn fetch_anthropic_models(api_key: &str) -> Vec<String> {
+    if api_key.is_empty() {
+        return Vec::new();
+    }
+    let client = Client::new();
+    match client
+        .get("https://api.anthropic.com/v1/models")
+        .header("x-api-key", api_key)
+        .header("anthropic-version", "2023-06-01")
+        .send()
+        .await
+    {
+        Ok(res) => {
+            if res.status().is_success() {
+                if let Ok(json) = res.json::<AnthropicModelList>().await {
+                    return json.data.into_iter().map(|m| m.id).collect();
+                }
+            }
+            Vec::new()
+        }
+        Err(_) => Vec::new(),
+    }
+}
+
+async fn fetch_minimax_models(api_key: &str) -> Vec<String> {
+    if api_key.is_empty() {
+        return Vec::new();
+    }
+    let client = Client::new();
+    match client
+        .get("https://api.minimax.io/v1/models")
+        .header("Authorization", format!("Bearer {}", api_key))
+        .send()
+        .await
+    {
+        Ok(res) => {
+            if res.status().is_success() {
+                if let Ok(json) = res.json::<OpenAiModelList>().await {
+                    return json.data.into_iter().map(|m| m.id).collect();
                 }
             }
             Vec::new()
@@ -297,6 +354,22 @@ pub async fn get_ai_models(
                     }
                 }
 
+                // Always refresh Anthropic if API key is present
+                if let Ok(key) = config::get_ai_api_key(&app, "anthropic") {
+                    let anthropic_models = fetch_anthropic_models(&key).await;
+                    if !anthropic_models.is_empty() {
+                        cached_models.insert("anthropic".to_string(), anthropic_models);
+                    }
+                }
+
+                // Always refresh MiniMax if API key is present
+                if let Ok(key) = config::get_ai_api_key(&app, "minimax") {
+                    let minimax_models = fetch_minimax_models(&key).await;
+                    if !minimax_models.is_empty() {
+                        cached_models.insert("minimax".to_string(), minimax_models);
+                    }
+                }
+
                 return Ok(cached_models);
             }
         }
@@ -323,7 +396,33 @@ pub async fn get_ai_models(
         }
     }
 
-    // 3. OpenRouter (Dynamic public)
+    // 3. Anthropic (Dynamic if key exists)
+    if let Ok(key) = config::get_ai_api_key(&app, "anthropic") {
+        let remote_models = fetch_anthropic_models(&key).await;
+        if !remote_models.is_empty() {
+            if let Some(static_list) = models.get_mut("anthropic") {
+                let mut set: HashSet<String> = static_list.iter().cloned().collect();
+                set.extend(remote_models);
+                *static_list = set.into_iter().collect();
+                static_list.sort();
+            }
+        }
+    }
+
+    // 4. MiniMax (Dynamic if key exists)
+    if let Ok(key) = config::get_ai_api_key(&app, "minimax") {
+        let remote_models = fetch_minimax_models(&key).await;
+        if !remote_models.is_empty() {
+            if let Some(static_list) = models.get_mut("minimax") {
+                let mut set: HashSet<String> = static_list.iter().cloned().collect();
+                set.extend(remote_models);
+                *static_list = set.into_iter().collect();
+                static_list.sort();
+            }
+        }
+    }
+
+    // 5. OpenRouter (Dynamic public)
     let openrouter_models = fetch_openrouter_models().await;
     if !openrouter_models.is_empty() {
         if let Some(static_list) = models.get_mut("openrouter") {
@@ -339,7 +438,7 @@ pub async fn get_ai_models(
         }
     }
 
-    // 4. Custom OpenAI (Dynamic if configured)
+    // 6. Custom OpenAI (Dynamic if configured)
     if let (Some(base_url), Ok(api_key)) = (
         app_config.ai_custom_openai_url,
         config::get_ai_api_key(&app, "custom-openai"),
@@ -919,7 +1018,14 @@ mod tests {
 
         // Check for new futuristic models from yaml
         let openai = models.get("openai").unwrap();
-        assert!(openai.contains(&"gpt-5.2".to_string()));
+        assert!(openai.contains(&"gpt-5.5".to_string()));
+
+        // Anthropic should include the flagship Fable 5 and current Opus/Sonnet/Haiku
+        let anthropic = models.get("anthropic").unwrap();
+        assert!(anthropic.contains(&"claude-fable-5".to_string()));
+        assert!(anthropic.contains(&"claude-opus-4-8".to_string()));
+        assert!(anthropic.contains(&"claude-sonnet-4-6".to_string()));
+        assert!(anthropic.contains(&"claude-haiku-4-5".to_string()));
 
         // Check MiniMax models
         let minimax = models.get("minimax").unwrap();

--- a/src-tauri/src/ai_models.yaml
+++ b/src-tauri/src/ai_models.yaml
@@ -1,18 +1,22 @@
 openai:
-  - gpt-5.2
-  - gpt-5.2-instant
-  - gpt-5.2-thinking
+  - gpt-5.5
+  - gpt-5.4
+  - gpt-5.4-mini
+  - gpt-5.4-nano
   - gpt-4o
   - gpt-4o-mini
   - gpt-oss-120B
   - gpt-oss-20B
 
 anthropic:
-  - claude-opus-4.5
-  - claude-sonnet-4.5
-  - claude-haiku-4.5
-  - claude-3.5-sonnet
-  - claude-3.5-haiku
+  - claude-fable-5
+  - claude-opus-4-8
+  - claude-sonnet-4-6
+  - claude-haiku-4-5
+  - claude-opus-4-7
+  - claude-opus-4-6
+  - claude-sonnet-4-5
+  - claude-opus-4-5
 
 minimax:
   - MiniMax-M3
@@ -20,6 +24,9 @@ minimax:
   - MiniMax-M2.7-highspeed
 
 openrouter:
+  - openai/gpt-5.5
+  - openai/gpt-5.4
+  - openai/gpt-5.4-mini
   - openai/gpt-4o
   - openai/gpt-4o-mini
   - google/gemini-3-pro-preview
@@ -28,9 +35,10 @@ openrouter:
   - google/gemini-2.5-flash
   - google/gemini-2.5-flash-lite
   - google/gemini-2.0-flash-001
-  - anthropic/claude-opus-4.5
-  - anthropic/claude-sonnet-4.5
-  - anthropic/claude-haiku-4.5
+  - anthropic/claude-fable-5
+  - anthropic/claude-opus-4-8
+  - anthropic/claude-sonnet-4-6
+  - anthropic/claude-haiku-4-5
   - deepseek/deepseek-v3.2
   - openai/gpt-oss-120b:free
   - z-ai/glm-4.5-air:free


### PR DESCRIPTION
## Summary

Fixes the issue where the model list under **Settings → AI** never refreshed for **Anthropic** and **MiniMax**, leaving users stuck with an outdated set of selectable models.

Closes #358

## The problem

Each AI provider in `get_ai_models` either has a remote fetch that augments the static fallback list, or is served from the static list alone. OpenAI, OpenRouter, Ollama and Custom OpenAI all had a remote fetch wired in — but **Anthropic** and **MiniMax** did not.

As a result:

- The Anthropic and MiniMax dropdowns only ever showed the hard-coded fallback entries from `ai_models.yaml`.
- Hitting the **Refresh Models** button (which forces `force_refresh`) re-ran the same code path, which had nothing to fetch for these two providers, so the list never changed — even after an app update.
- The bundled fallback lists had drifted behind the providers' current line-ups, so the only models on offer were stale.

## The fix

- Added `fetch_anthropic_models` — queries `GET https://api.anthropic.com/v1/models` (using `x-api-key` + `anthropic-version` headers) and returns the live model ids.
- Added `fetch_minimax_models` — queries `GET https://api.minimax.io/v1/models` (Bearer auth, OpenAI-compatible response shape) and returns the live model ids.
- Wired both providers into the two relevant code paths in `get_ai_models`:
  - **Cache-warm path** (cache younger than 24h): refreshed in place whenever an API key is present, alongside the existing always-refresh providers (Ollama, Custom OpenAI).
  - **Full refresh path**: the remote results are merged with the static favourites (de-duplicated via a `HashSet`, then sorted), matching how OpenAI is handled.
- Refreshed the static fallback lists in `ai_models.yaml` for `openai`, `anthropic`, `openrouter` and the OpenRouter aliases, which had fallen behind the current models. These remain the offline fallback for when no API key is configured or the network request fails.

A remote fetch only runs when an API key for the provider is configured; failures degrade gracefully to the static list, so behaviour for users without keys is unchanged.

## Notes on the secondary report

The issue also mentions the previous provider's default model name leaking when switching providers (e.g. *"Model claude-opus-4.5 not found in OpenAI"*). That is a separate selection/validation concern and is not addressed here; this PR is scoped to making the model lists actually refresh.

## Testing

- `cargo test --lib ai::` passes.
- Updated the model-list unit test to assert the current Anthropic flagship/Opus/Sonnet/Haiku ids are present in the loaded defaults.