### PR TITLE
feat(registry): add Cloudflare D1 plugin v0.1.0

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -274,6 +274,24 @@
           }
         }
       ]
+    },
+    {
+      "id": "cloudflare-d1",
+      "name": "Cloudflare D1",
+      "description": "Browse and manage Cloudflare D1 serverless SQLite databases from Tabularis.",
+      "author": "josejorge <https://github.com/josejorge>",
+      "homepage": "https://github.com/josejorge/tabularis_cloudflare_d1_plugin",
+      "latest_version": "0.1.0",
+      "releases": [
+        {
+          "version": "0.1.0",
+          "min_tabularis_version": "0.8.15",
+          "assets": {
+            "linux-x64": "https://github.com/josejorge/tabularis_cloudflare_d1_plugin/releases/download/v0.1.0/cloudflare-d1-linux-x64-0.1.0.zip",
+            "win-x64": "https://github.com/josejorge/tabularis_cloudflare_d1_plugin/releases/download/v0.1.0/cloudflare-d1-win-x64-0.1.0.zip"
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
josejorge/tabularis_cloudflare_d1_plugin — D1 serverless SQLite driver. linux-x64 + win-x64 assets (no macOS build in the v0.1.0 release).