### PR TITLE
feat(navigator): fuzzy search in the Quick Navigator

### DIFF
--- a/src/utils/quickNavigator.ts
+++ b/src/utils/quickNavigator.ts
@@ -1,4 +1,5 @@
 import type { TableInfo, ViewInfo, RoutineInfo, TriggerInfo, SchemaData } from '../contexts/DatabaseContext';
+import { fuzzyFilter } from './fuzzy';
 
 export interface NavigatorItem {
   name: string;
@@ -158,11 +159,7 @@ export function getNavigatorItems(params: NavigatorItemParams): NavigatorItem[] 
 }
 
 export function filterNavigatorItems(items: NavigatorItem[], search: string): NavigatorItem[] {
-  if (!search) return items;
-  const lowerSearch = search.toLowerCase();
-  return items.filter((item) => {
-    const matchName = item.name.toLowerCase().includes(lowerSearch);
-    const matchSchema = item.schema?.toLowerCase().includes(lowerSearch);
-    return matchName || matchSchema;
-  });
+  return fuzzyFilter(items, search, (item) =>
+    item.schema ? `${item.name} ${item.schema}` : item.name,
+  );
 }

--- a/tests/utils/quickNavigator.test.ts
+++ b/tests/utils/quickNavigator.test.ts
@@ -135,5 +135,11 @@ describe("quickNavigator utility", () => {
       expect(result).toHaveLength(1);
       expect(result[0].name).toBe("user_sessions");
     });
+
+    it("should tolerate typos", () => {
+      const result = filterNavigatorItems(mockItems, "sesion").map((i) => i.name);
+      expect(result).toContain("user_sessions");
+      expect(result).toContain("active_sessions");
+    });
   });
 });


### PR DESCRIPTION
## Summary
Follow-up to #417 (fuzzy search for the sidebar filters). The Quick Navigator (⌘P) still did a strict substring match — this routes it through the same shared `fuzzyFilter` helper, so it's now **typo-tolerant** and ranks the closest matches first.

## Changes
- `filterNavigatorItems` now uses `fuzzyFilter` (Fuse.js), searching a combined `name + schema` string — this preserves the previous "match name *or* schema" behaviour, now fuzzy and relevance-ranked.
- Added a typo-tolerance test; the existing name/schema tests pass unchanged.