### PR TITLE
feat(sidebar): keyboard shortcut to focus the table filter

### DIFF
--- a/src/components/layout/ExplorerSidebar.tsx
+++ b/src/components/layout/ExplorerSidebar.tsx
@@ -332,6 +332,21 @@ export const ExplorerSidebar = ({ sidebarWidth, startResize, onCollapse, sidebar
     return () => window.removeEventListener("tabularis:paste-import", handler);
   }, [activeConnectionId, activeCapabilities]);
 
+  // Focus the first visible "Filter tables…" input (flat / per-schema / per-db
+  // layouts) when the focus_table_filter shortcut fires.
+  useEffect(() => {
+    const handler = () => {
+      const input = sidebarBodyRef.current?.querySelector<HTMLInputElement>(
+        "[data-table-filter]",
+      );
+      input?.focus();
+      input?.select();
+    };
+    window.addEventListener("tabularis:focus-table-filter", handler);
+    return () =>
+      window.removeEventListener("tabularis:focus-table-filter", handler);
+  }, []);
+
   const handleTableClick = (tableName: string, schema?: string) => {
     setActiveTable(tableName, schema);
   };
@@ -1438,6 +1453,7 @@ export const ExplorerSidebar = ({ sidebarWidth, startResize, onCollapse, sidebar
                           <Search size={11} className="absolute left-2 text-muted pointer-events-none" />
                           <input
                             type="text"
+                            data-table-filter
                             value={tableFilter}
                             onChange={(e) => setTableFilter(e.target.value)}
                             placeholder={t("sidebar.filterTables")}

--- a/src/components/layout/sidebar/SidebarDatabaseItem.tsx
+++ b/src/components/layout/sidebar/SidebarDatabaseItem.tsx
@@ -265,6 +265,7 @@ export const SidebarDatabaseItem = ({
                       <Search size={11} className="absolute left-2 text-muted pointer-events-none" />
                       <input
                         type="text"
+                        data-table-filter
                         value={tableFilter}
                         onChange={(e) => setTableFilter(e.target.value)}
                         placeholder={t("sidebar.filterTables")}

--- a/src/components/layout/sidebar/SidebarSchemaItem.tsx
+++ b/src/components/layout/sidebar/SidebarSchemaItem.tsx
@@ -223,6 +223,7 @@ export const SidebarSchemaItem = ({
                       <Search size={11} className="absolute left-2 text-muted pointer-events-none" />
                       <input
                         type="text"
+                        data-table-filter
                         value={tableFilter}
                         onChange={(e) => setTableFilter(e.target.value)}
                         placeholder={t("sidebar.filterTables")}

--- a/src/config/shortcuts.json
+++ b/src/config/shortcuts.json
@@ -100,6 +100,16 @@
     "overridable": true
   },
   {
+    "id": "focus_table_filter",
+    "category": "navigation",
+    "defaultMac": "⌘+Shift+F",
+    "defaultWin": "Ctrl+Shift+F",
+    "macMatch": { "metaKey": true, "shiftKey": true, "key": "f" },
+    "winMatch": { "ctrlKey": true, "shiftKey": true, "key": "f" },
+    "i18nKey": "settings.shortcuts.focusTableFilter",
+    "overridable": true
+  },
+  {
     "id": "open_connections",
     "category": "navigation",
     "defaultMac": "⌘+Shift+C",

--- a/src/hooks/useGlobalShortcuts.ts
+++ b/src/hooks/useGlobalShortcuts.ts
@@ -17,11 +17,13 @@ export function useGlobalShortcuts() {
       // Don't fire when typing in inputs / textareas / contenteditable (except for the quick navigator)
       const target = e.target as HTMLElement;
       const isQuickNavigator = matchesShortcut(e, "quick_navigator");
+      const isFocusTableFilter = matchesShortcut(e, "focus_table_filter");
       if (
         (target.tagName === "INPUT" ||
         target.tagName === "TEXTAREA" ||
         target.isContentEditable) &&
-        !isQuickNavigator
+        !isQuickNavigator &&
+        !isFocusTableFilter
       ) {
         return;
       }
@@ -29,6 +31,12 @@ export function useGlobalShortcuts() {
       if (matchesShortcut(e, "toggle_sidebar")) {
         e.preventDefault();
         window.dispatchEvent(new CustomEvent("tabularis:toggle-sidebar"));
+        return;
+      }
+
+      if (matchesShortcut(e, "focus_table_filter")) {
+        e.preventDefault();
+        window.dispatchEvent(new CustomEvent("tabularis:focus-table-filter"));
         return;
       }
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -572,6 +572,7 @@
       "tabSwitcher": "Tab wechseln",
       "copySelection": "Auswahl kopieren",
       "toggleSidebar": "Seitenleiste umschalten",
+      "focusTableFilter": "Tabellenfilter fokussieren",
       "openConnections": "Verbindungen öffnen",
       "newConnection": "Neue Verbindung",
       "newTab": "Neuer Tab",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -605,6 +605,7 @@
       "tabSwitcher": "Switch tab",
       "copySelection": "Copy selection",
       "toggleSidebar": "Toggle sidebar",
+      "focusTableFilter": "Focus table filter",
       "openConnections": "Open connections",
       "newConnection": "New connection",
       "newTab": "New tab",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -577,6 +577,7 @@
       "tabSwitcher": "Cambiar pestaña",
       "copySelection": "Copiar selección",
       "toggleSidebar": "Mostrar/ocultar barra lateral",
+      "focusTableFilter": "Enfocar el filtro de tablas",
       "openConnections": "Abrir conexiones",
       "newConnection": "Nueva conexión",
       "newTab": "Nueva pestaña",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -572,6 +572,7 @@
       "tabSwitcher": "Changer d’onglet",
       "copySelection": "Copier la sélection",
       "toggleSidebar": "Afficher/masquer la barre latérale",
+      "focusTableFilter": "Focaliser le filtre de tables",
       "openConnections": "Ouvrir les connexions",
       "newConnection": "Nouvelle connexion",
       "newTab": "Nouvel onglet",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -577,6 +577,7 @@
       "tabSwitcher": "Cambia tab",
       "copySelection": "Copia selezione",
       "toggleSidebar": "Mostra/nascondi sidebar",
+      "focusTableFilter": "Focalizza il filtro tabelle",
       "openConnections": "Apri connessioni",
       "newConnection": "Nuova connessione",
       "newTab": "Nuovo tab",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -586,6 +586,7 @@
       "tabSwitcher": "タブを切り替え",
       "copySelection": "選択範囲をコピー",
       "toggleSidebar": "サイドバーを切り替え",
+      "focusTableFilter": "テーブルフィルターにフォーカス",
       "openConnections": "接続を開く",
       "newConnection": "新規接続",
       "newTab": "新規タブ",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -567,6 +567,7 @@
       "tabSwitcher": "Переключить вкладку",
       "copySelection": "Копировать выделение",
       "toggleSidebar": "Показать/скрыть боковую панель",
+      "focusTableFilter": "Фокус на фильтре таблиц",
       "openConnections": "Открыть подключения",
       "newConnection": "Новое подключение",
       "newTab": "Новая вкладка",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -541,6 +541,7 @@
       "tabSwitcher": "切换标签",
       "copySelection": "复制选区",
       "toggleSidebar": "切换侧边栏",
+      "focusTableFilter": "聚焦表格筛选",
       "openConnections": "打开连接",
       "newConnection": "新建连接",
       "newTab": "新建标签",


### PR DESCRIPTION
## Summary
Today the only way to reach the sidebar's "Filter tables…" input is with the mouse. This adds a keyboard shortcut — **⌘⇧F / Ctrl+Shift+F** — that focuses it.

## Changes
- New `focus_table_filter` shortcut in `shortcuts.json` (navigation, `overridable`) — so it shows up under **Settings → Shortcuts** and can be rebound.
- Handled in `useGlobalShortcuts`: it dispatches a `tabularis:focus-table-filter` event and is whitelisted in the "ignore while typing" guard (like the Quick Navigator), so you can jump to the filter even from the SQL editor.
- `ExplorerSidebar` focuses (and selects) the first visible "Filter tables…" input. That input is rendered three ways — flat (MySQL/SQLite), per-schema (Postgres), and per-database (multi-DB) — so it's targeted via a stable `data-table-filter` attribute rather than the translated placeholder.
- i18n: `settings.shortcuts.focusTableFilter` added to all 8 locales.