### PR TITLE
fix: manual update check no longer hidden by a dismissed version

### DIFF
--- a/src/contexts/UpdateProvider.tsx
+++ b/src/contexts/UpdateProvider.tsx
@@ -38,17 +38,24 @@ export const UpdateProvider = ({ children }: { children: ReactNode }) => {
         force,
       });
       if (result.hasUpdate) {
-        // Check if user dismissed this version
-        const config = await invoke<{ lastDismissedVersion: string }>(
-          "get_config",
-        );
-        if (config.lastDismissedVersion !== result.latestVersion) {
-          setUpdateInfo(result);
-          setIsUpToDate(false);
-        } else {
-          // Version was dismissed, show up to date
+        // A manual check (force) always surfaces an available update. Only a
+        // background check honours a previous "remind me later" dismissal,
+        // otherwise the button would keep reporting "up to date" forever once
+        // a version has been dismissed.
+        let dismissed = false;
+        if (!force) {
+          const config = await invoke<{ lastDismissedVersion: string }>(
+            "get_config",
+          );
+          dismissed = config.lastDismissedVersion === result.latestVersion;
+        }
+
+        if (dismissed) {
           setUpdateInfo(null);
           setIsUpToDate(true);
+        } else {
+          setUpdateInfo(result);
+          setIsUpToDate(false);
         }
       } else {
         // No update available

--- a/tests/contexts/UpdateProvider.test.tsx
+++ b/tests/contexts/UpdateProvider.test.tsx
@@ -140,6 +140,50 @@ describe("UpdateProvider", () => {
     });
   });
 
+  it("should surface a dismissed version on a manual (forced) check", async () => {
+    const mockUpdateResult: UpdateCheckResult = {
+      hasUpdate: true,
+      currentVersion: "1.0.0",
+      latestVersion: "1.1.0",
+      releaseNotes: "New features",
+      releaseUrl: "https://github.com/user/repo/releases/tag/v1.1.0",
+      publishedAt: "2024-01-01T00:00:00Z",
+      downloadUrls: [],
+    };
+
+    const getConfig = vi.fn(() =>
+      Promise.resolve({
+        lastDismissedVersion: "1.1.0",
+        autoCheckUpdatesOnStartup: false,
+      }),
+    );
+
+    vi.mocked(invoke).mockImplementation((cmd: string) => {
+      if (cmd === "get_installation_source") return Promise.resolve(null);
+      if (cmd === "check_for_updates") return Promise.resolve(mockUpdateResult);
+      if (cmd === "get_config") return getConfig();
+      return Promise.reject(new Error(`Unexpected command: ${cmd}`));
+    });
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(UpdateProvider, null, children);
+
+    const { result } = renderHook(() => useUpdate(), { wrapper });
+
+    await act(async () => {
+      await result.current.checkForUpdates(true);
+    });
+
+    await waitFor(() => {
+      expect(result.current.updateInfo).not.toBeNull();
+      expect(result.current.updateInfo?.latestVersion).toBe("1.1.0");
+      expect(result.current.isUpToDate).toBe(false);
+    });
+
+    // A forced check must not consult the dismissed-version config at all.
+    expect(getConfig).not.toHaveBeenCalled();
+  });
+
   it("should show up to date when no update available", async () => {
     const mockUpdateResult: UpdateCheckResult = {
       hasUpdate: false,


### PR DESCRIPTION
## What

"Check for Updates Now" in Settings → Info kept showing "You're up to date" even when a newer release was available.

## Why it happens

The version check itself works fine: `check_for_updates` hits the GitHub API, compares the tags and correctly returns `hasUpdate: true`. The problem is in `UpdateProvider.checkForUpdates`, which sits in front of that result.

Whenever the update notification modal is closed — either via the X or the "Remind me later" button — `dismissUpdate` persists the version into `lastDismissedVersion`. From that point on, `checkForUpdates` compares the latest version against the dismissed one and, on a match, forces the UI into the "up to date" state regardless of `hasUpdate`.

That guard is reasonable for the automatic startup check, but it also swallowed the explicit, user-initiated check. So once you closed the notification for, say, 0.13.3, the button would never offer it again — exactly the behaviour reported on Windows 11 going from 0.13.2 to 0.13.3.

## The fix

The dismissal is now only honoured for background startup checks. A manual check (the `force` path used by the button) always surfaces an available update and skips the `lastDismissedVersion` lookup entirely — if you explicitly ask whether there's an update, you get the real answer.

## Testing

- Added a `UpdateProvider` test covering a forced check against a previously dismissed version (it must show the update and must not read the config).
- Existing tests, including the background "don't show a dismissed version" case, still pass.

Closes #397
