### PR TITLE
chore: enforce 3-day release-age cooldown for pnpm deps

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,8 @@
 packages:
   - packages/*
 
+# Supply-chain hardening: only install package versions published >=3 days ago
+minimumReleaseAge: 4320
+
 ignoredBuiltDependencies:
   - esbuild


### PR DESCRIPTION
## What

Adds `minimumReleaseAge: 4320` (3 days, in minutes) to `pnpm-workspace.yaml`.

pnpm 10.16+ supports this natively, so no new tooling. It applies workspace-wide (root + `packages/*`): pnpm will refuse to install any package version published less than 3 days ago.

## Why

Supply-chain hardening. Malicious releases (compromised maintainer accounts, malicious install scripts) are usually caught and yanked within hours-to-days. Gating on release age cuts exposure to freshly-published bad versions.

## Notes

- Existing pinned versions in `pnpm-lock.yaml` are unaffected — this only gates new resolutions.
- Need a fresh release through? Add `minimumReleaseAgeExclude: [pkg-name]`.
- **Rust/Cargo (`src-tauri`) is not covered** — Cargo has no native minimum-release-age feature. Tracked as a known gap.

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)