### PR TITLE
Add a customizable keyboard shortcut that manually triggers the Monac…

### DIFF
--- a/src/components/ui/SqlEditorWrapper.tsx
+++ b/src/components/ui/SqlEditorWrapper.tsx
@@ -5,6 +5,7 @@ import { useEditorTheme } from "../../hooks/useEditorTheme";
 import { loadMonacoTheme } from "../../themes/themeUtils";
 import { readText } from "@tauri-apps/plugin-clipboard-manager";
 import { useSettings } from "../../hooks/useSettings";
+import { useKeybindings } from "../../hooks/useKeybindings";
 import { getFontCSS } from "../../utils/settings";
 
 interface SqlEditorWrapperProps {
@@ -33,6 +34,9 @@ const SqlEditorInternal = ({
   onRunRef.current = onRun;
   const editorTheme = useEditorTheme();
   const { settings } = useSettings();
+  const { matchesShortcut } = useKeybindings();
+  const matchesShortcutRef = useRef(matchesShortcut);
+  matchesShortcutRef.current = matchesShortcut;
 
   // Dispose editor on unmount to prevent "domNode" errors from ResizeObserver
   // firing after the DOM container is removed (e.g., cell deletion/movement)
@@ -140,6 +144,15 @@ const SqlEditorInternal = ({
           onRunRef.current();
         }
       );
+
+      // Force the suggestion widget via the user-configurable shortcut
+      editor.onKeyDown((e) => {
+        if (matchesShortcutRef.current(e.browserEvent, "trigger_suggestions")) {
+          e.preventDefault();
+          e.stopPropagation();
+          editor.trigger("keyboard", "editor.action.triggerSuggest", {});
+        }
+      });
 
       if (onMount) onMount(editor, monaco);
     };

--- a/src/config/shortcuts.json
+++ b/src/config/shortcuts.json
@@ -158,5 +158,15 @@
     "winMatch": { "ctrlKey": true, "key": "p" },
     "i18nKey": "settings.shortcuts.quickNavigator",
     "overridable": true
+  },
+  {
+    "id": "trigger_suggestions",
+    "category": "editor",
+    "defaultMac": "⌘+I",
+    "defaultWin": "Ctrl+Space",
+    "macMatch": { "metaKey": true, "key": "i" },
+    "winMatch": { "ctrlKey": true, "key": " " },
+    "i18nKey": "settings.shortcuts.triggerSuggestions",
+    "overridable": true
   }
 ]

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -577,7 +577,8 @@
       "notebookRunAll": "Alle Zellen ausführen",
       "categories_notebook": "Notebook",
       "pasteImportClipboard": "Aus Zwischenablage importieren",
-      "quickNavigator": "Schnellnavigation"
+      "quickNavigator": "Schnellnavigation",
+      "triggerSuggestions": "Vorschläge anzeigen"
     },
     "aiActivity": "KI-Aktivität"
   },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -611,7 +611,8 @@
       "notebookRunAll": "Run All Cells",
       "categories_notebook": "Notebook",
       "pasteImportClipboard": "Import from Clipboard",
-      "quickNavigator": "Quick Navigator"
+      "quickNavigator": "Quick Navigator",
+      "triggerSuggestions": "Trigger suggestions"
     },
     "aiActivity": "AI Activity"
   },

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -582,7 +582,8 @@
       "notebookRunAll": "Ejecutar Todas las Celdas",
       "categories_notebook": "Notebook",
       "pasteImportClipboard": "Importar desde Portapapeles",
-      "quickNavigator": "Navegador rápido"
+      "quickNavigator": "Navegador rápido",
+      "triggerSuggestions": "Mostrar sugerencias"
     },
     "aiActivity": "Actividad IA"
   },

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -577,7 +577,8 @@
       "notebookRunAll": "Exécuter toutes les cellules",
       "categories_notebook": "Notebook",
       "pasteImportClipboard": "Importer depuis le Presse-papiers",
-      "quickNavigator": "Navigateur rapide"
+      "quickNavigator": "Navigateur rapide",
+      "triggerSuggestions": "Afficher les suggestions"
     },
     "aiActivity": "Activité IA"
   },

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -582,7 +582,8 @@
       "notebookRunAll": "Esegui Tutte le Celle",
       "categories_notebook": "Notebook",
       "pasteImportClipboard": "Importa dagli Appunti",
-      "quickNavigator": "Navigatore rapido"
+      "quickNavigator": "Navigatore rapido",
+      "triggerSuggestions": "Mostra suggerimenti"
     },
     "aiActivity": "Attività AI"
   },

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -591,7 +591,8 @@
       "notebookRunAll": "すべてのセルを実行",
       "categories_notebook": "ノートブック",
       "pasteImportClipboard": "クリップボードからインポート",
-      "quickNavigator": "クイックナビゲーター"
+      "quickNavigator": "クイックナビゲーター",
+      "triggerSuggestions": "候補を表示"
     },
     "aiActivity": "AI アクティビティ"
   },

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -572,7 +572,8 @@
       "notebookRunAll": "Выполнить все ячейки",
       "categories_notebook": "Ноутбук",
       "pasteImportClipboard": "Импортировать из буфера обмена",
-      "quickNavigator": "Быстрый навигатор"
+      "quickNavigator": "Быстрый навигатор",
+      "triggerSuggestions": "Показать подсказки"
     },
     "aiActivity": "Активность AI"
   },

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -545,7 +545,8 @@
       "pressKeys": "按下组合键...",
       "notebookRunAll": "运行所有单元格",
       "categories_notebook": "笔记本",
-      "quickNavigator": "快速导航"
+      "quickNavigator": "快速导航",
+      "triggerSuggestions": "触发建议"
     },
     "aiActivity": "AI 活动"
   },


### PR DESCRIPTION
- New `trigger_suggestions` shortcut (default ⌘+I on Mac, Ctrl+Space on
  Windows) wired through the existing keybindings system, so it respects
  user overrides from Settings → Keyboard Shortcuts → Editor
- SqlEditorWrapper listens via Monaco onKeyDown and fires
  editor.action.triggerSuggest, covering both the main editor and
  notebook cells
- Mac default avoids Ctrl+Space since macOS reserves it for input-source
  switching
- Add "Trigger suggestions" label across all 8 locales
