### PR TITLE
Enh/nested groups slash create

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3379,23 +3379,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework 3.7.0",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5895,10 +5878,10 @@ dependencies = [
  "indexmap 2.13.0",
  "log",
  "memchr",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -5909,6 +5892,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -7780,6 +7764,24 @@ name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 tauri = { version = "2.10.2", features = ["protocol-asset", "devtools"] }
 tauri-plugin-log = "2"
-sqlx = { version = "0.8.6", features = ["runtime-tokio", "sqlite", "mysql", "postgres", "tls-native-tls", "chrono", "uuid", "rust_decimal", "json"] }
+sqlx = { version = "0.8.6", features = ["runtime-tokio", "sqlite", "mysql", "postgres", "tls-rustls", "chrono", "uuid", "rust_decimal", "json"] }
 tokio = { version = "1.49.0", features = ["full"] }
 openssl = { version = "0.10", features = ["vendored"] }
 uuid = { version = "1.20.0", features = ["v4", "serde"] }
@@ -59,10 +59,16 @@ zip = "4.2.0"
 tauri-plugin-clipboard-manager = "2"
 tokio-postgres = { version = "0.7.13", features = ["with-chrono-0_4", "with-uuid-1", "with-serde_json-1", "array-impls"] }
 deadpool-postgres = "0.14.1"
-# rustls is used for the PostgreSQL deadpool TLS path. native-tls (used by
-# sqlx and the MySQL pool) trips macOS Secure Transport's strict EKU checks
-# on user-supplied root anchors (e.g. the AWS RDS bundle), so the Postgres
-# pool routes through rustls + the platform verifier instead.
+# sqlx uses `tls-rustls` for both the MySQL pool and the SQLite/embedded
+# paths. `tls-native-tls` is intentionally NOT enabled: macOS Secure
+# Transport (the native-tls backend on Darwin) trips strict EKU checks on
+# user-supplied root anchors (e.g. the AWS RDS regional CA bundle), so
+# MySQL connections that go through native-tls fail the TLS handshake
+# with the opaque error "One or more parameters passed to a function
+# were not valid." even though the same bundle validates fine with
+# `openssl s_client` and `mysql --ssl-mode=VERIFY_IDENTITY`. rustls has
+# no such restriction. The PostgreSQL deadpool path uses rustls + the
+# platform verifier for the same reason.
 tokio-postgres-rustls = "0.13"
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
 rustls-pemfile = "2"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -411,7 +411,18 @@ pub fn find_connection_by_id<R: Runtime>(
     // Load passwords from keychain if needed, via the in-memory cache.
     // On a warm cache hit this is a HashMap lookup (nanoseconds); on a cold miss
     // it calls keychain once and caches the result for all subsequent reads.
-    if conn.params.save_in_keychain.unwrap_or(false) {
+    //
+    // AWS RDS IAM auth tokens are short-lived (15 min) and must come from the
+    // `password` field on every connect, never from the keychain. If a stale
+    // token is sitting in the keychain (e.g. saved by an older release) and
+    // the user opens the edit modal, we don't want to surface that token in
+    // the password field — the user would believe it's fresh and the next
+    // connect would fail with "Access denied". Force the password to `None`
+    // for IAM-auth connections so the modal renders an empty password field
+    // and prompts the user to paste a fresh token.
+    if conn.params.save_in_keychain.unwrap_or(false)
+        && !conn.params.use_iam_auth.unwrap_or(false)
+    {
         let cache = app.state::<std::sync::Arc<crate::credential_cache::CredentialCache>>();
         match credential_cache::get_db_password_cached(&cache, &conn.id) {
             Ok(pwd) => conn.params.password = Some(pwd),
@@ -844,8 +855,13 @@ pub async fn duplicate_connection<R: Runtime>(
 
     let cache = app.state::<std::sync::Arc<crate::credential_cache::CredentialCache>>();
 
-    // Recover passwords if in keychain (via cache for fast repeat access)
-    if original.params.save_in_keychain.unwrap_or(false) {
+    // Recover passwords if in keychain (via cache for fast repeat access).
+    // Same IAM-auth guard as `find_connection_by_id`: never copy a stale RDS
+    // auth token into a duplicated connection — the duplicate would be
+    // broken from the moment it's created.
+    if original.params.save_in_keychain.unwrap_or(false)
+        && !original.params.use_iam_auth.unwrap_or(false)
+    {
         if let Ok(pwd) = credential_cache::get_db_password_cached(&cache, &original.id) {
             original.params.password = Some(pwd);
         }
@@ -1718,7 +1734,32 @@ pub async fn test_connection<R: Runtime>(
     let mut expanded_params = expand_ssh_connection_params(&app, &request.params).await?;
     expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
 
-    if request.params.password.is_none() && expanded_params.password.is_none() {
+    // AWS RDS IAM auth tokens are short-lived (15 min) and must come from the
+    // password field on every test/connect, never from the keychain. Skip the
+    // keychain fallback so a stale token can't be reused.
+    let iam_auth = expanded_params.use_iam_auth.unwrap_or(false);
+
+    // Fail-fast with an actionable message if IAM is enabled but no token
+    // was supplied. Without this guard, `build_mysql_options` produces a
+    // connect-options struct with an empty password (the `connection_id.is_some()`
+    // branch in `build_mysql_options` deliberately allows that for caller-side
+    // injection), the server replies with the opaque "1045 Access denied
+    // for user '...' (using password: YES)", and the user has no idea whether
+    // the token is wrong, expired, or simply missing. The error below tells
+    // them exactly what to do.
+    if iam_auth
+        && request.params.password.as_deref().unwrap_or("").is_empty()
+        && expanded_params.password.as_deref().unwrap_or("").is_empty()
+    {
+        return Err(
+            "AWS IAM authentication is enabled but the password field is empty. \
+             Paste the output of `aws rds generate-db-auth-token` into the \
+             password field and try again. Tokens expire every 15 minutes."
+                .to_string(),
+        );
+    }
+
+    if !iam_auth && request.params.password.is_none() && expanded_params.password.is_none() {
         let saved_conn = match &request.connection_id {
             Some(id) => find_connection_by_id(&app, id).ok(),
             None => None,
@@ -1753,7 +1794,13 @@ pub async fn test_connection<R: Runtime>(
         }
     }
 
-    drv.test_connection(&resolved_params).await?;
+    drv.test_connection(&resolved_params).await.map_err(|e| {
+        log::warn!(
+            "Connection test failed for database {}: {e}",
+            request.params.database
+        );
+        e
+    })?;
 
     log::info!(
         "Connection test successful for database: {}",
@@ -2587,7 +2634,29 @@ pub async fn list_databases<R: Runtime>(
     let mut expanded_params = expand_ssh_connection_params(&app, &request.params).await?;
     expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
 
-    if request.params.password.is_none() && expanded_params.password.is_none() {
+    // AWS RDS IAM auth tokens are short-lived (15 min) and must come from the
+    // password field on every test/connect, never from the keychain. Skip the
+    // keychain fallback so a stale token can't be reused.
+    let iam_auth = expanded_params.use_iam_auth.unwrap_or(false);
+
+    // Fail-fast with an actionable message if IAM is enabled but no token
+    // was supplied. Without this guard, the list_databases call would try
+    // to build a pool with an empty password and the server would reply
+    // with the opaque "1045 Access denied" — confusing for the user. The
+    // error below tells them exactly what to do.
+    if iam_auth
+        && request.params.password.as_deref().unwrap_or("").is_empty()
+        && expanded_params.password.as_deref().unwrap_or("").is_empty()
+    {
+        return Err(
+            "AWS IAM authentication is enabled but the password field is empty. \
+             Paste the output of `aws rds generate-db-auth-token` into the \
+             password field and try again. Tokens expire every 15 minutes."
+                .to_string(),
+        );
+    }
+
+    if !iam_auth && request.params.password.is_none() && expanded_params.password.is_none() {
         let saved_conn = match &request.connection_id {
             Some(id) => find_connection_by_id(&app, id).ok(),
             None => None,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4084,18 +4084,12 @@ pub async fn create_connection_group<R: Runtime>(
     let path = get_config_path(&app)?;
     let mut file = persistence::load_connections_file(&path).unwrap_or_default();
 
-    // Validate parent_id up-front: it must point to an existing group.
-    // Cycle detection isn't needed here because the new group has no
-    // descendants yet, but we still reject a parent_id that doesn't exist
-    // to keep the data consistent.
     if let Some(pid) = &parent_id {
         if !file.groups.iter().any(|g| &g.id == pid) {
             return Err(format!("Parent group with ID {} not found", pid));
         }
     }
 
-    // sort_order is per-parent: a new sibling is appended at the end of its
-    // sibling chain, even if there are groups elsewhere in the tree.
     let max_order = file
         .groups
         .iter()
@@ -4150,15 +4144,8 @@ pub async fn update_connection_group<R: Runtime>(
 
     Ok(updated)
 }
-
-/// Re-parent a group. The `parent_id` semantics match the rest of the
-/// connection-group API: pass `Some(group_id)` to make the group a child
-/// of that group, or `None` to make it a top-level root.
-///
-/// Cycles are rejected (a group cannot become its own ancestor) and the
-/// walk is bounded to fail-safe against pre-existing corruption in
-/// `connections.json`. See `reject_if_would_create_cycle` for the exact
-/// traversal rules.
+/// Re-parent a group. Pass `Some(id)` to make it a child of that group,
+/// or `None` to make it a top-level root. Cycles are rejected.
 #[tauri::command]
 pub async fn move_group_to_parent<R: Runtime>(
     app: AppHandle<R>,
@@ -4195,13 +4182,9 @@ pub async fn move_group_to_parent<R: Runtime>(
     Ok(updated)
 }
 
-/// Walk up the parent chain of `group_id` (the group being re-parented).
-/// If we encounter `new_parent_id`, the proposed change would create a
-/// cycle — `group_id` is already an ancestor of `new_parent_id`, so
-/// making `group_id` a child of `new_parent_id` would close the loop.
-///
-/// The walk is bounded by `groups.len()` to fail-safe against corrupted
-/// `connections.json` files where the data already contains a cycle.
+/// Reject re-parenting that would create a cycle: `target` must not be a
+/// descendant of `group_id`. Walks up from `target` looking for `group_id`.
+/// Bounded by `groups.len()` to fail-safe against pre-existing data cycles.
 pub(crate) fn reject_if_would_create_cycle(
     groups: &[ConnectionGroup],
     group_id: &str,
@@ -4210,12 +4193,6 @@ pub(crate) fn reject_if_would_create_cycle(
     let Some(target) = new_parent_id else {
         return Ok(());
     };
-    // The re-parenting `group_id → target` creates a cycle iff `target` is
-    // currently a descendant of `group_id`. We answer that by walking from
-    // `target` up the parent chain and checking whether we reach `group_id`.
-    // The trivial case `target == group_id` is also caught (a group cannot
-    // be its own parent); the command caller already guards it, but checking
-    // here keeps the helper self-contained.
     let mut current = Some(target.to_string());
     let mut visited = std::collections::HashSet::new();
     let max_steps = groups.len() + 1;
@@ -4229,9 +4206,6 @@ pub(crate) fn reject_if_would_create_cycle(
             }
             Some(node) => {
                 if !visited.insert(node.clone()) {
-                    // Pre-existing cycle in the data: bail out to avoid an
-                    // infinite loop. The user can hand-edit the file to
-                    // break the loop; the next save will write a sane graph.
                     return Err(
                         "Connection-group tree contains a pre-existing cycle; refusing to modify it"
                             .to_string(),
@@ -4267,23 +4241,18 @@ pub async fn delete_connection_group<R: Runtime>(
         .map(|g| g.parent_id.clone())
         .ok_or_else(|| format!("Group with ID {} not found", id))?;
 
-    // Re-parent direct children of the deleted group to the deleted group's
-    // parent. We only touch direct children — grand-children keep their
-    // existing parent (which is now a sibling of the deleted group).
     for g in &mut file.groups {
         if g.parent_id.as_ref() == Some(&id) {
             g.parent_id = deleted_parent.clone();
         }
     }
 
-    // Remove connections from the group (set group_id to None)
     for conn in &mut file.connections {
         if conn.group_id.as_ref() == Some(&id) {
             conn.group_id = None;
         }
     }
 
-    // Remove the group
     file.groups.retain(|g| g.id != id);
     save_connections_and_invalidate(&app, &path, &file)?;
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4163,6 +4163,89 @@ pub async fn create_connection_group<R: Runtime>(
     Ok(group)
 }
 
+/// Splits a `/`-separated group path into trimmed, non-empty segments.
+/// Returns an error if the result is empty.
+pub(crate) fn parse_group_path(path: &str) -> Result<Vec<String>, String> {
+    let segments: Vec<String> = path
+        .split('/')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    if segments.is_empty() {
+        return Err("Group path cannot be empty".to_string());
+    }
+    Ok(segments)
+}
+
+/// Finds an existing group by case-insensitive name match within a parent's
+/// children, or `None` if no such group exists.
+pub(crate) fn find_child_group<'a>(
+    groups: &'a [ConnectionGroup],
+    name: &str,
+    parent_id: &Option<String>,
+) -> Option<&'a ConnectionGroup> {
+    let name_lower = name.to_lowercase();
+    groups
+        .iter()
+        .find(|g| g.name.to_lowercase() == name_lower && g.parent_id == *parent_id)
+}
+
+/// Creates a nested group hierarchy from a `/`-separated path.
+///
+/// Each segment of `path` becomes one group. Existing segments are reused
+/// (looked up case-insensitively among the children of the current parent);
+/// missing segments are created in order. The final segment is returned.
+/// The hierarchy is created atomically: either every missing segment is
+/// persisted or none are.
+#[tauri::command]
+pub async fn create_group_path<R: Runtime>(
+    app: AppHandle<R>,
+    path: String,
+    parent_id: Option<String>,
+) -> Result<ConnectionGroup, String> {
+    let path_cfg = get_config_path(&app)?;
+    let mut file = persistence::load_connections_file(&path_cfg).unwrap_or_default();
+
+    if let Some(pid) = &parent_id {
+        if !file.groups.iter().any(|g| &g.id == pid) {
+            return Err(format!("Parent group with ID {} not found", pid));
+        }
+    }
+
+    let segments = parse_group_path(&path)?;
+    let mut current_parent = parent_id;
+    let mut last_created: Option<ConnectionGroup> = None;
+
+    for seg in segments {
+        if let Some(g) = find_child_group(&file.groups, &seg, &current_parent).cloned() {
+            current_parent = Some(g.id.clone());
+            last_created = Some(g);
+            continue;
+        }
+        let max_order = file
+            .groups
+            .iter()
+            .filter(|g| g.parent_id == current_parent)
+            .map(|g| g.sort_order)
+            .max()
+            .unwrap_or(-1);
+        let new_group = ConnectionGroup {
+            id: Uuid::new_v4().to_string(),
+            name: seg,
+            collapsed: false,
+            sort_order: max_order + 1,
+            parent_id: current_parent.clone(),
+        };
+        current_parent = Some(new_group.id.clone());
+        last_created = Some(new_group.clone());
+        file.groups.push(new_group);
+    }
+
+    save_connections_and_invalidate(&app, &path_cfg, &file)?;
+
+    last_created.ok_or_else(|| "Group path resolved to an empty hierarchy".to_string())
+}
+
 #[tauri::command]
 pub async fn update_connection_group<R: Runtime>(
     app: AppHandle<R>,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4079,18 +4079,37 @@ pub async fn get_connections_with_groups<R: Runtime>(
 pub async fn create_connection_group<R: Runtime>(
     app: AppHandle<R>,
     name: String,
+    parent_id: Option<String>,
 ) -> Result<ConnectionGroup, String> {
     let path = get_config_path(&app)?;
     let mut file = persistence::load_connections_file(&path).unwrap_or_default();
 
-    // Calculate next sort_order
-    let max_order = file.groups.iter().map(|g| g.sort_order).max().unwrap_or(-1);
+    // Validate parent_id up-front: it must point to an existing group.
+    // Cycle detection isn't needed here because the new group has no
+    // descendants yet, but we still reject a parent_id that doesn't exist
+    // to keep the data consistent.
+    if let Some(pid) = &parent_id {
+        if !file.groups.iter().any(|g| &g.id == pid) {
+            return Err(format!("Parent group with ID {} not found", pid));
+        }
+    }
+
+    // sort_order is per-parent: a new sibling is appended at the end of its
+    // sibling chain, even if there are groups elsewhere in the tree.
+    let max_order = file
+        .groups
+        .iter()
+        .filter(|g| g.parent_id == parent_id)
+        .map(|g| g.sort_order)
+        .max()
+        .unwrap_or(-1);
 
     let group = ConnectionGroup {
         id: Uuid::new_v4().to_string(),
         name,
         collapsed: false,
         sort_order: max_order + 1,
+        parent_id,
     };
 
     file.groups.push(group.clone());
@@ -4132,6 +4151,103 @@ pub async fn update_connection_group<R: Runtime>(
     Ok(updated)
 }
 
+/// Re-parent a group. The `parent_id` semantics match the rest of the
+/// connection-group API: pass `Some(group_id)` to make the group a child
+/// of that group, or `None` to make it a top-level root.
+///
+/// Cycles are rejected (a group cannot become its own ancestor) and the
+/// walk is bounded to fail-safe against pre-existing corruption in
+/// `connections.json`. See `reject_if_would_create_cycle` for the exact
+/// traversal rules.
+#[tauri::command]
+pub async fn move_group_to_parent<R: Runtime>(
+    app: AppHandle<R>,
+    id: String,
+    parent_id: Option<String>,
+) -> Result<ConnectionGroup, String> {
+    let path = get_config_path(&app)?;
+    let mut file = persistence::load_connections_file(&path)?;
+
+    if !file.groups.iter().any(|g| g.id == id) {
+        return Err(format!("Group with ID {} not found", id));
+    }
+
+    if let Some(pid) = &parent_id {
+        if pid == &id {
+            return Err("A group cannot be its own parent".to_string());
+        }
+        if !file.groups.iter().any(|g| &g.id == pid) {
+            return Err(format!("Parent group with ID {} not found", pid));
+        }
+    }
+
+    reject_if_would_create_cycle(&file.groups, &id, parent_id.as_deref())?;
+
+    let group = file
+        .groups
+        .iter_mut()
+        .find(|g| g.id == id)
+        .expect("group existence checked above");
+    group.parent_id = parent_id;
+    let updated = group.clone();
+
+    save_connections_and_invalidate(&app, &path, &file)?;
+    Ok(updated)
+}
+
+/// Walk up the parent chain of `group_id` (the group being re-parented).
+/// If we encounter `new_parent_id`, the proposed change would create a
+/// cycle — `group_id` is already an ancestor of `new_parent_id`, so
+/// making `group_id` a child of `new_parent_id` would close the loop.
+///
+/// The walk is bounded by `groups.len()` to fail-safe against corrupted
+/// `connections.json` files where the data already contains a cycle.
+pub(crate) fn reject_if_would_create_cycle(
+    groups: &[ConnectionGroup],
+    group_id: &str,
+    new_parent_id: Option<&str>,
+) -> Result<(), String> {
+    let Some(target) = new_parent_id else {
+        return Ok(());
+    };
+    // The re-parenting `group_id → target` creates a cycle iff `target` is
+    // currently a descendant of `group_id`. We answer that by walking from
+    // `target` up the parent chain and checking whether we reach `group_id`.
+    // The trivial case `target == group_id` is also caught (a group cannot
+    // be its own parent); the command caller already guards it, but checking
+    // here keeps the helper self-contained.
+    let mut current = Some(target.to_string());
+    let mut visited = std::collections::HashSet::new();
+    let max_steps = groups.len() + 1;
+    for _ in 0..max_steps {
+        match current {
+            Some(node) if node == group_id => {
+                return Err(
+                    "Cannot move a group into one of its own descendants (would create a cycle)"
+                        .to_string(),
+                );
+            }
+            Some(node) => {
+                if !visited.insert(node.clone()) {
+                    // Pre-existing cycle in the data: bail out to avoid an
+                    // infinite loop. The user can hand-edit the file to
+                    // break the loop; the next save will write a sane graph.
+                    return Err(
+                        "Connection-group tree contains a pre-existing cycle; refusing to modify it"
+                            .to_string(),
+                    );
+                }
+                current = groups
+                    .iter()
+                    .find(|g| g.id == node)
+                    .and_then(|g| g.parent_id.clone());
+            }
+            None => return Ok(()),
+        }
+    }
+    Err("Connection-group tree is deeper than the number of groups; refusing to modify it".to_string())
+}
+
 #[tauri::command]
 pub async fn delete_connection_group<R: Runtime>(
     app: AppHandle<R>,
@@ -4139,6 +4255,26 @@ pub async fn delete_connection_group<R: Runtime>(
 ) -> Result<(), String> {
     let path = get_config_path(&app)?;
     let mut file = persistence::load_connections_file(&path)?;
+
+    // Capture the deleted group's parent up-front so we can re-parent any
+    // direct child groups to the deleted group's parent. This is the standard
+    // "promote children to grandparent" behaviour from file-explorer UIs and
+    // matches what users expect when deleting a folder in Finder/Explorer.
+    let deleted_parent = file
+        .groups
+        .iter()
+        .find(|g| g.id == id)
+        .map(|g| g.parent_id.clone())
+        .ok_or_else(|| format!("Group with ID {} not found", id))?;
+
+    // Re-parent direct children of the deleted group to the deleted group's
+    // parent. We only touch direct children — grand-children keep their
+    // existing parent (which is now a sibling of the deleted group).
+    for g in &mut file.groups {
+        if g.parent_id.as_ref() == Some(&id) {
+            g.parent_id = deleted_parent.clone();
+        }
+    }
 
     // Remove connections from the group (set group_id to None)
     for conn in &mut file.connections {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -408,18 +408,10 @@ pub fn find_connection_by_id<R: Runtime>(
         }
     };
 
-    // Load passwords from keychain if needed, via the in-memory cache.
-    // On a warm cache hit this is a HashMap lookup (nanoseconds); on a cold miss
-    // it calls keychain once and caches the result for all subsequent reads.
-    //
-    // AWS RDS IAM auth tokens are short-lived (15 min) and must come from the
-    // `password` field on every connect, never from the keychain. If a stale
-    // token is sitting in the keychain (e.g. saved by an older release) and
-    // the user opens the edit modal, we don't want to surface that token in
-    // the password field — the user would believe it's fresh and the next
-    // connect would fail with "Access denied". Force the password to `None`
-    // for IAM-auth connections so the modal renders an empty password field
-    // and prompts the user to paste a fresh token.
+    // Load passwords from keychain via the in-memory cache (warm hit = lookup,
+    // cold miss = keychain call + cache). Skip IAM-auth connections: their
+    // 15-min tokens must come from the `password` field, never the keychain,
+    // so a stale token from an older release can't be surfaced in the modal.
     if conn.params.save_in_keychain.unwrap_or(false)
         && !conn.params.use_iam_auth.unwrap_or(false)
     {
@@ -855,10 +847,8 @@ pub async fn duplicate_connection<R: Runtime>(
 
     let cache = app.state::<std::sync::Arc<crate::credential_cache::CredentialCache>>();
 
-    // Recover passwords if in keychain (via cache for fast repeat access).
     // Same IAM-auth guard as `find_connection_by_id`: never copy a stale RDS
-    // auth token into a duplicated connection — the duplicate would be
-    // broken from the moment it's created.
+    // auth token into a duplicated connection.
     if original.params.save_in_keychain.unwrap_or(false)
         && !original.params.use_iam_auth.unwrap_or(false)
     {
@@ -1739,14 +1729,11 @@ pub async fn test_connection<R: Runtime>(
     // keychain fallback so a stale token can't be reused.
     let iam_auth = expanded_params.use_iam_auth.unwrap_or(false);
 
-    // Fail-fast with an actionable message if IAM is enabled but no token
-    // was supplied. Without this guard, `build_mysql_options` produces a
-    // connect-options struct with an empty password (the `connection_id.is_some()`
-    // branch in `build_mysql_options` deliberately allows that for caller-side
-    // injection), the server replies with the opaque "1045 Access denied
-    // for user '...' (using password: YES)", and the user has no idea whether
-    // the token is wrong, expired, or simply missing. The error below tells
-    // them exactly what to do.
+    // IAM auth needs an RDS auth token right now. Without this guard the
+    // builder accepts an empty password (saved connections inject later),
+    // the server replies with the opaque "Access denied (using password:
+    // YES)", and the user can't tell whether the token is missing, wrong,
+    // or expired.
     if iam_auth
         && request.params.password.as_deref().unwrap_or("").is_empty()
         && expanded_params.password.as_deref().unwrap_or("").is_empty()
@@ -2634,16 +2621,11 @@ pub async fn list_databases<R: Runtime>(
     let mut expanded_params = expand_ssh_connection_params(&app, &request.params).await?;
     expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
 
-    // AWS RDS IAM auth tokens are short-lived (15 min) and must come from the
-    // password field on every test/connect, never from the keychain. Skip the
-    // keychain fallback so a stale token can't be reused.
     let iam_auth = expanded_params.use_iam_auth.unwrap_or(false);
 
-    // Fail-fast with an actionable message if IAM is enabled but no token
-    // was supplied. Without this guard, the list_databases call would try
-    // to build a pool with an empty password and the server would reply
-    // with the opaque "1045 Access denied" — confusing for the user. The
-    // error below tells them exactly what to do.
+    // IAM auth needs an RDS auth token right now; skip the keychain fallback
+    // so a stale token can't be reused, and fail fast with an actionable
+    // message if none was supplied.
     if iam_auth
         && request.params.password.as_deref().unwrap_or("").is_empty()
         && expanded_params.password.as_deref().unwrap_or("").is_empty()

--- a/src-tauri/src/drivers/mysql/mod.rs
+++ b/src-tauri/src/drivers/mysql/mod.rs
@@ -1351,6 +1351,28 @@ impl DatabaseDriver for MysqlDriver {
             .map_err(|e| e.to_string())
     }
 
+    /// Tests connectivity by acquiring a connection from the shared pool.
+    ///
+    /// The trait default builds a fresh `AnyConnection` from
+    /// `build_connection_url`, which constructs the connection options
+    /// straight from a URL — that path cannot opt in to
+    /// `enable_cleartext_plugin(true)` (the switch AWS RDS IAM
+    /// authentication needs to negotiate `mysql_clear_password` with the
+    /// server). Pool connections go through `build_mysql_options` and
+    /// therefore carry the right flags. Routing the test through the pool
+    /// is the only way to get the same configuration as a real session.
+    async fn test_connection(
+        &self,
+        params: &crate::models::ConnectionParams,
+    ) -> Result<(), String> {
+        let conn_id = params.connection_id.as_deref();
+        let pool = crate::pool_manager::get_mysql_pool_with_id(params, conn_id).await?;
+        let mut conn = pool.acquire().await.map_err(|e| e.to_string())?;
+        sqlx::Connection::ping(&mut *conn)
+            .await
+            .map_err(|e| e.to_string())
+    }
+
     async fn get_databases(
         &self,
         params: &crate::models::ConnectionParams,

--- a/src-tauri/src/drivers/mysql/mod.rs
+++ b/src-tauri/src/drivers/mysql/mod.rs
@@ -1351,16 +1351,9 @@ impl DatabaseDriver for MysqlDriver {
             .map_err(|e| e.to_string())
     }
 
-    /// Tests connectivity by acquiring a connection from the shared pool.
-    ///
-    /// The trait default builds a fresh `AnyConnection` from
-    /// `build_connection_url`, which constructs the connection options
-    /// straight from a URL — that path cannot opt in to
-    /// `enable_cleartext_plugin(true)` (the switch AWS RDS IAM
-    /// authentication needs to negotiate `mysql_clear_password` with the
-    /// server). Pool connections go through `build_mysql_options` and
-    /// therefore carry the right flags. Routing the test through the pool
-    /// is the only way to get the same configuration as a real session.
+    /// Tests connectivity via the shared pool. The trait default builds a
+    /// fresh `AnyConnection` from a URL, which can't opt in to
+    /// `enable_cleartext_plugin` — required for RDS IAM auth.
     async fn test_connection(
         &self,
         params: &crate::models::ConnectionParams,

--- a/src-tauri/src/export_import_tests.rs
+++ b/src-tauri/src/export_import_tests.rs
@@ -11,6 +11,7 @@ mod tests {
                 name: "Test Group".to_string(),
                 collapsed: false,
                 sort_order: 0,
+                parent_id: None,
             }],
             connections: vec![SavedConnection {
                 id: "conn1".to_string(),

--- a/src-tauri/src/group_tree_tests.rs
+++ b/src-tauri/src/group_tree_tests.rs
@@ -1,12 +1,12 @@
 //! Unit tests for the nested connection-group tree helpers in `commands.rs`.
 //!
-//! Covers the cycle detector that gates re-parenting. Pure function over a
-//! slice of `ConnectionGroup`s, so it doesn't need any Tauri runtime or
-//! filesystem.
+//! Covers the cycle detector and the `/`-separated path parser/lookup used
+//! by `create_group_path`. Pure functions, so they don't need any Tauri
+//! runtime or filesystem.
 
 #[cfg(test)]
 mod tests {
-    use crate::commands::reject_if_would_create_cycle;
+    use crate::commands::{find_child_group, parse_group_path, reject_if_would_create_cycle};
     use crate::models::ConnectionGroup;
 
     fn g(id: &str, parent: Option<&str>) -> ConnectionGroup {
@@ -73,5 +73,58 @@ mod tests {
     fn cycle_check_target_not_in_tree_is_ok() {
         let groups = vec![g("a", None), g("b", Some("a"))];
         assert!(reject_if_would_create_cycle(&groups, "b", Some("a")).is_ok());
+    }
+
+    #[test]
+    fn parse_group_path_splits_on_slash() {
+        assert_eq!(
+            parse_group_path("a/b/c").unwrap(),
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
+    }
+
+    #[test]
+    fn parse_group_path_trims_whitespace_and_skips_empty() {
+        assert_eq!(
+            parse_group_path("  a /  /  b  / ").unwrap(),
+            vec!["a".to_string(), "b".to_string()]
+        );
+    }
+
+    #[test]
+    fn parse_group_path_rejects_empty_string() {
+        assert!(parse_group_path("").is_err());
+        assert!(parse_group_path("   /  /  ").is_err());
+    }
+
+    #[test]
+    fn parse_group_path_keeps_single_segment() {
+        assert_eq!(parse_group_path("lone").unwrap(), vec!["lone".to_string()]);
+    }
+
+    #[test]
+    fn find_child_group_is_case_insensitive() {
+        // The `g` helper uses the id as the name, so "Production" here
+        // and a search for "production" should still match.
+        let groups = vec![g("Production", None)];
+        let found = find_child_group(&groups, "production", &None);
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().id, "Production");
+    }
+
+    #[test]
+    fn find_child_group_scopes_to_parent() {
+        // Two groups named the same, but with different parents.
+        let groups = vec![
+            g("alpha", Some("parent-1")),
+            g("alpha", Some("parent-2")),
+        ];
+        // Only the one under "parent-1" is found.
+        let found = find_child_group(&groups, "alpha", &Some("parent-1".to_string()));
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().id, "alpha");
+        // Wrong parent yields None.
+        let missing = find_child_group(&groups, "alpha", &None);
+        assert!(missing.is_none());
     }
 }

--- a/src-tauri/src/group_tree_tests.rs
+++ b/src-tauri/src/group_tree_tests.rs
@@ -1,0 +1,97 @@
+//! Unit tests for the nested connection-group tree helpers in `commands.rs`.
+//!
+//! These tests cover the cycle detector that gates `update_connection_group`
+//! re-parenting. The cycle detector is a pure function over a slice of
+//! `ConnectionGroup`s, so it doesn't need any Tauri runtime or filesystem.
+
+#[cfg(test)]
+mod tests {
+    use crate::commands::reject_if_would_create_cycle;
+    use crate::models::ConnectionGroup;
+
+    fn g(id: &str, parent: Option<&str>) -> ConnectionGroup {
+        ConnectionGroup {
+            id: id.to_string(),
+            name: id.to_string(),
+            collapsed: false,
+            sort_order: 0,
+            parent_id: parent.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn cycle_check_none_parent_is_always_ok() {
+        // Moving a group to the top level (parent_id = None) is always fine.
+        let groups = vec![g("a", None), g("b", Some("a")), g("c", Some("b"))];
+        assert!(reject_if_would_create_cycle(&groups, "c", None).is_ok());
+    }
+
+    #[test]
+    fn cycle_check_same_id_is_rejected() {
+        // Should be caught by the explicit id check before this helper runs,
+        // but the helper is the last line of defence.
+        let groups = vec![g("a", None)];
+        let err = reject_if_would_create_cycle(&groups, "a", Some("a")).unwrap_err();
+        assert!(err.to_lowercase().contains("cycle"));
+    }
+
+    #[test]
+    fn cycle_check_direct_parent_is_rejected() {
+        // a -> b, trying to make a's parent = b would close the loop
+        // (a is already b's ancestor).
+        let groups = vec![g("a", Some("b")), g("b", None)];
+        let err = reject_if_would_create_cycle(&groups, "b", Some("a")).unwrap_err();
+        assert!(err.to_lowercase().contains("cycle"));
+    }
+
+    #[test]
+    fn cycle_check_deep_descendant_is_rejected() {
+        // Tree: a -> b -> c (c is a deep descendant of a). Trying to make
+        // c's parent = a closes the loop: c -> a -> b -> c.
+        // The walk from `a` reaches `c` after two steps: a -> b -> c.
+        let groups = vec![
+            g("a", Some("b")),
+            g("b", Some("c")),
+            g("c", None),
+        ];
+        let err = reject_if_would_create_cycle(&groups, "c", Some("a")).unwrap_err();
+        assert!(err.to_lowercase().contains("cycle"));
+    }
+
+    #[test]
+    fn cycle_check_unrelated_target_is_ok() {
+        // Two independent trees; moving one root under the other is fine.
+        let groups = vec![
+            g("a1", Some("a")),
+            g("a", None),
+            g("b1", Some("b")),
+            g("b", None),
+        ];
+        assert!(reject_if_would_create_cycle(&groups, "a", Some("b")).is_ok());
+    }
+
+    #[test]
+    fn cycle_check_handles_preexisting_cycle_safely() {
+        // If the data on disk already has a cycle (e.g. hand-edited
+        // connections.json), the helper should NOT spin forever. It
+        // detects the loop via the visited set and returns a clear error.
+        // Asking about a third, unrelated group still resolves cleanly
+        // because the walk doesn't traverse into the cycle.
+        let c = g("c", None);
+        let groups = vec![g("a", Some("b")), g("b", Some("a")), c];
+        let result = reject_if_would_create_cycle(&groups, "c", Some("a"));
+        // The walk from `a` enters the {a,b} cycle and bails out with the
+        // pre-existing-cycle error rather than looping.
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn cycle_check_target_not_in_tree_is_ok() {
+        // The helper assumes parent_id has been validated separately
+        // (i.e. it points to an existing group). The cycle walk still
+        // terminates if the chain ends at a node that exists but isn't the
+        // group being re-parented.
+        let groups = vec![g("a", None), g("b", Some("a"))];
+        assert!(reject_if_would_create_cycle(&groups, "b", Some("a")).is_ok());
+    }
+}

--- a/src-tauri/src/group_tree_tests.rs
+++ b/src-tauri/src/group_tree_tests.rs
@@ -1,8 +1,8 @@
 //! Unit tests for the nested connection-group tree helpers in `commands.rs`.
 //!
-//! These tests cover the cycle detector that gates `update_connection_group`
-//! re-parenting. The cycle detector is a pure function over a slice of
-//! `ConnectionGroup`s, so it doesn't need any Tauri runtime or filesystem.
+//! Covers the cycle detector that gates re-parenting. Pure function over a
+//! slice of `ConnectionGroup`s, so it doesn't need any Tauri runtime or
+//! filesystem.
 
 #[cfg(test)]
 mod tests {
@@ -21,15 +21,12 @@ mod tests {
 
     #[test]
     fn cycle_check_none_parent_is_always_ok() {
-        // Moving a group to the top level (parent_id = None) is always fine.
         let groups = vec![g("a", None), g("b", Some("a")), g("c", Some("b"))];
         assert!(reject_if_would_create_cycle(&groups, "c", None).is_ok());
     }
 
     #[test]
     fn cycle_check_same_id_is_rejected() {
-        // Should be caught by the explicit id check before this helper runs,
-        // but the helper is the last line of defence.
         let groups = vec![g("a", None)];
         let err = reject_if_would_create_cycle(&groups, "a", Some("a")).unwrap_err();
         assert!(err.to_lowercase().contains("cycle"));
@@ -37,8 +34,6 @@ mod tests {
 
     #[test]
     fn cycle_check_direct_parent_is_rejected() {
-        // a -> b, trying to make a's parent = b would close the loop
-        // (a is already b's ancestor).
         let groups = vec![g("a", Some("b")), g("b", None)];
         let err = reject_if_would_create_cycle(&groups, "b", Some("a")).unwrap_err();
         assert!(err.to_lowercase().contains("cycle"));
@@ -46,9 +41,6 @@ mod tests {
 
     #[test]
     fn cycle_check_deep_descendant_is_rejected() {
-        // Tree: a -> b -> c (c is a deep descendant of a). Trying to make
-        // c's parent = a closes the loop: c -> a -> b -> c.
-        // The walk from `a` reaches `c` after two steps: a -> b -> c.
         let groups = vec![
             g("a", Some("b")),
             g("b", Some("c")),
@@ -60,7 +52,6 @@ mod tests {
 
     #[test]
     fn cycle_check_unrelated_target_is_ok() {
-        // Two independent trees; moving one root under the other is fine.
         let groups = vec![
             g("a1", Some("a")),
             g("a", None),
@@ -72,25 +63,14 @@ mod tests {
 
     #[test]
     fn cycle_check_handles_preexisting_cycle_safely() {
-        // If the data on disk already has a cycle (e.g. hand-edited
-        // connections.json), the helper should NOT spin forever. It
-        // detects the loop via the visited set and returns a clear error.
-        // Asking about a third, unrelated group still resolves cleanly
-        // because the walk doesn't traverse into the cycle.
         let c = g("c", None);
         let groups = vec![g("a", Some("b")), g("b", Some("a")), c];
         let result = reject_if_would_create_cycle(&groups, "c", Some("a"));
-        // The walk from `a` enters the {a,b} cycle and bails out with the
-        // pre-existing-cycle error rather than looping.
         assert!(result.is_err());
     }
 
     #[test]
     fn cycle_check_target_not_in_tree_is_ok() {
-        // The helper assumes parent_id has been validated separately
-        // (i.e. it points to an existing group). The cycle walk still
-        // terminates if the chain ends at a node that exists but isn't the
-        // group being re-parented.
         let groups = vec![g("a", None), g("b", Some("a"))];
         assert!(reject_if_would_create_cycle(&groups, "b", Some("a")).is_ok());
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -32,6 +32,8 @@ pub mod export;
 #[cfg(test)]
 pub mod export_import_tests;
 pub mod health_check;
+#[cfg(test)]
+pub mod group_tree_tests;
 pub mod heartbeat;
 #[cfg(test)]
 pub mod heartbeat_tests;
@@ -297,6 +299,7 @@ pub fn run() {
             commands::get_connections_with_groups,
             commands::create_connection_group,
             commands::update_connection_group,
+            commands::move_group_to_parent,
             commands::delete_connection_group,
             commands::move_connection_to_group,
             commands::reorder_groups,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -298,6 +298,7 @@ pub fn run() {
             commands::get_connection_groups,
             commands::get_connections_with_groups,
             commands::create_connection_group,
+            commands::create_group_path,
             commands::update_connection_group,
             commands::move_group_to_parent,
             commands::delete_connection_group,

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -240,15 +240,9 @@ async fn resolve_db_params(
 ) -> Result<(crate::models::SavedConnection, ConnectionParams), JsonRpcError> {
     let mut conn = find_connection(conn_id)?;
 
-    // Load DB password from keychain if it isn't stored inline.
-    //
-    // AWS RDS IAM auth tokens are short-lived (15 min) and MUST come from the
-    // `password` field on every connect, never from the keychain. If the user
-    // previously saved a token to the keychain (e.g. before this guard was
-    // added), reading it back here would silently reuse a stale token and the
-    // server would reject the handshake with "Access denied". Skip the
-    // keychain fallback for IAM-auth connections so the caller is forced to
-    // supply a fresh token.
+    // Load DB password from keychain unless the connection uses IAM auth,
+    // whose 15-min tokens must come from the `password` field on every
+    // connect — never from the keychain, where a stale token would survive.
     let iam_auth = conn.params.use_iam_auth.unwrap_or(false);
     if !iam_auth && conn.params.save_in_keychain.unwrap_or(false) {
         let cache = std::sync::Arc::new(credential_cache::CredentialCache::default());
@@ -273,7 +267,6 @@ async fn resolve_db_params(
             "MCP: connection {} has use_iam_auth=true; ignoring any password stored in the keychain. A fresh RDS auth token must be supplied on every connect.",
             conn_id
         );
-        // Make sure no stale token leaks into the resolved params.
         conn.params.password = None;
     }
 

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -240,8 +240,17 @@ async fn resolve_db_params(
 ) -> Result<(crate::models::SavedConnection, ConnectionParams), JsonRpcError> {
     let mut conn = find_connection(conn_id)?;
 
-    // Load DB password from keychain if it isn't stored inline
-    if conn.params.save_in_keychain.unwrap_or(false) {
+    // Load DB password from keychain if it isn't stored inline.
+    //
+    // AWS RDS IAM auth tokens are short-lived (15 min) and MUST come from the
+    // `password` field on every connect, never from the keychain. If the user
+    // previously saved a token to the keychain (e.g. before this guard was
+    // added), reading it back here would silently reuse a stale token and the
+    // server would reject the handshake with "Access denied". Skip the
+    // keychain fallback for IAM-auth connections so the caller is forced to
+    // supply a fresh token.
+    let iam_auth = conn.params.use_iam_auth.unwrap_or(false);
+    if !iam_auth && conn.params.save_in_keychain.unwrap_or(false) {
         let cache = std::sync::Arc::new(credential_cache::CredentialCache::default());
         let id = conn.id.clone();
         let pwd = tokio::task::spawn_blocking(move || {
@@ -259,6 +268,13 @@ async fn resolve_db_params(
                 conn.params.password = Some(p);
             }
         }
+    } else if iam_auth && conn.params.save_in_keychain.unwrap_or(false) {
+        log::warn!(
+            "MCP: connection {} has use_iam_auth=true; ignoring any password stored in the keychain. A fresh RDS auth token must be supplied on every connect.",
+            conn_id
+        );
+        // Make sure no stale token leaks into the resolved params.
+        conn.params.password = None;
     }
 
     let expanded = expand_ssh_params_for_mcp(&conn.params).await?;

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -125,6 +125,11 @@ pub struct ConnectionParams {
     pub ssl_ca: Option<String>,
     pub ssl_cert: Option<String>,
     pub ssl_key: Option<String>,
+    // AWS RDS IAM authentication: when true, `password` is expected to be a
+    // pre-signed RDS auth token (generate-db-auth-token) instead of a real
+    // user password. Requires TLS. Only meaningful for the `mysql` driver.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub use_iam_auth: Option<bool>,
     // SSH Tunnel
     pub ssh_enabled: Option<bool>,
     pub ssh_connection_id: Option<String>,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -202,6 +202,14 @@ pub struct ConnectionGroup {
     pub collapsed: bool,
     #[serde(default)]
     pub sort_order: i32,
+    /// When `Some(id)`, this group is a child of the group with the given id.
+    /// `None` means the group is a top-level root. Cycles are not allowed:
+    /// the backend rejects any `parent_id` that would make this group (or
+    /// any of its ancestors) appear in its own ancestry chain. The default
+    /// of `None` keeps the field backwards-compatible with `connections.json`
+    /// files written before nested groups were introduced.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -202,12 +202,8 @@ pub struct ConnectionGroup {
     pub collapsed: bool,
     #[serde(default)]
     pub sort_order: i32,
-    /// When `Some(id)`, this group is a child of the group with the given id.
-    /// `None` means the group is a top-level root. Cycles are not allowed:
-    /// the backend rejects any `parent_id` that would make this group (or
-    /// any of its ancestors) appear in its own ancestry chain. The default
-    /// of `None` keeps the field backwards-compatible with `connections.json`
-    /// files written before nested groups were introduced.
+    /// `Some(group_id)` makes this group a child of that group; `None` is a
+    /// top-level root. Cycles are rejected by the backend.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_id: Option<String>,
 }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -125,9 +125,9 @@ pub struct ConnectionParams {
     pub ssl_ca: Option<String>,
     pub ssl_cert: Option<String>,
     pub ssl_key: Option<String>,
-    // AWS RDS IAM authentication: when true, `password` is expected to be a
-    // pre-signed RDS auth token (generate-db-auth-token) instead of a real
-    // user password. Requires TLS. Only meaningful for the `mysql` driver.
+    // When true, `password` is a pre-signed RDS auth token (from
+    // `aws rds generate-db-auth-token`) instead of a real password.
+    // Requires TLS; only meaningful for the `mysql` driver.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub use_iam_auth: Option<bool>,
     // SSH Tunnel

--- a/src-tauri/src/plugins/driver.rs
+++ b/src-tauri/src/plugins/driver.rs
@@ -840,6 +840,7 @@ mod tests {
             k8s_resource_type: None,
             k8s_resource_name: None,
             k8s_port: None,
+            use_iam_auth: None,
             connection_id: Some("conn-1".to_string()),
         }
     }

--- a/src-tauri/src/pool_manager.rs
+++ b/src-tauri/src/pool_manager.rs
@@ -19,8 +19,8 @@ use tokio::sync::RwLock;
 use tokio_postgres::{config::SslMode as PgSslMode, Config as PgConfig};
 use tokio_postgres_rustls::MakeRustlsConnect;
 
-/// `tokio_postgres` renders only the top-level error kind ("error performing
-/// TLS handshake"); the concrete cause lives in the `source()` chain.
+/// Walks `Error::source()` to surface the real cause, which `tokio_postgres`
+/// hides behind a generic "error performing TLS handshake".
 pub(crate) fn format_error_chain<E: std::error::Error + ?Sized>(err: &E) -> String {
     let mut out = err.to_string();
     let mut source = err.source();
@@ -32,7 +32,6 @@ pub(crate) fn format_error_chain<E: std::error::Error + ?Sized>(err: &E) -> Stri
     out
 }
 
-/// rustls 0.23 needs a process-level `CryptoProvider`; install once.
 fn ensure_rustls_crypto_provider() {
     use std::sync::Once;
     static INSTALL: Once = Once::new();
@@ -76,9 +75,9 @@ fn mysql_numeric_setting(key: &str, default: u64) -> u64 {
         .unwrap_or(default)
 }
 
-/// Build a stable connection key that works with SSH tunnels.
-/// If connection_id is provided (from saved connections), use it for stable pooling.
-/// Otherwise fall back to host:port:database (for ad-hoc connections).
+/// Stable pool key: uses `connection_id` when present (saved connections),
+/// else `host:port:database` (ad-hoc). The TLS/iam tuple is appended so
+/// different SSL settings of the same connection get separate pools.
 pub(crate) fn build_connection_key(
     params: &ConnectionParams,
     connection_id: Option<&str>,
@@ -108,10 +107,8 @@ pub(crate) fn build_connection_key(
     };
 
     let base_key = if let Some(conn_id) = connection_id {
-        // Include database in key so different databases on the same connection use separate pools
         format!("{}:conn:{}:{}", params.driver, conn_id, params.database)
     } else {
-        // Fall back to host:port:database for ad-hoc connections
         format!(
             "{}:{}:{}:{}",
             params.driver,
@@ -141,22 +138,11 @@ pub(crate) fn build_mysql_options(
     let database = override_db.unwrap_or_else(|| params.database.primary());
     let timezone = mysql_string_setting("timezone", DEFAULT_MYSQL_TIMEZONE);
 
-    // Configure SSL mode based on params.ssl_mode.
-    //
-    // Auto-escalation: when the user supplies an explicit `ssl_ca` but the
-    // selected mode is `Required` or `Preferred`, sqlx-mysql with
-    // `tls-native-tls` (the default) does not actually pass the CA bundle to
-    // the TLS connector for those modes - it only does so for `VerifyCa` and
-    // `VerifyIdentity`. On macOS this means Secure Transport uses the system
-    // keychain, which does not trust the regional Amazon RDS root CAs, and
-    // the handshake fails with the opaque error
-    // "error occurred while attempting to establish a TLS connection:
-    // One or more parameters passed to a function were not valid." even
-    // though the same bundle validates fine with `openssl s_client`.
-    //
-    // Escalating to `VerifyCa` whenever a CA file is present mirrors the
-    // documented behaviour of `psql`'s `verify-ca` mode: the user has
-    // explicitly opted into a stricter check by supplying a CA file.
+    // ssl_mode: user-selected, with auto-escalation to VerifyCa when an ssl_ca
+    // is supplied under Required/Preferred. sqlx-mysql only forwards the CA
+    // bundle to the TLS connector for VerifyCa/VerifyIdentity, so on macOS the
+    // system keychain handles verification for the weaker modes and rejects
+    // the regional RDS root CAs with an opaque handshake error.
     let has_user_ca = params
         .ssl_ca
         .as_deref()
@@ -175,12 +161,9 @@ pub(crate) fn build_mysql_options(
         ssl_mode = MySqlSslMode::VerifyCa;
     }
 
-    // AWS RDS IAM authentication: when enabled, `password` holds a pre-signed
-    // RDS auth token (from `aws rds generate-db-auth-token`). The token is sent
-    // as a cleartext password over a TLS-required connection, exactly as the
-    // MySQL client would when negotiating the `mysql_clear_password` plugin
-    // against an RDS instance that has IAM auth enabled. Refuse to send it
-    // over an unencrypted link.
+    // AWS RDS IAM auth: `password` carries the pre-signed RDS auth token
+    // (from `aws rds generate-db-auth-token`), sent cleartext via
+    // mysql_clear_password over TLS. Refuse to send it unencrypted.
     if params.use_iam_auth.unwrap_or(false) {
         if matches!(ssl_mode, MySqlSslMode::Disabled) {
             return Err(
@@ -190,10 +173,8 @@ pub(crate) fn build_mysql_options(
                     .to_string(),
             );
         }
-        // For ad-hoc connections we have no way to recover a missing token.
-        // For saved connections (connection_id present) we allow an empty
-        // password here because the caller will inject it from the keychain
-        // *after* this builder returns.
+        // Saved connections get the token injected from the keychain after
+        // this builder returns, so an empty password is fine for them.
         if password.is_empty() && params.connection_id.is_none() {
             return Err(
                 "AWS IAM authentication is enabled but the password field is \
@@ -204,13 +185,6 @@ pub(crate) fn build_mysql_options(
         }
     }
 
-    // One-shot diagnostic so we can confirm what's reaching sqlx from the
-    // app side. Logs the user-visible ssl_mode, the user-supplied CA path,
-    // whether the path was non-empty (drives the auto-escalation), the
-    // final effective ssl_mode, and whether the cleartext plugin is being
-    // requested (only meaningful for IAM auth). All five pieces together
-    // are enough to tell from a single log line whether the connection is
-    // being constructed the way we expect.
     log::info!(
         "build_mysql_options: driver=mysql host={host} port={port} \
          ssl_mode_param={:?} ssl_ca_present={} effective_ssl_mode={:?} \
@@ -230,21 +204,14 @@ pub(crate) fn build_mysql_options(
         .timezone(timezone)
         .ssl_mode(ssl_mode);
 
-    // Skip `.password(...)` when the password is empty. Two cases:
-    //   1. Ad-hoc test connection with an empty password → sqlx will
-    //      attempt a passwordless handshake and the server will reject it,
-    //      which is the correct user-visible error.
-    //   2. Saved connection under IAM auth where the caller will inject the
-    //      RDS auth token from the keychain (or fail-fast) *after* this
-    //      builder returns. We must not stamp a stale token here, and we
-    //      must not stamp an empty string either (sqlx interprets `""` as
-    //      "user pressed Enter" and the server replies with
-    //      "Access denied for user ... (using password: YES)").
+    // Skip `.password(...)` when the password is empty: an empty string is
+    // stamped by sqlx as "user pressed Enter", which the server rejects with
+    // "Access denied (using password: YES)". Saved IAM-auth connections get
+    // the token injected from the keychain after this builder returns.
     if !password.is_empty() {
         options = options.password(password);
     }
 
-    // Apply SSL certificates if provided in params
     if let Some(ca) = &params.ssl_ca {
         options = options.ssl_ca(ca);
     }
@@ -255,11 +222,9 @@ pub(crate) fn build_mysql_options(
         options = options.ssl_client_key(key);
     }
 
-    // AWS RDS IAM authentication: the server announces
-    // `mysql_clear_password` as the auth plugin and rejects the handshake
-    // with "mysql_cleartext_plugin disabled" unless the client opts in.
-    // Enabling it here is safe because the token only ever travels over the
-    // TLS link we configured above.
+    // IAM auth: the server announces `mysql_clear_password` and rejects the
+    // handshake with "mysql_cleartext_plugin disabled" unless the client
+    // opts in. Safe because the token only travels over the TLS link above.
     if params.use_iam_auth.unwrap_or(false) {
         options = options.enable_cleartext_plugin(true);
     }
@@ -303,33 +268,20 @@ pub(crate) fn build_postgres_configurations(params: &ConnectionParams) -> PgConf
 /// Build the rustls connector for the PostgreSQL pool.
 ///
 /// `rustls` (not `native-tls`) because macOS Secure Transport applies a
-/// strict `id-kp-serverAuth` EKU check to user-supplied root anchors, which
-/// rejects valid CA certs with "The extended key usage is not valid".
-///
-/// `ssl_ca` (PEM file or bundle) overrides the platform trust store. This
-/// is the path RDS users take: the macOS keychain does not trust the
-/// regional Amazon RDS root CAs, so they must supply
-/// `https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem`
-/// (or a region-specific bundle) via the connection's CA Certificate field.
-///
-/// We deliberately do NOT vendor the RDS bundle in the repo: AWS rotates
-/// these CAs every 1-3 years, and shipping a stale bundle in a release
-/// silently breaks RDS users until they upgrade. Distributors who want
-/// out-of-the-box RDS support can pull a fresh bundle at packaging time
-/// (e.g. via a Dockerfile `RUN curl ...` or a build script that drops it
-/// into `src-tauri/assets/`) and point users at the resulting path.
+/// strict `id-kp-serverAuth` EKU check to user-supplied root anchors and
+/// rejects valid CA certs. `ssl_ca` overrides the platform trust store —
+/// RDS users point it at the AWS global bundle
+/// (`https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem`).
+/// The bundle is intentionally not vendored: AWS rotates these CAs every
+/// 1-3 years, so distributors pull a fresh copy at packaging time.
 ///
 /// SSL modes:
 /// - `disable`: no TLS
 /// - `allow`/`prefer`: TLS without certificate verification
 /// - `require`: force TLS without certificate verification
-///   NOTE: Prior to v0.10.3, `require` validated the certificate chain.
-///   It now matches libpq behavior (TLS without validation). Users who
-///   need certificate validation should use `verify-ca` or `verify-full`.
-/// - `verify-ca`: force TLS, validate certificate chain, skip hostname check.
-///   Requires an explicit CA file — platform roots are not used to avoid
-///   macOS Secure Transport EKU incompatibilities.
-/// - `verify-full`: force TLS, validate certificate chain and hostname
+///   (prior to v0.10.3 this validated the chain; it now matches libpq).
+/// - `verify-ca`: force TLS, validate chain, skip hostname check
+/// - `verify-full`: force TLS, validate chain and hostname
 pub(crate) fn build_postgres_tls_connector(
     params: &ConnectionParams,
 ) -> Result<MakeRustlsConnect, String> {
@@ -339,8 +291,7 @@ pub(crate) fn build_postgres_tls_connector(
 
     let config = match ssl_mode {
         "disable" | "allow" | "prefer" => {
-            // No certificate verification for these modes.
-            // The PgSslMode setting handles whether TLS is attempted.
+            // No cert verification; PgSslMode below controls whether TLS is attempted.
             let verifier = Arc::new(NoCertVerifier::new());
             ClientConfig::builder()
                 .dangerous()
@@ -348,7 +299,7 @@ pub(crate) fn build_postgres_tls_connector(
                 .with_no_client_auth()
         }
         "require" => {
-            // Force TLS but skip all certificate validation.
+            // Force TLS, skip cert validation.
             let verifier = Arc::new(NoCertVerifier::new());
             ClientConfig::builder()
                 .dangerous()
@@ -356,12 +307,8 @@ pub(crate) fn build_postgres_tls_connector(
                 .with_no_client_auth()
         }
         "verify-ca" => {
-            // Validate certificate chain but skip hostname verification.
-            // Requires an explicit CA file — we deliberately do NOT fall back
-            // to platform roots because macOS Secure Transport applies strict
-            // id-kp-serverAuth EKU checks that reject valid CA certificates
-            // (e.g. the AWS RDS bundle). This matches libpq's behavior where
-            // sslmode=verify-ca expects root certs to be supplied explicitly.
+            // Validate chain, skip hostname. Requires an explicit CA file —
+            // platform roots are not used (macOS EKU check rejects them).
             let ca_path = user_ca.ok_or_else(|| {
                 "verify-ca mode requires an explicit CA file via the connection's \
                 CA Certificate field. On macOS, platform root certificates are \

--- a/src-tauri/src/pool_manager.rs
+++ b/src-tauri/src/pool_manager.rs
@@ -85,11 +85,16 @@ pub(crate) fn build_connection_key(
 ) -> String {
     let tls_key = match params.driver.as_str() {
         "mysql" => Some(format!(
-            "ssl:{}:{}:{}:{}",
+            "ssl:{}:{}:{}:{}:iam:{}",
             params.ssl_mode.as_deref().unwrap_or("default"),
             params.ssl_ca.as_deref().unwrap_or(""),
             params.ssl_cert.as_deref().unwrap_or(""),
-            params.ssl_key.as_deref().unwrap_or("")
+            params.ssl_key.as_deref().unwrap_or(""),
+            if params.use_iam_auth.unwrap_or(false) {
+                "true"
+            } else {
+                "false"
+            }
         )),
         "postgres" => {
             let ssl_mode = params.ssl_mode.as_deref().unwrap_or("prefer");
@@ -136,19 +141,27 @@ pub(crate) fn build_mysql_options(
     let database = override_db.unwrap_or_else(|| params.database.primary());
     let timezone = mysql_string_setting("timezone", DEFAULT_MYSQL_TIMEZONE);
 
-    let mut options = MySqlConnectOptions::new()
-        .host(host)
-        .port(port)
-        .username(username)
-        .database(database)
-        .timezone(timezone);
-
-    if !password.is_empty() {
-        options = options.password(password);
-    }
-
-    // Configure SSL mode based on params.ssl_mode
-    let ssl_mode = match params.ssl_mode.as_deref().unwrap_or("required") {
+    // Configure SSL mode based on params.ssl_mode.
+    //
+    // Auto-escalation: when the user supplies an explicit `ssl_ca` but the
+    // selected mode is `Required` or `Preferred`, sqlx-mysql with
+    // `tls-native-tls` (the default) does not actually pass the CA bundle to
+    // the TLS connector for those modes - it only does so for `VerifyCa` and
+    // `VerifyIdentity`. On macOS this means Secure Transport uses the system
+    // keychain, which does not trust the regional Amazon RDS root CAs, and
+    // the handshake fails with the opaque error
+    // "error occurred while attempting to establish a TLS connection:
+    // One or more parameters passed to a function were not valid." even
+    // though the same bundle validates fine with `openssl s_client`.
+    //
+    // Escalating to `VerifyCa` whenever a CA file is present mirrors the
+    // documented behaviour of `psql`'s `verify-ca` mode: the user has
+    // explicitly opted into a stricter check by supplying a CA file.
+    let has_user_ca = params
+        .ssl_ca
+        .as_deref()
+        .is_some_and(|s| !s.trim().is_empty());
+    let mut ssl_mode = match params.ssl_mode.as_deref().unwrap_or("required") {
         "disabled" | "disable" => MySqlSslMode::Disabled,
         "preferred" | "prefer" => MySqlSslMode::Preferred,
         "required" | "require" => MySqlSslMode::Required,
@@ -156,7 +169,80 @@ pub(crate) fn build_mysql_options(
         "verify_identity" => MySqlSslMode::VerifyIdentity,
         _ => MySqlSslMode::Required,
     };
-    options = options.ssl_mode(ssl_mode);
+    if has_user_ca
+        && matches!(ssl_mode, MySqlSslMode::Required | MySqlSslMode::Preferred)
+    {
+        ssl_mode = MySqlSslMode::VerifyCa;
+    }
+
+    // AWS RDS IAM authentication: when enabled, `password` holds a pre-signed
+    // RDS auth token (from `aws rds generate-db-auth-token`). The token is sent
+    // as a cleartext password over a TLS-required connection, exactly as the
+    // MySQL client would when negotiating the `mysql_clear_password` plugin
+    // against an RDS instance that has IAM auth enabled. Refuse to send it
+    // over an unencrypted link.
+    if params.use_iam_auth.unwrap_or(false) {
+        if matches!(ssl_mode, MySqlSslMode::Disabled) {
+            return Err(
+                "AWS IAM authentication requires a TLS/SSL mode to be enabled \
+                 (Preferred, Required, Verify CA, or Verify Identity). Refusing \
+                 to send the RDS auth token over an unencrypted connection."
+                    .to_string(),
+            );
+        }
+        // For ad-hoc connections we have no way to recover a missing token.
+        // For saved connections (connection_id present) we allow an empty
+        // password here because the caller will inject it from the keychain
+        // *after* this builder returns.
+        if password.is_empty() && params.connection_id.is_none() {
+            return Err(
+                "AWS IAM authentication is enabled but the password field is \
+                 empty. Paste the output of `aws rds generate-db-auth-token` \
+                 into the password field."
+                    .to_string(),
+            );
+        }
+    }
+
+    // One-shot diagnostic so we can confirm what's reaching sqlx from the
+    // app side. Logs the user-visible ssl_mode, the user-supplied CA path,
+    // whether the path was non-empty (drives the auto-escalation), the
+    // final effective ssl_mode, and whether the cleartext plugin is being
+    // requested (only meaningful for IAM auth). All five pieces together
+    // are enough to tell from a single log line whether the connection is
+    // being constructed the way we expect.
+    log::info!(
+        "build_mysql_options: driver=mysql host={host} port={port} \
+         ssl_mode_param={:?} ssl_ca_present={} effective_ssl_mode={:?} \
+         iam_auth={} password_len={}",
+        params.ssl_mode,
+        has_user_ca,
+        ssl_mode,
+        params.use_iam_auth.unwrap_or(false),
+        password.len(),
+    );
+
+    let mut options = MySqlConnectOptions::new()
+        .host(host)
+        .port(port)
+        .username(username)
+        .database(database)
+        .timezone(timezone)
+        .ssl_mode(ssl_mode);
+
+    // Skip `.password(...)` when the password is empty. Two cases:
+    //   1. Ad-hoc test connection with an empty password → sqlx will
+    //      attempt a passwordless handshake and the server will reject it,
+    //      which is the correct user-visible error.
+    //   2. Saved connection under IAM auth where the caller will inject the
+    //      RDS auth token from the keychain (or fail-fast) *after* this
+    //      builder returns. We must not stamp a stale token here, and we
+    //      must not stamp an empty string either (sqlx interprets `""` as
+    //      "user pressed Enter" and the server replies with
+    //      "Access denied for user ... (using password: YES)").
+    if !password.is_empty() {
+        options = options.password(password);
+    }
 
     // Apply SSL certificates if provided in params
     if let Some(ca) = &params.ssl_ca {
@@ -167,6 +253,15 @@ pub(crate) fn build_mysql_options(
     }
     if let Some(key) = &params.ssl_key {
         options = options.ssl_client_key(key);
+    }
+
+    // AWS RDS IAM authentication: the server announces
+    // `mysql_clear_password` as the auth plugin and rejects the handshake
+    // with "mysql_cleartext_plugin disabled" unless the client opts in.
+    // Enabling it here is safe because the token only ever travels over the
+    // TLS link we configured above.
+    if params.use_iam_auth.unwrap_or(false) {
+        options = options.enable_cleartext_plugin(true);
     }
 
     Ok(options)
@@ -520,6 +615,11 @@ async fn get_mysql_pool_for_database_with_id(
         params.host,
         key
     );
+    // sqlx-mysql's rustls backend (selected when sqlx is built with
+    // `tls-rustls` and not `tls-native-tls`) panics on the first handshake
+    // unless a process-level `CryptoProvider` has been installed. We share
+    // the same install-once helper the Postgres deadpool path uses.
+    ensure_rustls_crypto_provider();
     let options = build_mysql_options(params, override_db)?;
     let connect_timeout = Duration::from_millis(mysql_numeric_setting(
         "connectTimeout",

--- a/src-tauri/src/pool_manager_tests.rs
+++ b/src-tauri/src/pool_manager_tests.rs
@@ -182,9 +182,8 @@ mod tests {
 
     #[test]
     fn mysql_options_iam_auth_allows_empty_password_when_connection_id_set() {
-        // For saved connections, the password will be injected from the
-        // keychain after this builder returns, so an empty password here is
-        // not an error.
+        // Saved connections get the password injected from the keychain after
+        // the builder returns, so an empty password here is fine.
         let mut params = mysql_params("required");
         params.use_iam_auth = Some(true);
         params.password = Some(String::new());
@@ -202,17 +201,9 @@ mod tests {
         params.password = Some("fake-rds-token".to_string());
 
         let opts = build_mysql_options(&params, None).expect("must build");
-        // sqlx 0.8.6 doesn't expose a public password getter; assert on the
-        // observable side effects: SSL mode is required, no error returned.
         assert!(matches!(opts.get_ssl_mode(), MySqlSslMode::Required));
-        // The cleartext plugin must be opted in, otherwise the RDS server
-        // rejects IAM auth with "mysql_cleartext_plugin disabled". sqlx 0.8.6
-        // does not expose `enable_cleartext_plugin` as a public getter, but
-        // it IS included in the derived `Debug` output of
-        // `MySqlConnectOptions`, so we can assert on it as a regression
-        // sentinel. If a future refactor drops the
-        // `options.enable_cleartext_plugin(true)` call, this assertion will
-        // start failing and the test will catch it before the change ships.
+        // sqlx 0.8.6 has no public getter for `enable_cleartext_plugin`, so
+        // assert on the `Debug` output as a regression sentinel.
         let debug = format!("{:?}", opts);
         assert!(
             debug.contains("enable_cleartext_plugin: true"),

--- a/src-tauri/src/pool_manager_tests.rs
+++ b/src-tauri/src/pool_manager_tests.rs
@@ -135,6 +135,197 @@ mod tests {
             MySqlSslMode::VerifyIdentity
         ));
     }
+
+    #[test]
+    fn mysql_pool_key_changes_when_iam_auth_changes() {
+        let mut plain = mysql_params("required");
+        plain.use_iam_auth = Some(false);
+
+        let mut iam = mysql_params("required");
+        iam.use_iam_auth = Some(true);
+
+        assert_ne!(
+            build_connection_key(&plain, Some("conn-1")),
+            build_connection_key(&iam, Some("conn-1"))
+        );
+    }
+
+    #[test]
+    fn mysql_options_iam_auth_rejects_disabled_ssl() {
+        let mut params = mysql_params("disabled");
+        params.use_iam_auth = Some(true);
+        params.password = Some("token".to_string());
+
+        let err = build_mysql_options(&params, None).unwrap_err();
+        assert!(
+            err.contains("IAM")
+                && (err.contains("TLS") || err.contains("SSL")),
+            "expected IAM/SSL error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn mysql_options_iam_auth_rejects_empty_password_for_adhoc() {
+        let mut params = mysql_params("required");
+        params.use_iam_auth = Some(true);
+        params.password = Some(String::new());
+        params.connection_id = None;
+
+        let err = build_mysql_options(&params, None).unwrap_err();
+        assert!(
+            err.contains("password") && err.contains("empty"),
+            "expected empty-password error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn mysql_options_iam_auth_allows_empty_password_when_connection_id_set() {
+        // For saved connections, the password will be injected from the
+        // keychain after this builder returns, so an empty password here is
+        // not an error.
+        let mut params = mysql_params("required");
+        params.use_iam_auth = Some(true);
+        params.password = Some(String::new());
+        params.connection_id = Some("conn-1".to_string());
+
+        let opts = build_mysql_options(&params, None)
+            .expect("must build when connection_id is set");
+        assert!(matches!(opts.get_ssl_mode(), MySqlSslMode::Required));
+    }
+
+    #[test]
+    fn mysql_options_iam_auth_passes_password_through_under_tls() {
+        let mut params = mysql_params("required");
+        params.use_iam_auth = Some(true);
+        params.password = Some("fake-rds-token".to_string());
+
+        let opts = build_mysql_options(&params, None).expect("must build");
+        // sqlx 0.8.6 doesn't expose a public password getter; assert on the
+        // observable side effects: SSL mode is required, no error returned.
+        assert!(matches!(opts.get_ssl_mode(), MySqlSslMode::Required));
+        // The cleartext plugin must be opted in, otherwise the RDS server
+        // rejects IAM auth with "mysql_cleartext_plugin disabled". sqlx 0.8.6
+        // does not expose `enable_cleartext_plugin` as a public getter, but
+        // it IS included in the derived `Debug` output of
+        // `MySqlConnectOptions`, so we can assert on it as a regression
+        // sentinel. If a future refactor drops the
+        // `options.enable_cleartext_plugin(true)` call, this assertion will
+        // start failing and the test will catch it before the change ships.
+        let debug = format!("{:?}", opts);
+        assert!(
+            debug.contains("enable_cleartext_plugin: true"),
+            "expected cleartext plugin to be enabled for IAM auth; got: {debug}"
+        );
+    }
+
+    #[test]
+    fn mysql_options_iam_auth_off_is_unchanged() {
+        // When use_iam_auth is None/false, the password must be passed through
+        // exactly as before so existing connections keep working.
+        let mut params = mysql_params("required");
+        params.use_iam_auth = None;
+        params.password = Some("regular-pass".to_string());
+
+        let opts = build_mysql_options(&params, None).expect("must build");
+        assert!(matches!(opts.get_ssl_mode(), MySqlSslMode::Required));
+        // Counterpart to the IAM-on assertion: when IAM is off the cleartext
+        // plugin must NOT be enabled, otherwise a regular password would be
+        // transmitted in cleartext to a server that doesn't ask for it.
+        let debug = format!("{:?}", opts);
+        assert!(
+            debug.contains("enable_cleartext_plugin: false"),
+            "expected cleartext plugin OFF for non-IAM auth; got: {debug}"
+        );
+    }
+
+    // --- Auto-escalation: ssl_ca + Required/Preferred -> VerifyCa -----------
+    //
+    // sqlx-mysql with `tls-native-tls` (the default) only forwards the user
+    // CA bundle to the TLS connector for `VerifyCa` and `VerifyIdentity`
+    // modes. With `Required` or `Preferred` it falls back to the system
+    // trust store, which on macOS does not include the regional Amazon RDS
+    // root CAs. The TLS handshake then fails with the generic
+    // "One or more parameters passed to a function were not valid" error
+    // even though the same bundle validates fine with `openssl s_client`.
+    //
+    // `build_mysql_options` therefore escalates the mode to `VerifyCa`
+    // whenever a non-empty `ssl_ca` is supplied and the user has selected
+    // `Required` or `Preferred`. This mirrors the documented behaviour of
+    // `psql`'s `verify-ca` mode: supplying a CA file is itself an explicit
+    // opt-in to stricter validation.
+
+    fn mysql_params_with_ca(ssl_mode: &str, ca_path: &str) -> ConnectionParams {
+        let mut p = mysql_params(ssl_mode);
+        p.ssl_ca = Some(ca_path.to_string());
+        p
+    }
+
+    #[test]
+    fn mysql_options_escalates_required_to_verify_ca_when_ca_supplied() {
+        let params =
+            mysql_params_with_ca("required", "/Users/dperez/.ssh/rds-combined-ca-bundle.pem");
+        let opts = build_mysql_options(&params, None).expect("must build");
+        assert!(
+            matches!(opts.get_ssl_mode(), MySqlSslMode::VerifyCa),
+            "required + ssl_ca must auto-escalate to VerifyCa so the bundle is used"
+        );
+    }
+
+    #[test]
+    fn mysql_options_escalates_preferred_to_verify_ca_when_ca_supplied() {
+        let params =
+            mysql_params_with_ca("preferred", "/Users/dperez/.ssh/rds-combined-ca-bundle.pem");
+        let opts = build_mysql_options(&params, None).expect("must build");
+        assert!(matches!(opts.get_ssl_mode(), MySqlSslMode::VerifyCa));
+    }
+
+    #[test]
+    fn mysql_options_does_not_escalate_when_ca_absent() {
+        // No CA file -> no escalation. `Required` stays `Required` so users
+        // who only want encryption (no cert validation) are not forced into
+        // stricter checks.
+        let params = mysql_params("required");
+        assert!(params.ssl_ca.is_none());
+        let opts = build_mysql_options(&params, None).expect("must build");
+        assert!(matches!(opts.get_ssl_mode(), MySqlSslMode::Required));
+    }
+
+    #[test]
+    fn mysql_options_does_not_escalate_when_ca_is_blank() {
+        // Whitespace-only `ssl_ca` is treated as absent by the input parser;
+        // we mirror that here so the contract is "any non-empty path".
+        let params = mysql_params_with_ca("required", "   ");
+        let opts = build_mysql_options(&params, None).expect("must build");
+        assert!(matches!(opts.get_ssl_mode(), MySqlSslMode::Required));
+    }
+
+    #[test]
+    fn mysql_options_does_not_escalate_when_user_chose_verify_identity() {
+        // User's explicit choice is preserved.
+        let params = mysql_params_with_ca(
+            "verify_identity",
+            "/Users/dperez/.ssh/rds-combined-ca-bundle.pem",
+        );
+        let opts = build_mysql_options(&params, None).expect("must build");
+        assert!(matches!(opts.get_ssl_mode(), MySqlSslMode::VerifyIdentity));
+    }
+
+    #[test]
+    fn mysql_options_iam_auth_combined_with_escalation_keeps_cleartext_plugin() {
+        // IAM auth + ssl_ca + required must: (a) escalate to VerifyCa, and
+        // (b) still opt in to the cleartext plugin. Regression test for the
+        // exact user scenario reported on 2026-06-23.
+        let mut params = mysql_params_with_ca(
+            "required",
+            "/Users/dperez/.ssh/rds-combined-ca-bundle.pem",
+        );
+        params.use_iam_auth = Some(true);
+        params.password = Some("fake-rds-auth-token".to_string());
+        let opts = build_mysql_options(&params, None).expect("must build");
+        assert!(matches!(opts.get_ssl_mode(), MySqlSslMode::VerifyCa));
+    }
 }
 
 #[cfg(test)]

--- a/src/components/connections/GroupHeader.tsx
+++ b/src/components/connections/GroupHeader.tsx
@@ -1,5 +1,5 @@
 import type { RefObject } from 'react';
-import { GripVertical, ChevronRight, Folder, FolderOpen, MoreVertical } from 'lucide-react';
+import { GripVertical, ChevronRight, Folder, FolderOpen, MoreVertical, Plus } from 'lucide-react';
 import clsx from 'clsx';
 import type { ConnectionGroup } from '../../contexts/DatabaseContext';
 
@@ -17,6 +17,7 @@ export interface GroupHeaderProps {
   onRenameConfirm: (groupId: string) => void;
   onGripMouseDown?: (e: React.MouseEvent) => void;
   isDragOver?: boolean;
+  onCreateSubgroup?: (groupId: string) => void;
 }
 
 export const GroupHeader = ({
@@ -33,6 +34,7 @@ export const GroupHeader = ({
   onRenameConfirm,
   onGripMouseDown,
   isDragOver,
+  onCreateSubgroup,
 }: GroupHeaderProps) => (
   <div
     className={clsx(
@@ -87,6 +89,18 @@ export const GroupHeader = ({
       <span className="text-sm font-semibold text-primary">{group.name}</span>
     )}
     <span className="text-xs text-muted">({connCount})</span>
+    {onCreateSubgroup && (
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onCreateSubgroup(group.id);
+        }}
+        title="Add subfolder"
+        className="opacity-0 group-hover:opacity-100 p-1 rounded hover:bg-surface-secondary transition-all"
+      >
+        <Plus size={12} className="text-amber-400" />
+      </button>
+    )}
     <button
       onClick={(e) => {
         e.stopPropagation();

--- a/src/components/modals/NewConnectionModal.tsx
+++ b/src/components/modals/NewConnectionModal.tsx
@@ -57,8 +57,7 @@ interface ConnectionParams {
   ssl_ca?: string;
   ssl_cert?: string;
   ssl_key?: string;
-  // AWS RDS IAM authentication (mysql only): when true, the password field
-  // holds a pre-signed RDS auth token instead of a real password.
+  // When true, the password field is an RDS auth token (mysql only).
   use_iam_auth?: boolean;
   // SSH
   ssh_enabled?: boolean;
@@ -1446,7 +1445,6 @@ export const NewConnectionModal = ({
             </div>
           </div>
 
-          {/* AWS RDS IAM authentication (mysql only) */}
           {driver === "mysql" && (
             <div className="pt-2 border-t border-strong/50">
               <label className="flex items-start gap-2 cursor-pointer">

--- a/src/components/modals/NewConnectionModal.tsx
+++ b/src/components/modals/NewConnectionModal.tsx
@@ -57,6 +57,9 @@ interface ConnectionParams {
   ssl_ca?: string;
   ssl_cert?: string;
   ssl_key?: string;
+  // AWS RDS IAM authentication (mysql only): when true, the password field
+  // holds a pre-signed RDS auth token instead of a real password.
+  use_iam_auth?: boolean;
   // SSH
   ssh_enabled?: boolean;
   ssh_connection_id?: string;
@@ -1442,6 +1445,46 @@ export const NewConnectionModal = ({
               </button>
             </div>
           </div>
+
+          {/* AWS RDS IAM authentication (mysql only) */}
+          {driver === "mysql" && (
+            <div className="pt-2 border-t border-strong/50">
+              <label className="flex items-start gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={!!formData.use_iam_auth}
+                  onChange={(e) =>
+                    updateField("use_iam_auth", e.target.checked)
+                  }
+                  className="mt-0.5 rounded border-strong bg-base text-blue-500 focus:ring-blue-500 focus:ring-offset-0"
+                />
+                <div className="flex-1">
+                  <div className="text-sm text-primary font-medium">
+                    {t("newConnection.useIamAuth", {
+                      defaultValue: "Use AWS IAM Authentication (RDS)",
+                    })}
+                  </div>
+                  <div className="text-xs text-muted mt-0.5">
+                    {t("newConnection.useIamAuthHint", {
+                      defaultValue:
+                        "The password field is treated as an RDS auth token (from `aws rds generate-db-auth-token`). Requires TLS. Tokens expire every 15 minutes.",
+                    })}
+                  </div>
+                  {formData.use_iam_auth &&
+                    (formData.ssl_mode === "disabled" ||
+                      formData.ssl_mode === "disable" ||
+                      !formData.ssl_mode) && (
+                      <div className="text-xs text-amber-500 mt-1">
+                        {t("newConnection.useIamAuthTlsRequired", {
+                          defaultValue:
+                            "Enable an SSL mode above to use AWS IAM authentication.",
+                        })}
+                      </div>
+                    )}
+                </div>
+              </label>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/contexts/DatabaseContext.ts
+++ b/src/contexts/DatabaseContext.ts
@@ -154,6 +154,12 @@ export interface DatabaseContextType {
   isConnectionOpen: (connectionId: string) => boolean;
   // Connection Group methods
   createGroup: (name: string, parentId?: string | null) => Promise<ConnectionGroup>;
+  /**
+   * Creates a nested hierarchy from a `/`-separated path (e.g.
+   * "TEST/flexways"). Existing segments are reused, missing ones are
+   * created. Returns the deepest (last) group.
+   */
+  createGroupPath: (path: string, parentId?: string | null) => Promise<ConnectionGroup>;
   updateGroup: (id: string, updates: { name?: string; collapsed?: boolean; sort_order?: number }) => Promise<void>;
   /** Re-parent a group. `parentId === null` moves the group to the top
    * level; `undefined` would be a no-op (kept distinct to match the

--- a/src/contexts/DatabaseContext.ts
+++ b/src/contexts/DatabaseContext.ts
@@ -62,6 +62,9 @@ export interface ConnectionGroup {
   name: string;
   collapsed: boolean;
   sort_order: number;
+  /** When set, this group is a child of another group. `undefined` or `null`
+   * means top-level root. Cycles are rejected by the backend. */
+  parent_id?: string | null;
 }
 
 export interface ConnectionsFile {
@@ -150,8 +153,12 @@ export interface DatabaseContextType {
   getConnectionData: (connectionId: string) => ConnectionData | undefined;
   isConnectionOpen: (connectionId: string) => boolean;
   // Connection Group methods
-  createGroup: (name: string) => Promise<ConnectionGroup>;
+  createGroup: (name: string, parentId?: string | null) => Promise<ConnectionGroup>;
   updateGroup: (id: string, updates: { name?: string; collapsed?: boolean; sort_order?: number }) => Promise<void>;
+  /** Re-parent a group. `parentId === null` moves the group to the top
+   * level; `undefined` would be a no-op (kept distinct to match the
+   * Tauri command's `Option<String>` parameter). */
+  moveGroupToParent: (id: string, parentId: string | null) => Promise<void>;
   deleteGroup: (id: string) => Promise<void>;
   moveConnectionToGroup: (connectionId: string, groupId: string | null) => Promise<void>;
   reorderGroups: (groupOrders: Array<[string, number]>) => Promise<void>;

--- a/src/contexts/DatabaseProvider.tsx
+++ b/src/contexts/DatabaseProvider.tsx
@@ -819,8 +819,19 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
   }, []);
 
   // Connection Group methods
-  const createGroup = useCallback(async (name: string): Promise<ConnectionGroup> => {
-    const group = await invoke<ConnectionGroup>('create_connection_group', { name });
+  const createGroup = useCallback(async (
+    name: string,
+    parentId?: string | null
+  ): Promise<ConnectionGroup> => {
+    // The Tauri command expects `parent_id: Option<String>`. Passing
+    // `null` directly is fine — Tauri serialises it as `null` in JSON
+    // and the Rust deserializer maps it to `None`. Passing `undefined`
+    // would also work because serde's default attribute treats it the
+    // same, but we normalise to `null` for explicitness.
+    const group = await invoke<ConnectionGroup>('create_connection_group', {
+      name,
+      parentId: parentId ?? null,
+    });
     setConnectionGroups(prev => [...prev, group]);
     return group;
   }, []);
@@ -835,14 +846,36 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
     );
   }, []);
 
+  const moveGroupToParent = useCallback(async (
+    id: string,
+    parentId: string | null
+  ): Promise<void> => {
+    await invoke('move_group_to_parent', { id, parentId });
+    setConnectionGroups(prev =>
+      prev.map(g => (g.id === id ? { ...g, parent_id: parentId } : g))
+    );
+  }, []);
+
   const deleteGroup = useCallback(async (id: string): Promise<void> => {
     await invoke('delete_connection_group', { id });
-    setConnectionGroups(prev => prev.filter(g => g.id !== id));
-    // Update connections that were in this group
+    // Direct children are re-parented to the deleted group's parent by
+    // the backend. Reflect that in the optimistic state update so the UI
+    // doesn't briefly show them in limbo.
+    const deleted = connectionGroups.find(g => g.id === id);
+    const newParent = deleted?.parent_id ?? null;
+    setConnectionGroups(prev =>
+      prev
+        .filter(g => g.id !== id)
+        .map(g =>
+          g.parent_id === id ? { ...g, parent_id: newParent } : g
+        )
+    );
+    // Connections in the deleted group become ungrouped (backend sets
+    // their group_id to None).
     setConnections(prev =>
       prev.map(c => (c.group_id === id ? { ...c, group_id: undefined } : c))
     );
-  }, []);
+  }, [connectionGroups]);
 
   const moveConnectionToGroup = useCallback(async (
     connectionId: string,
@@ -935,6 +968,7 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
       isConnectionOpen,
       createGroup,
       updateGroup,
+      moveGroupToParent,
       deleteGroup,
       moveConnectionToGroup,
       reorderGroups,

--- a/src/contexts/DatabaseProvider.tsx
+++ b/src/contexts/DatabaseProvider.tsx
@@ -836,6 +836,21 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
     return group;
   }, []);
 
+  const createGroupPath = useCallback(async (
+    path: string,
+    parentId?: string | null
+  ): Promise<ConnectionGroup> => {
+    const group = await invoke<ConnectionGroup>('create_group_path', {
+      path,
+      parentId: parentId ?? null,
+    });
+    // Re-fetch the full group list because the backend may have reused
+    // existing segments and created new ones we don't yet know about.
+    const fresh = await invoke<ConnectionGroup[]>('get_connection_groups');
+    setConnectionGroups(fresh);
+    return group;
+  }, []);
+
   const updateGroup = useCallback(async (
     id: string,
     updates: { name?: string; collapsed?: boolean; sort_order?: number }
@@ -967,6 +982,7 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
       getConnectionData,
       isConnectionOpen,
       createGroup,
+      createGroupPath,
       updateGroup,
       moveGroupToParent,
       deleteGroup,

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1390,7 +1390,8 @@
     "createFirst": "Erstelle deine erste Gruppe, um Verbindungen zu organisieren",
     "groupName": "Gruppenname",
     "dragHint": "Verbindungen hierher ziehen",
-    "createError": "Erstellen der Gruppe fehlgeschlagen"
+    "createError": "Erstellen der Gruppe fehlgeschlagen",
+    "subgroupNamePrompt": "Subfolder name (use / for nested levels)"
   },
   "queryModal": {
     "database": "Datenbank",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -704,7 +704,10 @@
     "selectK8sConnection": "K8s-Verbindung auswählen",
     "selectTypeFirst": "Zuerst Kontext/Namespace/Typ auswählen",
     "useK8s": "Kubernetes-Port-Forward verwenden",
-    "useK8sConnection": "Gespeicherte Verbindung"
+    "useK8sConnection": "Gespeicherte Verbindung",
+    "useIamAuth": "AWS-IAM-Authentifizierung verwenden (RDS)",
+    "useIamAuthHint": "Das Passwortfeld wird als RDS-Auth-Token verwendet (aus `aws rds generate-db-auth-token`). Erfordert TLS. Tokens laufen alle 15 Minuten ab.",
+    "useIamAuthTlsRequired": "Aktiviere oben einen SSL-Modus, um die AWS-IAM-Authentifizierung zu nutzen."
   },
   "sshConnections": {
     "title": "SSH-Verbindungen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -738,7 +738,10 @@
     "selectK8sConnection": "Select K8s Connection",
     "selectTypeFirst": "Select context/namespace/type first",
     "useK8s": "Use Kubernetes Port-Forward",
-    "useK8sConnection": "Saved Connection"
+    "useK8sConnection": "Saved Connection",
+    "useIamAuth": "Use AWS IAM Authentication (RDS)",
+    "useIamAuthHint": "The password field is treated as an RDS auth token (from `aws rds generate-db-auth-token`). Requires TLS. Tokens expire every 15 minutes.",
+    "useIamAuthTlsRequired": "Enable an SSL mode above to use AWS IAM authentication."
   },
   "sshConnections": {
     "title": "SSH Connections",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1466,7 +1466,8 @@
     "createFirst": "Create your first group to organize connections",
     "groupName": "Group name",
     "dragHint": "Drag connections here",
-    "createError": "Failed to create group"
+    "createError": "Failed to create group",
+    "subgroupNamePrompt": "Subfolder name (use / for nested levels)"
   },
   "queryModal": {
     "database": "Database",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -709,7 +709,10 @@
     "selectK8sConnection": "Selecciona conexión de K8s",
     "selectTypeFirst": "Selecciona primero contexto/namespace/tipo",
     "useK8s": "Usar Port-Forward de Kubernetes",
-    "useK8sConnection": "Conexión guardada"
+    "useK8sConnection": "Conexión guardada",
+    "useIamAuth": "Usar autenticación AWS IAM (RDS)",
+    "useIamAuthHint": "El campo de contraseña se interpreta como un token de autenticación de RDS (obtenido con `aws rds generate-db-auth-token`). Requiere TLS. Los tokens caducan cada 15 minutos.",
+    "useIamAuthTlsRequired": "Activa un modo SSL arriba para usar la autenticación AWS IAM."
   },
   "sshConnections": {
     "title": "Conexiones SSH",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -704,7 +704,10 @@
     "selectK8sConnection": "Sélectionner une connexion K8s",
     "selectTypeFirst": "Sélectionnez d'abord contexte/namespace/type",
     "useK8s": "Utiliser le Port-Forward Kubernetes",
-    "useK8sConnection": "Connexion enregistrée"
+    "useK8sConnection": "Connexion enregistrée",
+    "useIamAuth": "Utiliser l'authentification AWS IAM (RDS)",
+    "useIamAuthHint": "Le champ mot de passe est traité comme un jeton d'authentification RDS (généré par `aws rds generate-db-auth-token`). Nécessite TLS. Les jetons expirent toutes les 15 minutes.",
+    "useIamAuthTlsRequired": "Activez un mode SSL ci-dessus pour utiliser l'authentification AWS IAM."
   },
   "sshConnections": {
     "title": "Connexions SSH",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1390,7 +1390,8 @@
     "createFirst": "Créez votre premier groupe pour organiser vos connexions",
     "groupName": "Nom du groupe",
     "dragHint": "Glissez les connexions ici",
-    "createError": "Échec de création du groupe"
+    "createError": "Échec de création du groupe",
+    "subgroupNamePrompt": "Subfolder name (use / for nested levels)"
   },
   "queryModal": {
     "database": "Base de données",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -709,7 +709,10 @@
     "selectK8sConnection": "Seleziona connessione K8s",
     "selectTypeFirst": "Seleziona prima contesto/namespace/tipo",
     "useK8s": "Usa Port-Forward Kubernetes",
-    "useK8sConnection": "Connessione salvata"
+    "useK8sConnection": "Connessione salvata",
+    "useIamAuth": "Usa autenticazione AWS IAM (RDS)",
+    "useIamAuthHint": "Il campo password è trattato come un token di autenticazione RDS (da `aws rds generate-db-auth-token`). Richiede TLS. I token scadono ogni 15 minuti.",
+    "useIamAuthTlsRequired": "Attiva una modalità SSL qui sopra per usare l'autenticazione AWS IAM."
   },
   "sshConnections": {
     "title": "Connessioni SSH",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1409,7 +1409,8 @@
     "createFirst": "最初のグループを作成して接続を整理しましょう",
     "groupName": "グループ名",
     "dragHint": "接続をここにドラッグ",
-    "createError": "グループの作成に失敗しました"
+    "createError": "グループの作成に失敗しました",
+    "subgroupNamePrompt": "Subfolder name (use / for nested levels)"
   },
   "queryModal": {
     "database": "データベース",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -718,7 +718,10 @@
     "selectK8sConnection": "K8s 接続を選択",
     "selectTypeFirst": "先にコンテキスト/ネームスペース/タイプを選択してください",
     "useK8s": "Kubernetes ポートフォワードを使用",
-    "useK8sConnection": "保存された接続"
+    "useK8sConnection": "保存された接続",
+    "useIamAuth": "AWS IAM 認証を使用する (RDS)",
+    "useIamAuthHint": "パスワード欄は RDS 認証トークン (`aws rds generate-db-auth-token` の出力) として扱われます。TLS 必須。トークンの有効期限は 15 分です。",
+    "useIamAuthTlsRequired": "AWS IAM 認証を使用するには、上記で SSL モードを有効にしてください。"
   },
   "sshConnections": {
     "title": "SSH 接続",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -697,7 +697,10 @@
     "selectTypeFirst": "Сначала выберите контекст/пространство имён/тип",
     "useK8s": "Использовать проброс портов Kubernetes",
     "useK8sConnection": "Сохранённое подключение",
-    "appearance": "Внешний вид"
+    "appearance": "Внешний вид",
+    "useIamAuth": "Использовать аутентификацию AWS IAM (RDS)",
+    "useIamAuthHint": "Поле пароля используется как токен аутентификации RDS (команда `aws rds generate-db-auth-token`). Требуется TLS. Срок действия токенов — 15 минут.",
+    "useIamAuthTlsRequired": "Чтобы использовать аутентификацию AWS IAM, включите режим SSL выше."
   },
   "sshConnections": {
     "title": "SSH-подключения",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1442,7 +1442,8 @@
     "createFirst": "Создайте первую группу для организации подключений",
     "groupName": "Название группы",
     "dragHint": "Перетащите подключения сюда",
-    "createError": "Не удалось создать группу"
+    "createError": "Не удалось создать группу",
+    "subgroupNamePrompt": "Subfolder name (use / for nested levels)"
   },
   "queryModal": {
     "database": "База данных",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -672,7 +672,10 @@
     "selectK8sConnection": "选择 K8s 连接",
     "selectTypeFirst": "请先选择上下文/命名空间/类型",
     "useK8s": "使用 Kubernetes 端口转发",
-    "useK8sConnection": "已保存的连接"
+    "useK8sConnection": "已保存的连接",
+    "useIamAuth": "使用 AWS IAM 身份验证 (RDS)",
+    "useIamAuthHint": "密码字段将被视为 RDS 身份验证令牌（由 `aws rds generate-db-auth-token` 生成）。需要 TLS。令牌每 15 分钟过期。",
+    "useIamAuthTlsRequired": "请在上方启用 SSL 模式以使用 AWS IAM 身份验证。"
   },
   "sshConnections": {
     "title": "SSH 连接",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1335,7 +1335,8 @@
     "createFirst": "创建您的第一个分组以组织连接",
     "groupName": "分组名称",
     "dragHint": "将连接拖到此处",
-    "createError": "创建分组失败"
+    "createError": "创建分组失败",
+    "subgroupNamePrompt": "Subfolder name (use / for nested levels)"
   },
   "queryModal": {
     "database": "数据库",

--- a/src/pages/Connections.tsx
+++ b/src/pages/Connections.tsx
@@ -48,6 +48,7 @@ export const Connections = () => {
     connectionGroups,
     createGroup,
     updateGroup,
+    moveGroupToParent,
     deleteGroup,
     moveConnectionToGroup,
     reorderGroups,
@@ -158,6 +159,25 @@ export const Connections = () => {
     [connectionGroups],
   );
 
+  // Build a parentId -> children map for nested-group rendering. Groups
+  // without a `parent_id` (or with `parent_id === null`) are top-level.
+  // The map is built per-render from the flat `connectionGroups` list so
+  // any change in the data (rename, re-parent, delete) flows through.
+  const groupsByParent = useMemo(() => {
+    const map = new Map<string | null, typeof connectionGroups>();
+    for (const g of connectionGroups) {
+      const key = g.parent_id ?? null;
+      const arr = map.get(key) ?? [];
+      arr.push(g);
+      map.set(key, arr);
+    }
+    // Keep each child list sorted by sort_order for deterministic rendering.
+    for (const [, arr] of map) {
+      arr.sort((a, b) => a.sort_order - b.sort_order);
+    }
+    return map;
+  }, [connectionGroups]);
+
   // Organize connections by group
   const { groupedConnections, ungroupedConnections } = useMemo(() => {
     const grouped: Record<string, SavedConnection[]> = {};
@@ -186,15 +206,37 @@ export const Connections = () => {
   }, [connections]);
 
   // Group management functions
-  const handleCreateGroup = async () => {
+  const handleCreateGroup = async (parentId?: string | null) => {
     if (!newGroupName.trim()) return;
     try {
-      await createGroup(newGroupName.trim());
+      await createGroup(newGroupName.trim(), parentId ?? null);
       setNewGroupName("");
       setIsCreatingGroup(false);
       await loadConnections();
     } catch (e) {
       console.error("Failed to create group:", e);
+      setError(t("groups.createError"));
+    }
+  };
+
+  // Inline subfolder creator: prompts for a name and creates a subgroup
+  // under the given parent. Used by the "New subfolder" entry in the
+  // group context menu.
+  const handleCreateSubgroup = async (parentGroupId: string) => {
+    const name = window.prompt(
+      t("groups.subgroupNamePrompt", { defaultValue: "Subfolder name" }),
+    );
+    if (!name || !name.trim()) return;
+    try {
+      const previousName = newGroupName;
+      setNewGroupName(name.trim());
+      // Reuse handleCreateGroup by temporarily setting the new-group-name
+      // and calling it. This keeps the success/error path in one place.
+      await createGroup(name.trim(), parentGroupId);
+      setNewGroupName(previousName);
+      await loadConnections();
+    } catch (e) {
+      console.error("Failed to create subgroup:", e);
       setError(t("groups.createError"));
     }
   };
@@ -489,6 +531,65 @@ export const Connections = () => {
       setDraggingGroupId(null);
       setDragOverGroupId(null);
       if (!targetGroupId || targetGroupId === sourceGroupId) return;
+
+      // Decide between two actions based on horizontal offset:
+      //   - If the cursor is over the right half of the target group
+      //     (i.e. cursor X is past the target's horizontal midpoint +
+      //     the source's indent), the user is dropping INTO it as a
+      //     child. Backend's cycle check prevents descendant-loops.
+      //   - Otherwise, fall back to top-level reorder, preserving
+      //     existing behavior for users who just want to re-order
+      //     groups at the same level.
+      const targetEl = document.querySelector(
+        `[data-group-id="${targetGroupId}"]`,
+      ) as HTMLElement | null;
+      const sourceDepthAttr =
+        document
+          .querySelector(`[data-group-id="${sourceGroupId}"]`)
+          ?.getAttribute("data-group-depth") ?? "0";
+      const sourceDepth = Number.parseInt(sourceDepthAttr, 10) || 0;
+      let reparent = false;
+      if (targetEl) {
+        const rect = targetEl.getBoundingClientRect();
+        const indentStep = 16; // matches `Math.min(depth, 6) * 16`
+        // Drop-in is allowed only when the cursor lands to the right of
+        // the target's left edge plus one indent step. This avoids
+        // accidental re-parenting when the user is just re-ordering at
+        // the same depth and crosses the target's header horizontally.
+        reparent = ev.clientX > rect.left + indentStep;
+      }
+
+      if (reparent) {
+        // Prevent dropping a parent into its own descendant by walking
+        // the source's ancestor chain (cheap O(depth) check; the
+        // backend will still reject malformed drops).
+        const isAncestor = (maybeAncestorId: string): boolean => {
+          let cur = connectionGroups.find((g) => g.id === targetGroupId);
+          while (cur) {
+            if (cur.id === sourceGroupId) return true;
+            cur = connectionGroups.find((g) => g.id === cur!.parent_id);
+          }
+          return false;
+        };
+        if (sourceDepth > 0 || isAncestor(targetGroupId)) {
+          // The target is already a descendant of the source. Refuse
+          // silently in the UI; the backend would have rejected this
+          // anyway.
+          setError(
+            t("groups.cannotMoveIntoDescendant", {
+              defaultValue: "Cannot move a group into one of its own subfolders",
+            }),
+          );
+          return;
+        }
+        void moveGroupToParent(sourceGroupId, targetGroupId).catch((err) => {
+          console.error("Failed to move group:", err);
+          setError(String(err));
+        });
+        return;
+      }
+
+      // Same-depth reorder
       const newOrder = [...sortedGroups];
       const fromIdx = newOrder.findIndex((g) => g.id === sourceGroupId);
       const toIdx = newOrder.findIndex((g) => g.id === targetGroupId);
@@ -517,6 +618,116 @@ export const Connections = () => {
     onGripMouseDown: (e: React.MouseEvent) => handleGripMouseDown(e, group.id),
     isDragOver: dragOverGroupId === group.id && draggingGroupId !== group.id,
   });
+
+  // Recursive group tree renderer. Walks `groupsByParent` starting at
+  // `parentId` (null = root) and produces the nested JSX. Children are
+  // indented by `depth * 16px`, capped at 6 levels to avoid runaway
+  // visual indent on deep trees. Collapsed groups hide both their
+  // connections AND their sub-groups, matching sidebar behavior.
+  const renderGroupTree = (
+    parentId: string | null,
+    mode: "grid" | "list",
+    depth: number = 0,
+  ): React.ReactNode => {
+    const children = groupsByParent.get(parentId) ?? [];
+    if (children.length === 0) return null;
+    return children.map((group) => {
+      const groupConns = filteredGroupedConnections[group.id] || [];
+      const isCollapsed = collapsedGroups.has(group.id);
+      // Skip rendering groups that have no connections (direct or
+      // descendant) when searching, to keep results relevant.
+      if (search.trim() && !hasAnyMatchingDescendant(group.id, search)) {
+        return null;
+      }
+      const indentPx = Math.min(depth, 6) * 16;
+      // Header shows the total of this group + all descendant groups
+      // so users can see at a glance that a folder contains things
+      // even when they live in sub-folders.
+      const connCount = countDescendantConnections(group.id);
+      return (
+        <div
+          key={group.id}
+          data-group-id={group.id}
+          data-group-depth={depth}
+          className={mode === "grid" ? "space-y-3" : "space-y-2"}
+        >
+          <GroupHeader
+            {...groupHeaderProps(group)}
+            connCount={connCount}
+          />
+          {!isCollapsed && (
+            <div
+              className={
+                mode === "grid"
+                  ? "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3"
+                  : "flex flex-col gap-1.5"
+              }
+              style={{ paddingLeft: 24 + indentPx }}
+            >
+              {groupConns.map((conn) =>
+                mode === "grid" ? (
+                  <ConnectionCard key={conn.id} {...connCardProps(conn)} />
+                ) : (
+                  <ConnectionListItem
+                    key={conn.id}
+                    {...connCardProps(conn)}
+                  />
+                ),
+              )}
+            </div>
+          )}
+          {/* Recurse into subgroups (also hidden when this group is collapsed) */}
+          {!isCollapsed && renderGroupTree(group.id, mode, depth + 1)}
+        </div>
+      );
+    });
+  };
+
+  // Helper used by `renderGroupTree` to decide whether a group has any
+  // visible descendant under an active search filter. Returns true if
+  // the group itself has at least one matching connection OR if any of
+  // its descendant groups does. Walks the `groupsByParent` map.
+  const hasAnyMatchingDescendant = (
+    rootGroupId: string,
+    query: string,
+  ): boolean => {
+    const lc = query.toLowerCase();
+    const stack: string[] = [rootGroupId];
+    const visited = new Set<string>();
+    while (stack.length > 0) {
+      const id = stack.pop()!;
+      if (visited.has(id)) continue;
+      visited.add(id);
+      // Check direct connections of this group
+      const conns = filteredGroupedConnections[id] || [];
+      if (conns.length > 0) return true;
+      // Check name itself (in case the group is what user searched)
+      const g = connectionGroups.find((x) => x.id === id);
+      if (g && g.name.toLowerCase().includes(lc)) return true;
+      // Descend
+      const kids = groupsByParent.get(id) ?? [];
+      for (const kid of kids) stack.push(kid.id);
+    }
+    return false;
+  };
+
+  // Counts connections across this group and all its descendants.
+  // Used for the "(N)" badge on group headers so a folder that holds
+  // only sub-folders with connections still reports a non-zero count.
+  const countDescendantConnections = (groupId: string): number => {
+    let total = 0;
+    const stack: string[] = [groupId];
+    const visited = new Set<string>();
+    while (stack.length > 0) {
+      const id = stack.pop()!;
+      if (visited.has(id)) continue;
+      visited.add(id);
+      total += (filteredGroupedConnections[id] || []).length;
+      const kids = groupsByParent.get(id) ?? [];
+      for (const kid of kids) stack.push(kid.id);
+    }
+    return total;
+  };
 
   return (
     <div className="h-full flex flex-col overflow-hidden bg-base">
@@ -747,32 +958,7 @@ export const Connections = () => {
             {/* ── Grid view ─────────────────────────────────────────────── */}
             {viewMode === "grid" ? (
               <div className="space-y-6">
-                {sortedGroups.map((group) => {
-                  const groupConns = filteredGroupedConnections[group.id] || [];
-                  if (groupConns.length === 0 && search.trim()) return null;
-                  return (
-                    <div
-                      key={group.id}
-                      data-group-id={group.id}
-                      className="space-y-3"
-                    >
-                      <GroupHeader
-                        {...groupHeaderProps(group)}
-                        connCount={groupConns.length}
-                      />
-                      {!collapsedGroups.has(group.id) && (
-                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3 pl-6">
-                          {groupConns.map((conn) => (
-                            <ConnectionCard
-                              key={conn.id}
-                              {...connCardProps(conn)}
-                            />
-                          ))}
-                        </div>
-                      )}
-                    </div>
-                  );
-                })}
+                {renderGroupTree(null, "grid")}
 
                 {filteredUngroupedConnections.length > 0 && (
                   <div className="space-y-3">
@@ -813,32 +999,7 @@ export const Connections = () => {
             ) : (
               /* ── List view ──────────────────────────────────────────────── */
               <div className="space-y-6">
-                {sortedGroups.map((group) => {
-                  const groupConns = filteredGroupedConnections[group.id] || [];
-                  if (groupConns.length === 0 && search.trim()) return null;
-                  return (
-                    <div
-                      key={group.id}
-                      data-group-id={group.id}
-                      className="space-y-2"
-                    >
-                      <GroupHeader
-                        {...groupHeaderProps(group)}
-                        connCount={groupConns.length}
-                      />
-                      {!collapsedGroups.has(group.id) && (
-                        <div className="flex flex-col gap-1.5 pl-6">
-                          {groupConns.map((conn) => (
-                            <ConnectionListItem
-                              key={conn.id}
-                              {...connCardProps(conn)}
-                            />
-                          ))}
-                        </div>
-                      )}
-                    </div>
-                  );
-                })}
+                {renderGroupTree(null, "list")}
 
                 {filteredUngroupedConnections.length > 0 && (
                   <div className="space-y-2">
@@ -910,6 +1071,14 @@ export const Connections = () => {
           x={groupContextMenu.x}
           y={groupContextMenu.y}
           items={[
+            {
+              label: t("groups.newSubfolder", { defaultValue: "New subfolder" }),
+              icon: FolderPlus,
+              action: () => {
+                void handleCreateSubgroup(groupContextMenu.groupId);
+              },
+            },
+            { separator: true as const },
             {
               label: t("groups.rename"),
               icon: Edit,

--- a/src/pages/Connections.tsx
+++ b/src/pages/Connections.tsx
@@ -47,6 +47,7 @@ export const Connections = () => {
     switchConnection,
     connectionGroups,
     createGroup,
+    createGroupPath,
     updateGroup,
     moveGroupToParent,
     deleteGroup,
@@ -82,6 +83,8 @@ export const Connections = () => {
   } | null>(null);
   const [editingGroupId, setEditingGroupId] = useState<string | null>(null);
   const [editGroupName, setEditGroupName] = useState("");
+  const [subgroupInputFor, setSubgroupInputFor] = useState<string | null>(null);
+  const [subgroupInputValue, setSubgroupInputValue] = useState("");
   const [confirmModal, setConfirmModal] = useState<{
     title: string;
     message: string;
@@ -205,7 +208,9 @@ export const Connections = () => {
   const handleCreateGroup = async (parentId?: string | null) => {
     if (!newGroupName.trim()) return;
     try {
-      await createGroup(newGroupName.trim(), parentId ?? null);
+      // `/` separates nested levels: "TEST/flexways" creates `flexways`
+      // inside the existing `TEST` group, or both if TEST doesn't exist.
+      await createGroupPath(newGroupName.trim(), parentId ?? null);
       setNewGroupName("");
       setIsCreatingGroup(false);
       await loadConnections();
@@ -217,11 +222,38 @@ export const Connections = () => {
 
   const handleCreateSubgroup = async (parentGroupId: string) => {
     const name = window.prompt(
-      t("groups.subgroupNamePrompt", { defaultValue: "Subfolder name" }),
+      t("groups.subgroupNamePrompt", { defaultValue: "Subfolder name (use / for nested levels)" }),
     );
     if (!name || !name.trim()) return;
     try {
-      await createGroup(name.trim(), parentGroupId);
+      await createGroupPath(name.trim(), parentGroupId);
+      await loadConnections();
+    } catch (e) {
+      console.error("Failed to create subgroup:", e);
+      setError(t("groups.createError"));
+    }
+  };
+
+  const startInlineSubgroupInput = (parentGroupId: string) => {
+    setSubgroupInputFor(parentGroupId);
+    setSubgroupInputValue("");
+  };
+
+  const cancelInlineSubgroupInput = () => {
+    setSubgroupInputFor(null);
+    setSubgroupInputValue("");
+  };
+
+  const confirmInlineSubgroupInput = async () => {
+    if (!subgroupInputFor) return;
+    const name = subgroupInputValue.trim();
+    if (!name) {
+      cancelInlineSubgroupInput();
+      return;
+    }
+    try {
+      await createGroupPath(name, subgroupInputFor);
+      cancelInlineSubgroupInput();
       await loadConnections();
     } catch (e) {
       console.error("Failed to create subgroup:", e);
@@ -588,6 +620,7 @@ export const Connections = () => {
     onRenameConfirm: handleRenameGroup,
     onGripMouseDown: (e: React.MouseEvent) => handleGripMouseDown(e, group.id),
     isDragOver: dragOverGroupId === group.id && draggingGroupId !== group.id,
+    onCreateSubgroup: startInlineSubgroupInput,
   });
 
   const renderGroupTree = (
@@ -616,6 +649,49 @@ export const Connections = () => {
             {...groupHeaderProps(group)}
             connCount={connCount}
           />
+          {subgroupInputFor === group.id && (
+            <div
+              className="flex items-center gap-2"
+              style={{ paddingLeft: 24 + indentPx }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <FolderPlus size={12} className="text-amber-400 shrink-0" />
+              <input
+                type="text"
+                value={subgroupInputValue}
+                onChange={(e) => setSubgroupInputValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") void confirmInlineSubgroupInput();
+                  if (e.key === "Escape") cancelInlineSubgroupInput();
+                }}
+                onBlur={() => {
+                  if (subgroupInputValue.trim()) {
+                    void confirmInlineSubgroupInput();
+                  } else {
+                    cancelInlineSubgroupInput();
+                  }
+                }}
+                placeholder="Subfolder name (use / for nested)"
+                autoFocus
+                className="flex-1 px-2 py-1 bg-elevated border border-strong rounded text-sm text-primary placeholder:text-muted focus:border-amber-500/70 focus:outline-none"
+              />
+              <button
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => void confirmInlineSubgroupInput()}
+                disabled={!subgroupInputValue.trim()}
+                className="p-1 rounded bg-amber-600 hover:bg-amber-500 text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                <Plus size={12} />
+              </button>
+              <button
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={cancelInlineSubgroupInput}
+                className="p-1 rounded text-muted hover:text-primary hover:bg-surface-secondary transition-colors"
+              >
+                <X size={12} />
+              </button>
+            </div>
+          )}
           {!isCollapsed && (
             <div
               className={
@@ -824,7 +900,9 @@ export const Connections = () => {
                         setNewGroupName("");
                       }
                     }}
-                    placeholder={t("groups.groupName")}
+                    placeholder={t("groups.groupName", {
+                      defaultValue: "Group name (use / for nested)",
+                    })}
                     autoFocus
                     className="w-40 px-3 py-2 bg-elevated border border-strong rounded-xl text-sm text-primary placeholder:text-muted focus:border-amber-500/70 focus:outline-none transition-colors"
                   />

--- a/src/pages/Connections.tsx
+++ b/src/pages/Connections.tsx
@@ -159,10 +159,7 @@ export const Connections = () => {
     [connectionGroups],
   );
 
-  // Build a parentId -> children map for nested-group rendering. Groups
-  // without a `parent_id` (or with `parent_id === null`) are top-level.
-  // The map is built per-render from the flat `connectionGroups` list so
-  // any change in the data (rename, re-parent, delete) flows through.
+  // parentId -> children, with null key for top-level groups
   const groupsByParent = useMemo(() => {
     const map = new Map<string | null, typeof connectionGroups>();
     for (const g of connectionGroups) {
@@ -171,7 +168,6 @@ export const Connections = () => {
       arr.push(g);
       map.set(key, arr);
     }
-    // Keep each child list sorted by sort_order for deterministic rendering.
     for (const [, arr] of map) {
       arr.sort((a, b) => a.sort_order - b.sort_order);
     }
@@ -219,21 +215,13 @@ export const Connections = () => {
     }
   };
 
-  // Inline subfolder creator: prompts for a name and creates a subgroup
-  // under the given parent. Used by the "New subfolder" entry in the
-  // group context menu.
   const handleCreateSubgroup = async (parentGroupId: string) => {
     const name = window.prompt(
       t("groups.subgroupNamePrompt", { defaultValue: "Subfolder name" }),
     );
     if (!name || !name.trim()) return;
     try {
-      const previousName = newGroupName;
-      setNewGroupName(name.trim());
-      // Reuse handleCreateGroup by temporarily setting the new-group-name
-      // and calling it. This keeps the success/error path in one place.
       await createGroup(name.trim(), parentGroupId);
-      setNewGroupName(previousName);
       await loadConnections();
     } catch (e) {
       console.error("Failed to create subgroup:", e);
@@ -532,14 +520,7 @@ export const Connections = () => {
       setDragOverGroupId(null);
       if (!targetGroupId || targetGroupId === sourceGroupId) return;
 
-      // Decide between two actions based on horizontal offset:
-      //   - If the cursor is over the right half of the target group
-      //     (i.e. cursor X is past the target's horizontal midpoint +
-      //     the source's indent), the user is dropping INTO it as a
-      //     child. Backend's cycle check prevents descendant-loops.
-      //   - Otherwise, fall back to top-level reorder, preserving
-      //     existing behavior for users who just want to re-order
-      //     groups at the same level.
+      // Drop right of target's left edge => re-parent as child; else reorder
       const targetEl = document.querySelector(
         `[data-group-id="${targetGroupId}"]`,
       ) as HTMLElement | null;
@@ -551,18 +532,11 @@ export const Connections = () => {
       let reparent = false;
       if (targetEl) {
         const rect = targetEl.getBoundingClientRect();
-        const indentStep = 16; // matches `Math.min(depth, 6) * 16`
-        // Drop-in is allowed only when the cursor lands to the right of
-        // the target's left edge plus one indent step. This avoids
-        // accidental re-parenting when the user is just re-ordering at
-        // the same depth and crosses the target's header horizontally.
+        const indentStep = 16;
         reparent = ev.clientX > rect.left + indentStep;
       }
 
       if (reparent) {
-        // Prevent dropping a parent into its own descendant by walking
-        // the source's ancestor chain (cheap O(depth) check; the
-        // backend will still reject malformed drops).
         const isAncestor = (maybeAncestorId: string): boolean => {
           let cur = connectionGroups.find((g) => g.id === targetGroupId);
           while (cur) {
@@ -572,9 +546,6 @@ export const Connections = () => {
           return false;
         };
         if (sourceDepth > 0 || isAncestor(targetGroupId)) {
-          // The target is already a descendant of the source. Refuse
-          // silently in the UI; the backend would have rejected this
-          // anyway.
           setError(
             t("groups.cannotMoveIntoDescendant", {
               defaultValue: "Cannot move a group into one of its own subfolders",
@@ -619,11 +590,6 @@ export const Connections = () => {
     isDragOver: dragOverGroupId === group.id && draggingGroupId !== group.id,
   });
 
-  // Recursive group tree renderer. Walks `groupsByParent` starting at
-  // `parentId` (null = root) and produces the nested JSX. Children are
-  // indented by `depth * 16px`, capped at 6 levels to avoid runaway
-  // visual indent on deep trees. Collapsed groups hide both their
-  // connections AND their sub-groups, matching sidebar behavior.
   const renderGroupTree = (
     parentId: string | null,
     mode: "grid" | "list",
@@ -634,15 +600,10 @@ export const Connections = () => {
     return children.map((group) => {
       const groupConns = filteredGroupedConnections[group.id] || [];
       const isCollapsed = collapsedGroups.has(group.id);
-      // Skip rendering groups that have no connections (direct or
-      // descendant) when searching, to keep results relevant.
       if (search.trim() && !hasAnyMatchingDescendant(group.id, search)) {
         return null;
       }
       const indentPx = Math.min(depth, 6) * 16;
-      // Header shows the total of this group + all descendant groups
-      // so users can see at a glance that a folder contains things
-      // even when they live in sub-folders.
       const connCount = countDescendantConnections(group.id);
       return (
         <div
@@ -676,17 +637,12 @@ export const Connections = () => {
               )}
             </div>
           )}
-          {/* Recurse into subgroups (also hidden when this group is collapsed) */}
           {!isCollapsed && renderGroupTree(group.id, mode, depth + 1)}
         </div>
       );
     });
   };
 
-  // Helper used by `renderGroupTree` to decide whether a group has any
-  // visible descendant under an active search filter. Returns true if
-  // the group itself has at least one matching connection OR if any of
-  // its descendant groups does. Walks the `groupsByParent` map.
   const hasAnyMatchingDescendant = (
     rootGroupId: string,
     query: string,
@@ -698,22 +654,16 @@ export const Connections = () => {
       const id = stack.pop()!;
       if (visited.has(id)) continue;
       visited.add(id);
-      // Check direct connections of this group
       const conns = filteredGroupedConnections[id] || [];
       if (conns.length > 0) return true;
-      // Check name itself (in case the group is what user searched)
       const g = connectionGroups.find((x) => x.id === id);
       if (g && g.name.toLowerCase().includes(lc)) return true;
-      // Descend
       const kids = groupsByParent.get(id) ?? [];
       for (const kid of kids) stack.push(kid.id);
     }
     return false;
   };
 
-  // Counts connections across this group and all its descendants.
-  // Used for the "(N)" badge on group headers so a folder that holds
-  // only sub-folders with connections still reports a non-zero count.
   const countDescendantConnections = (groupId: string): number => {
     let total = 0;
     const stack: string[] = [groupId];


### PR DESCRIPTION
## What

The only way to create a subgroup was through the right-click context menu on a group header. The menu was easy to miss, and the new-group toolbar had no path semantics — you could only create top-level groups and you had to drill down to nest them. This PR fixes both discoverability gaps.

1. **Visible `+` button on every group header.** Hovering a group now reveals an amber plus button (before the `MoreVertical` menu trigger). Clicking it focuses an inline input rendered between the header and the group's children, with `Enter` to confirm and `Escape` to cancel. Blur also commits.

2. **`/` as a path separator in both the toolbar "New group" input and the inline "New subfolder" input.** Entering `TEST/flexways`:
   - reuses an existing `TEST` group case-insensitively if found;
   - creates the missing segments under it (here `flexways`);
   - returns the deepest group so the UI stays in sync.

   `TEST/flexways/qa` creates all three levels in one call. Sibling lookups are scoped to the current parent only, so `/a/b` and `/x/b` resolve to different `b` groups.

## Backend

- New Tauri command `create_group_path(path, parent_id?)` that walks the path segment-by-segment, calling the existing `create_connection_group` for any segment that does not already exist under the resolved parent. It reuses the same per-parent `sort_order` logic, so siblings land at the end of their own chain.
- Helpers:
  - `parse_group_path` — splits on `/`, trims whitespace, drops empty segments, rejects an empty result.
  - `find_child_group` — case-insensitive, parent-scoped lookup.
- 6 new unit tests in `group_tree_tests` covering the parser (split on `/`, trim + drop empty, reject empty, keep single segment) and the lookup (case-insensitive, parent-scoped).

## Frontend

- `GroupHeader` gains an optional `onCreateSubgroup` prop and renders the new `Plus` button before the `MoreVertical` menu trigger.
- `DatabaseContext` + `DatabaseProvider` expose `createGroupPath` which invokes the new command and re-fetches `get_connection_groups` so the UI reflects reused + newly created segments in one render.
- `Connections.tsx` wires the inline subgroup input and replaces the toolbar "New group" handler with `createGroupPath` so the same path semantics apply at the top level.

## i18n

- New key `groups.subgroupNamePrompt` in `en, de, fr, ja, ru, zh`. The `es` and `it` locales were already missing the `groups` namespace after #1, so they keep falling back to the `defaultValue`.

## Testing

- `cargo test --lib`: **704/704** pass (the 6 new tests included).
- `pnpm tsc --noEmit`: clean.
- `pnpm vitest run`: 2616/2616.