### PR TITLE
fix(postgres): resolve view definition lookup for qualified view names

### DIFF
--- a/src-tauri/src/drivers/postgres/mod.rs
+++ b/src-tauri/src/drivers/postgres/mod.rs
@@ -1006,7 +1006,7 @@ pub async fn get_view_definition(
 
     let row = client
         .query_one(
-            "SELECT pg_get_viewdef($1::regclass, true) as definition",
+            "SELECT pg_get_viewdef(($1::text)::regclass, true) as definition",
             &[&qualified],
         )
         .await


### PR DESCRIPTION
## Summary

Fetching a PostgreSQL view definition could fail because of how the view name parameter was passed to `pg_get_viewdef`.

The query used `pg_get_viewdef($1::regclass, true)`. Since the value is sent through the extended query protocol as a bound parameter, the `::regclass` cast was applied to a parameter the server treated as `regclass` rather than to the text we actually send. For schema-qualified view names this caused the lookup to fail instead of resolving the view.

## Fix

Cast the bound parameter to `text` first and then to `regclass`:

```sql
SELECT pg_get_viewdef(($1::text)::regclass, true) as definition
```

This makes the parameter bind as text, after which `regclass` resolution runs on the qualified name as intended.

## Testing

- Opened a PostgreSQL connection and viewed the definition of schema-qualified views, which now load correctly.
