### PR TITLE
Confirm before running destructive queries (missing WHERE, DROP, TRUNCATE)

### DIFF
--- a/src/components/modals/ConfirmModal.tsx
+++ b/src/components/modals/ConfirmModal.tsx
@@ -1,16 +1,26 @@
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AlertTriangle, X } from "lucide-react";
 import { Modal } from "../ui/Modal";
+import { SqlPreview } from "../ui/SqlPreview";
 
 interface ConfirmModalProps {
   isOpen: boolean;
   onClose: () => void;
   title: string;
   message: string;
+  /** Optional SQL shown in a read-only preview below the message. */
+  sql?: string;
   confirmLabel?: string;
   confirmClassName?: string;
   onConfirm: () => void;
   variant?: "danger" | "warning" | "info";
+  /**
+   * When set, the confirm button stays disabled for this many seconds after the
+   * modal opens, showing a countdown. Gives the user a beat to actually read the
+   * message before confirming a destructive action.
+   */
+  confirmDelaySeconds?: number;
 }
 
 export const ConfirmModal = ({
@@ -18,12 +28,33 @@ export const ConfirmModal = ({
   onClose,
   title,
   message,
+  sql,
   confirmLabel,
   confirmClassName,
   onConfirm,
   variant = "danger",
+  confirmDelaySeconds,
 }: ConfirmModalProps) => {
   const { t } = useTranslation();
+  const [remaining, setRemaining] = useState(confirmDelaySeconds ?? 0);
+
+  // Reset the countdown whenever the modal transitions to open — done during
+  // render (React's recommended pattern) rather than in an effect.
+  const [prevOpen, setPrevOpen] = useState(isOpen);
+  if (isOpen !== prevOpen) {
+    setPrevOpen(isOpen);
+    setRemaining(isOpen ? (confirmDelaySeconds ?? 0) : 0);
+  }
+
+  useEffect(() => {
+    if (!isOpen || !confirmDelaySeconds) return;
+    const interval = setInterval(() => {
+      setRemaining((prev) => (prev <= 1 ? 0 : prev - 1));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [isOpen, confirmDelaySeconds]);
+
+  const isCountingDown = remaining > 0;
 
   const variantStyles = {
     danger: {
@@ -62,8 +93,9 @@ export const ConfirmModal = ({
         </div>
 
         {/* Content */}
-        <div className="p-6">
+        <div className="p-6 space-y-4">
           <p className="text-sm text-secondary leading-relaxed">{message}</p>
+          {sql && <SqlPreview sql={sql} height="120px" />}
         </div>
 
         {/* Footer */}
@@ -76,12 +108,15 @@ export const ConfirmModal = ({
           </button>
           <button
             onClick={onConfirm}
-            className={
+            disabled={isCountingDown}
+            className={`${
               confirmClassName ??
               `px-4 py-2 ${currentVariant.button} text-white rounded-lg text-sm font-medium transition-colors`
-            }
+            } disabled:opacity-50 disabled:cursor-not-allowed`}
           >
-            {confirmLabel ?? (variant === "danger" ? t("common.delete") : t("common.ok"))}
+            {isCountingDown
+              ? `${confirmLabel ?? (variant === "danger" ? t("common.delete") : t("common.ok"))} (${remaining})`
+              : (confirmLabel ?? (variant === "danger" ? t("common.delete") : t("common.ok")))}
           </button>
         </div>
       </div>

--- a/src/components/notebook/NotebookView.tsx
+++ b/src/components/notebook/NotebookView.tsx
@@ -63,6 +63,8 @@ import { isMultiDatabaseCapable } from "../../utils/database";
 import { useSettings } from "../../hooks/useSettings";
 import { useAlert } from "../../hooks/useAlert";
 import { useKeybindings } from "../../hooks/useKeybindings";
+import { useDangerousQueryGuard } from "../../hooks/useDangerousQueryGuard";
+import { ConfirmModal } from "../modals/ConfirmModal";
 import { NotebookToolbar } from "./NotebookToolbar";
 import { NotebookHistoryPanel } from "./NotebookHistoryPanel";
 import { NotebookCellWrapper } from "./NotebookCellWrapper";
@@ -98,6 +100,11 @@ export function NotebookView({
   const { settings } = useSettings();
   const { showAlert } = useAlert();
   const { matchesShortcut } = useKeybindings();
+  const {
+    isPending: isDangerousQueryPending,
+    guardQuery: guardDangerousQuery,
+    resolve: resolveDangerousQuery,
+  } = useDangerousQueryGuard();
 
   // Local notebook state — loaded from store/disk, NOT from tab
   const [notebook, setNotebook] = useState<NotebookState | null>(() =>
@@ -356,6 +363,11 @@ export function NotebookView({
         return;
       }
 
+      if (!(await guardDangerousQuery(resolvedSql))) {
+        updateCell(cellId, { isLoading: false });
+        return;
+      }
+
       const start = performance.now();
       try {
         const res = await invoke<QueryResult>("execute_query", {
@@ -409,6 +421,7 @@ export function NotebookView({
       settings.resultPageSize,
       updateCell,
       params,
+      guardDangerousQuery,
     ],
   );
 
@@ -820,6 +833,15 @@ export function NotebookView({
 
   return (
     <div className="flex flex-col h-full relative">
+      <ConfirmModal
+        isOpen={isDangerousQueryPending}
+        onClose={() => resolveDangerousQuery(false)}
+        onConfirm={() => resolveDangerousQuery(true)}
+        title={t("editor.dangerousQueryTitle")}
+        message={t("editor.dangerousQueryMessage")}
+        confirmLabel={t("editor.dangerousQueryConfirm")}
+        variant="danger"
+      />
       <NotebookToolbar {...toolbarProps} />
       {showHistory && (
         <NotebookHistoryPanel

--- a/src/components/notebook/NotebookView.tsx
+++ b/src/components/notebook/NotebookView.tsx
@@ -63,7 +63,10 @@ import { isMultiDatabaseCapable } from "../../utils/database";
 import { useSettings } from "../../hooks/useSettings";
 import { useAlert } from "../../hooks/useAlert";
 import { useKeybindings } from "../../hooks/useKeybindings";
-import { useDangerousQueryGuard } from "../../hooks/useDangerousQueryGuard";
+import {
+  useDangerousQueryGuard,
+  DANGEROUS_QUERY_I18N,
+} from "../../hooks/useDangerousQueryGuard";
 import { ConfirmModal } from "../modals/ConfirmModal";
 import { NotebookToolbar } from "./NotebookToolbar";
 import { NotebookHistoryPanel } from "./NotebookHistoryPanel";
@@ -101,7 +104,7 @@ export function NotebookView({
   const { showAlert } = useAlert();
   const { matchesShortcut } = useKeybindings();
   const {
-    isPending: isDangerousQueryPending,
+    pending: dangerousQuery,
     guardQuery: guardDangerousQuery,
     resolve: resolveDangerousQuery,
   } = useDangerousQueryGuard();
@@ -834,13 +837,23 @@ export function NotebookView({
   return (
     <div className="flex flex-col h-full relative">
       <ConfirmModal
-        isOpen={isDangerousQueryPending}
+        isOpen={!!dangerousQuery}
         onClose={() => resolveDangerousQuery(false)}
         onConfirm={() => resolveDangerousQuery(true)}
-        title={t("editor.dangerousQueryTitle")}
-        message={t("editor.dangerousQueryMessage")}
+        title={t(
+          dangerousQuery
+            ? DANGEROUS_QUERY_I18N[dangerousQuery.kind].title
+            : "editor.dangerousQueryTitle",
+        )}
+        message={t(
+          dangerousQuery
+            ? DANGEROUS_QUERY_I18N[dangerousQuery.kind].message
+            : "editor.dangerousQueryMessage",
+        )}
+        sql={dangerousQuery?.sql}
         confirmLabel={t("editor.dangerousQueryConfirm")}
         variant="danger"
+        confirmDelaySeconds={5}
       />
       <NotebookToolbar {...toolbarProps} />
       {showHistory && (

--- a/src/hooks/useDangerousQueryGuard.ts
+++ b/src/hooks/useDangerousQueryGuard.ts
@@ -1,41 +1,87 @@
 import { useCallback, useRef, useState } from "react";
-import { isDestructiveWithoutWhere } from "../utils/sqlAnalysis";
+import {
+  classifyDangerousQuery,
+  type DangerousQueryKind,
+} from "../utils/sqlAnalysis";
+
+/** Details about the dangerous statement that triggered a confirmation. */
+export interface DangerousQueryInfo {
+  /** Why the statement was flagged — drives the dialog copy. */
+  kind: DangerousQueryKind;
+  /** The flagged statement itself, shown to the user as a preview. */
+  sql: string;
+  /** How many statements in the batch were flagged (>= 1). */
+  count: number;
+}
+
+/** i18n key pairs for each danger kind, shared by every consumer of the guard. */
+export const DANGEROUS_QUERY_I18N: Record<
+  DangerousQueryKind,
+  { title: string; message: string }
+> = {
+  "no-where": {
+    title: "editor.dangerousQueryTitle",
+    message: "editor.dangerousQueryMessage",
+  },
+  drop: {
+    title: "editor.dangerousQueryDropTitle",
+    message: "editor.dangerousQueryDropMessage",
+  },
+  truncate: {
+    title: "editor.dangerousQueryTruncateTitle",
+    message: "editor.dangerousQueryTruncateMessage",
+  },
+};
 
 /**
- * Gates execution of DELETE/UPDATE statements with no WHERE clause behind a
- * user confirmation. `guardQuery` resolves immediately (no dialog) for safe
- * statements; for dangerous ones it opens the dialog and resolves once the
- * user answers. A second dangerous statement submitted while a dialog is
- * already open is declined immediately instead of replacing the pending
- * one, so the first caller's promise always settles.
+ * Gates execution of dangerous statements (DELETE/UPDATE with no WHERE, DROP,
+ * TRUNCATE) behind a user confirmation. `guardQuery` resolves immediately (no
+ * dialog) for safe statements; for dangerous ones it opens the dialog and
+ * resolves once the user answers. A second dangerous statement submitted while
+ * a dialog is already open is declined immediately instead of replacing the
+ * pending one, so the first caller's promise always settles.
  */
 export function useDangerousQueryGuard() {
-  const [isPending, setIsPending] = useState(false);
+  const [pending, setPending] = useState<DangerousQueryInfo | null>(null);
   const resolverRef = useRef<((confirmed: boolean) => void) | null>(null);
 
-  const requestConfirmation = useCallback((): Promise<boolean> => {
-    if (resolverRef.current) return Promise.resolve(false);
-    return new Promise((resolve) => {
-      resolverRef.current = resolve;
-      setIsPending(true);
-    });
-  }, []);
+  const requestConfirmation = useCallback(
+    (info: DangerousQueryInfo): Promise<boolean> => {
+      if (resolverRef.current) return Promise.resolve(false);
+      return new Promise((resolve) => {
+        resolverRef.current = resolve;
+        setPending(info);
+      });
+    },
+    [],
+  );
 
   const resolve = useCallback((confirmed: boolean) => {
     resolverRef.current?.(confirmed);
     resolverRef.current = null;
-    setIsPending(false);
+    setPending(null);
   }, []);
 
   const guardQuery = useCallback(
     (sqlOrQueries: string | string[]): Promise<boolean> => {
-      const isDangerous = Array.isArray(sqlOrQueries)
-        ? sqlOrQueries.some(isDestructiveWithoutWhere)
-        : isDestructiveWithoutWhere(sqlOrQueries);
-      return isDangerous ? requestConfirmation() : Promise.resolve(true);
+      const statements = Array.isArray(sqlOrQueries)
+        ? sqlOrQueries
+        : [sqlOrQueries];
+
+      let first: DangerousQueryInfo | null = null;
+      let count = 0;
+      for (const sql of statements) {
+        const kind = classifyDangerousQuery(sql);
+        if (!kind) continue;
+        count++;
+        if (!first) first = { kind, sql, count: 0 };
+      }
+
+      if (!first) return Promise.resolve(true);
+      return requestConfirmation({ ...first, count });
     },
     [requestConfirmation],
   );
 
-  return { isPending, guardQuery, resolve };
+  return { pending, isPending: pending !== null, guardQuery, resolve };
 }

--- a/src/hooks/useDangerousQueryGuard.ts
+++ b/src/hooks/useDangerousQueryGuard.ts
@@ -1,0 +1,41 @@
+import { useCallback, useRef, useState } from "react";
+import { isDestructiveWithoutWhere } from "../utils/sqlAnalysis";
+
+/**
+ * Gates execution of DELETE/UPDATE statements with no WHERE clause behind a
+ * user confirmation. `guardQuery` resolves immediately (no dialog) for safe
+ * statements; for dangerous ones it opens the dialog and resolves once the
+ * user answers. A second dangerous statement submitted while a dialog is
+ * already open is declined immediately instead of replacing the pending
+ * one, so the first caller's promise always settles.
+ */
+export function useDangerousQueryGuard() {
+  const [isPending, setIsPending] = useState(false);
+  const resolverRef = useRef<((confirmed: boolean) => void) | null>(null);
+
+  const requestConfirmation = useCallback((): Promise<boolean> => {
+    if (resolverRef.current) return Promise.resolve(false);
+    return new Promise((resolve) => {
+      resolverRef.current = resolve;
+      setIsPending(true);
+    });
+  }, []);
+
+  const resolve = useCallback((confirmed: boolean) => {
+    resolverRef.current?.(confirmed);
+    resolverRef.current = null;
+    setIsPending(false);
+  }, []);
+
+  const guardQuery = useCallback(
+    (sqlOrQueries: string | string[]): Promise<boolean> => {
+      const isDangerous = Array.isArray(sqlOrQueries)
+        ? sqlOrQueries.some(isDestructiveWithoutWhere)
+        : isDestructiveWithoutWhere(sqlOrQueries);
+      return isDangerous ? requestConfirmation() : Promise.resolve(true);
+    },
+    [requestConfirmation],
+  );
+
+  return { isPending, guardQuery, resolve };
+}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -880,6 +880,10 @@
     "dangerousQueryTitle": "Ohne WHERE-Klausel ausführen?",
     "dangerousQueryMessage": "Diese Anweisung betrifft alle Zeilen der Tabelle, da keine WHERE-Klausel vorhanden ist. Dies kann nicht rückgängig gemacht werden.",
     "dangerousQueryConfirm": "Trotzdem ausführen",
+    "dangerousQueryDropTitle": "Dieses Objekt löschen?",
+    "dangerousQueryDropMessage": "DROP entfernt dieses Objekt und alle seine Daten dauerhaft. Dies kann nicht rückgängig gemacht werden.",
+    "dangerousQueryTruncateTitle": "Diese Tabelle leeren?",
+    "dangerousQueryTruncateMessage": "TRUNCATE löscht alle Zeilen der Tabelle. Dies kann nicht rückgängig gemacht werden.",
     "showErrorDetails": "Details anzeigen",
     "hideErrorDetails": "Details ausblenden",
     "errorBoundary": {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -877,6 +877,9 @@
     "saveThisQuery": "Diese Abfrage speichern",
     "noValidQueries": "Keine gültigen Abfragen gefunden",
     "queryFailed": "Abfrage fehlgeschlagen.",
+    "dangerousQueryTitle": "Ohne WHERE-Klausel ausführen?",
+    "dangerousQueryMessage": "Diese Anweisung betrifft alle Zeilen der Tabelle, da keine WHERE-Klausel vorhanden ist. Dies kann nicht rückgängig gemacht werden.",
+    "dangerousQueryConfirm": "Trotzdem ausführen",
     "showErrorDetails": "Details anzeigen",
     "hideErrorDetails": "Details ausblenden",
     "errorBoundary": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -893,6 +893,9 @@
     "saveThisQuery": "Save this query",
     "noValidQueries": "No valid queries found",
     "queryFailed": "Query failed.",
+    "dangerousQueryTitle": "Run without a WHERE clause?",
+    "dangerousQueryMessage": "This statement will affect every row in the table because it has no WHERE clause. This cannot be undone.",
+    "dangerousQueryConfirm": "Run anyway",
     "showErrorDetails": "Show details",
     "hideErrorDetails": "Hide details",
     "errorBoundary": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -896,6 +896,10 @@
     "dangerousQueryTitle": "Run without a WHERE clause?",
     "dangerousQueryMessage": "This statement will affect every row in the table because it has no WHERE clause. This cannot be undone.",
     "dangerousQueryConfirm": "Run anyway",
+    "dangerousQueryDropTitle": "Drop this object?",
+    "dangerousQueryDropMessage": "DROP permanently removes this object and all of its data. This cannot be undone.",
+    "dangerousQueryTruncateTitle": "Truncate this table?",
+    "dangerousQueryTruncateMessage": "TRUNCATE deletes every row in the table. This cannot be undone.",
     "showErrorDetails": "Show details",
     "hideErrorDetails": "Hide details",
     "errorBoundary": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -878,6 +878,10 @@
     "dangerousQueryTitle": "¿Ejecutar sin cláusula WHERE?",
     "dangerousQueryMessage": "Esta sentencia afectará a todas las filas de la tabla porque no tiene una cláusula WHERE. Esta acción no se puede deshacer.",
     "dangerousQueryConfirm": "Ejecutar de todos modos",
+    "dangerousQueryDropTitle": "¿Eliminar este objeto?",
+    "dangerousQueryDropMessage": "DROP elimina de forma permanente este objeto y todos sus datos. Esta acción no se puede deshacer.",
+    "dangerousQueryTruncateTitle": "¿Vaciar esta tabla?",
+    "dangerousQueryTruncateMessage": "TRUNCATE elimina todas las filas de la tabla. Esta acción no se puede deshacer.",
     "showErrorDetails": "Mostrar detalles",
     "hideErrorDetails": "Ocultar detalles",
     "errorBoundary": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -875,6 +875,9 @@
     "saveThisQuery": "Guardar esta consulta",
     "noValidQueries": "No se encontraron consultas válidas",
     "queryFailed": "La consulta falló.",
+    "dangerousQueryTitle": "¿Ejecutar sin cláusula WHERE?",
+    "dangerousQueryMessage": "Esta sentencia afectará a todas las filas de la tabla porque no tiene una cláusula WHERE. Esta acción no se puede deshacer.",
+    "dangerousQueryConfirm": "Ejecutar de todos modos",
     "showErrorDetails": "Mostrar detalles",
     "hideErrorDetails": "Ocultar detalles",
     "errorBoundary": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -880,6 +880,10 @@
     "dangerousQueryTitle": "Exécuter sans clause WHERE ?",
     "dangerousQueryMessage": "Cette instruction affectera toutes les lignes de la table car elle ne comporte pas de clause WHERE. Cette action est irréversible.",
     "dangerousQueryConfirm": "Exécuter quand même",
+    "dangerousQueryDropTitle": "Supprimer cet objet ?",
+    "dangerousQueryDropMessage": "DROP supprime définitivement cet objet et toutes ses données. Cette action est irréversible.",
+    "dangerousQueryTruncateTitle": "Vider cette table ?",
+    "dangerousQueryTruncateMessage": "TRUNCATE supprime toutes les lignes de la table. Cette action est irréversible.",
     "showErrorDetails": "Afficher les détails",
     "hideErrorDetails": "Masquer les détails",
     "errorBoundary": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -877,6 +877,9 @@
     "saveThisQuery": "Enregistrer cette requête",
     "noValidQueries": "Aucune requête valide trouvée",
     "queryFailed": "Échec de la requête.",
+    "dangerousQueryTitle": "Exécuter sans clause WHERE ?",
+    "dangerousQueryMessage": "Cette instruction affectera toutes les lignes de la table car elle ne comporte pas de clause WHERE. Cette action est irréversible.",
+    "dangerousQueryConfirm": "Exécuter quand même",
     "showErrorDetails": "Afficher les détails",
     "hideErrorDetails": "Masquer les détails",
     "errorBoundary": {

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -860,6 +860,9 @@
     "saveThisQuery": "Salva questa query",
     "noValidQueries": "Nessuna query valida trovata",
     "queryFailed": "Esecuzione query fallita.",
+    "dangerousQueryTitle": "Eseguire senza clausola WHERE?",
+    "dangerousQueryMessage": "Questa istruzione interesserà tutte le righe della tabella perché non ha una clausola WHERE. L'operazione non può essere annullata.",
+    "dangerousQueryConfirm": "Esegui comunque",
     "showErrorDetails": "Mostra dettagli",
     "hideErrorDetails": "Nascondi dettagli",
     "errorBoundary": {

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -863,6 +863,10 @@
     "dangerousQueryTitle": "Eseguire senza clausola WHERE?",
     "dangerousQueryMessage": "Questa istruzione interesserà tutte le righe della tabella perché non ha una clausola WHERE. L'operazione non può essere annullata.",
     "dangerousQueryConfirm": "Esegui comunque",
+    "dangerousQueryDropTitle": "Eliminare questo oggetto?",
+    "dangerousQueryDropMessage": "DROP rimuove in modo permanente questo oggetto e tutti i suoi dati. L'operazione non può essere annullata.",
+    "dangerousQueryTruncateTitle": "Svuotare questa tabella?",
+    "dangerousQueryTruncateMessage": "TRUNCATE elimina tutte le righe della tabella. L'operazione non può essere annullata.",
     "showErrorDetails": "Mostra dettagli",
     "hideErrorDetails": "Nascondi dettagli",
     "errorBoundary": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -893,6 +893,10 @@
     "dangerousQueryTitle": "WHERE句なしで実行しますか？",
     "dangerousQueryMessage": "このステートメントにはWHERE句がないため、テーブルのすべての行に影響します。この操作は元に戻せません。",
     "dangerousQueryConfirm": "実行する",
+    "dangerousQueryDropTitle": "このオブジェクトを削除しますか？",
+    "dangerousQueryDropMessage": "DROP はこのオブジェクトとそのすべてのデータを完全に削除します。この操作は元に戻せません。",
+    "dangerousQueryTruncateTitle": "このテーブルを空にしますか？",
+    "dangerousQueryTruncateMessage": "TRUNCATE はテーブルのすべての行を削除します。この操作は元に戻せません。",
     "showErrorDetails": "詳細を表示",
     "hideErrorDetails": "詳細を非表示",
     "errorBoundary": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -890,6 +890,9 @@
     "saveThisQuery": "このクエリを保存",
     "noValidQueries": "有効なクエリが見つかりません",
     "queryFailed": "クエリが失敗しました。",
+    "dangerousQueryTitle": "WHERE句なしで実行しますか？",
+    "dangerousQueryMessage": "このステートメントにはWHERE句がないため、テーブルのすべての行に影響します。この操作は元に戻せません。",
+    "dangerousQueryConfirm": "実行する",
     "showErrorDetails": "詳細を表示",
     "hideErrorDetails": "詳細を非表示",
     "errorBoundary": {

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -875,6 +875,10 @@
     "dangerousQueryTitle": "Выполнить без условия WHERE?",
     "dangerousQueryMessage": "Этот запрос затронет все строки таблицы, так как в нём отсутствует условие WHERE. Это действие нельзя отменить.",
     "dangerousQueryConfirm": "Всё равно выполнить",
+    "dangerousQueryDropTitle": "Удалить этот объект?",
+    "dangerousQueryDropMessage": "DROP безвозвратно удаляет этот объект и все его данные. Это действие нельзя отменить.",
+    "dangerousQueryTruncateTitle": "Очистить эту таблицу?",
+    "dangerousQueryTruncateMessage": "TRUNCATE удаляет все строки таблицы. Это действие нельзя отменить.",
     "showErrorDetails": "Показать подробности",
     "hideErrorDetails": "Скрыть подробности",
     "errorBoundary": {

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -872,6 +872,9 @@
     "saveThisQuery": "Сохранить этот запрос",
     "noValidQueries": "Допустимые запросы не найдены",
     "queryFailed": "Ошибка выполнения запроса.",
+    "dangerousQueryTitle": "Выполнить без условия WHERE?",
+    "dangerousQueryMessage": "Этот запрос затронет все строки таблицы, так как в нём отсутствует условие WHERE. Это действие нельзя отменить.",
+    "dangerousQueryConfirm": "Всё равно выполнить",
     "showErrorDetails": "Показать подробности",
     "hideErrorDetails": "Скрыть подробности",
     "errorBoundary": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -848,6 +848,10 @@
     "dangerousQueryTitle": "不带 WHERE 子句执行？",
     "dangerousQueryMessage": "此语句没有 WHERE 子句，将影响表中的所有行。此操作无法撤销。",
     "dangerousQueryConfirm": "仍然执行",
+    "dangerousQueryDropTitle": "删除此对象？",
+    "dangerousQueryDropMessage": "DROP 会永久删除此对象及其所有数据。此操作无法撤销。",
+    "dangerousQueryTruncateTitle": "清空此表？",
+    "dangerousQueryTruncateMessage": "TRUNCATE 会删除表中的所有行。此操作无法撤销。",
     "showErrorDetails": "显示详情",
     "hideErrorDetails": "隐藏详情",
     "errorBoundary": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -845,6 +845,9 @@
     "saveThisQuery": "保存此查询",
     "noValidQueries": "未找到有效查询",
     "queryFailed": "查询失败。",
+    "dangerousQueryTitle": "不带 WHERE 子句执行？",
+    "dangerousQueryMessage": "此语句没有 WHERE 子句，将影响表中的所有行。此操作无法撤销。",
+    "dangerousQueryConfirm": "仍然执行",
     "showErrorDetails": "显示详情",
     "hideErrorDetails": "隐藏详情",
     "errorBoundary": {

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -5,6 +5,7 @@ import { reconstructTableQuery } from "../utils/editor";
 import { serializePkKey, buildPkMap } from "../utils/dataGrid";
 import { isMultiDatabaseCapable } from "../utils/database";
 import { isReadonly } from "../utils/driverCapabilities";
+import { useDangerousQueryGuard } from "../hooks/useDangerousQueryGuard";
 import {
   generateTempId,
   initializeNewRow,
@@ -59,6 +60,7 @@ import { MultiResultPanel } from "../components/ui/MultiResultPanel";
 import { ErrorDisplay } from "../components/ui/ErrorDisplay";
 import { NewRowModal } from "../components/modals/NewRowModal";
 import { QuerySelectionModal } from "../components/modals/QuerySelectionModal";
+import { ConfirmModal } from "../components/modals/ConfirmModal";
 import { ExplainSelectionModal } from "../components/modals/ExplainSelectionModal";
 import { TabSwitcherModal } from "../components/modals/TabSwitcherModal";
 import { QueryModal } from "../components/modals/QueryModal";
@@ -338,6 +340,11 @@ export const Editor = () => {
   const [selectableQueries, setSelectableQueries] = useState<string[]>([]);
   const [isQuerySelectionModalOpen, setIsQuerySelectionModalOpen] =
     useState(false);
+  const {
+    isPending: isDangerousQueryPending,
+    guardQuery: guardDangerousQuery,
+    resolve: resolveDangerousQuery,
+  } = useDangerousQueryGuard();
   const [isTabSwitcherOpen, setIsTabSwitcherOpen] = useState(false);
   const [isRunDropdownOpen, setIsRunDropdownOpen] = useState(false);
   const [isDbDropdownOpen, setIsDbDropdownOpen] = useState(false);
@@ -682,6 +689,8 @@ export const Editor = () => {
 
       if (!textToRun || !textToRun.trim()) return;
 
+      if (!(await guardDangerousQuery(textToRun))) return;
+
       // Check for parameters
       const params = extractQueryParams(textToRun);
       if (params.length > 0) {
@@ -854,6 +863,7 @@ export const Editor = () => {
       isMultiDb,
       activeDatabaseName,
       addHistoryEntry,
+      guardDangerousQuery,
     ],
   );
 
@@ -864,6 +874,8 @@ export const Editor = () => {
 
       const targetTab = tabsRef.current.find((t) => t.id === targetTabId);
       if (!targetTab) return;
+
+      if (!(await guardDangerousQuery(queries))) return;
 
       // Collect all unique parameters across all queries
       const allParams = [
@@ -1035,7 +1047,7 @@ export const Editor = () => {
       });
       updateTab(targetTabId, { isLoading: false });
     },
-    [activeConnectionId, updateTab, patchResultEntry, settings.resultPageSize, activeSchema, t, isMultiDb, activeDatabaseName, addHistoryEntry],
+    [activeConnectionId, updateTab, patchResultEntry, settings.resultPageSize, activeSchema, t, isMultiDb, activeDatabaseName, addHistoryEntry, guardDangerousQuery],
   );
 
   // Auto-run entry point for navigation-initiated executions (sidebar "open
@@ -3911,6 +3923,15 @@ export const Editor = () => {
           setIsQuerySelectionModalOpen(false);
         }}
         onClose={() => setIsQuerySelectionModalOpen(false)}
+      />
+      <ConfirmModal
+        isOpen={isDangerousQueryPending}
+        onClose={() => resolveDangerousQuery(false)}
+        onConfirm={() => resolveDangerousQuery(true)}
+        title={t("editor.dangerousQueryTitle")}
+        message={t("editor.dangerousQueryMessage")}
+        confirmLabel={t("editor.dangerousQueryConfirm")}
+        variant="danger"
       />
       <TabSwitcherModal
         isOpen={isTabSwitcherOpen}

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -5,7 +5,10 @@ import { reconstructTableQuery } from "../utils/editor";
 import { serializePkKey, buildPkMap } from "../utils/dataGrid";
 import { isMultiDatabaseCapable } from "../utils/database";
 import { isReadonly } from "../utils/driverCapabilities";
-import { useDangerousQueryGuard } from "../hooks/useDangerousQueryGuard";
+import {
+  useDangerousQueryGuard,
+  DANGEROUS_QUERY_I18N,
+} from "../hooks/useDangerousQueryGuard";
 import {
   generateTempId,
   initializeNewRow,
@@ -341,7 +344,7 @@ export const Editor = () => {
   const [isQuerySelectionModalOpen, setIsQuerySelectionModalOpen] =
     useState(false);
   const {
-    isPending: isDangerousQueryPending,
+    pending: dangerousQuery,
     guardQuery: guardDangerousQuery,
     resolve: resolveDangerousQuery,
   } = useDangerousQueryGuard();
@@ -3925,13 +3928,23 @@ export const Editor = () => {
         onClose={() => setIsQuerySelectionModalOpen(false)}
       />
       <ConfirmModal
-        isOpen={isDangerousQueryPending}
+        isOpen={!!dangerousQuery}
         onClose={() => resolveDangerousQuery(false)}
         onConfirm={() => resolveDangerousQuery(true)}
-        title={t("editor.dangerousQueryTitle")}
-        message={t("editor.dangerousQueryMessage")}
+        title={t(
+          dangerousQuery
+            ? DANGEROUS_QUERY_I18N[dangerousQuery.kind].title
+            : "editor.dangerousQueryTitle",
+        )}
+        message={t(
+          dangerousQuery
+            ? DANGEROUS_QUERY_I18N[dangerousQuery.kind].message
+            : "editor.dangerousQueryMessage",
+        )}
+        sql={dangerousQuery?.sql}
         confirmLabel={t("editor.dangerousQueryConfirm")}
         variant="danger"
+        confirmDelaySeconds={5}
       />
       <TabSwitcherModal
         isOpen={isTabSwitcherOpen}

--- a/src/utils/sqlAnalysis.ts
+++ b/src/utils/sqlAnalysis.ts
@@ -113,19 +113,39 @@ function hasTopLevelWhere(cleaned: string): boolean {
   return false;
 }
 
-// Flags DELETE/UPDATE statements with no top-level WHERE clause — the
-// classic "forgot the WHERE" accident that wipes or overwrites a whole
-// table.
-export const isDestructiveWithoutWhere = (sql: string): boolean => {
+// The distinct ways a statement can be flagged as dangerous. Each maps to its
+// own confirmation copy so the dialog can explain the specific risk.
+//   - 'no-where':  DELETE/UPDATE with no top-level WHERE (wipes a whole table)
+//   - 'drop':      DROP removes an object (and its data) irreversibly
+//   - 'truncate':  TRUNCATE empties a table irreversibly
+export type DangerousQueryKind = 'no-where' | 'drop' | 'truncate';
+
+// Classifies a single statement's danger, or null when it is safe to run
+// without confirmation. Handles the same edge cases as the WHERE detection:
+// comments, string literals, and data-modifying CTEs.
+export const classifyDangerousQuery = (sql: string): DangerousQueryKind | null => {
   const cleaned = stripCommentsAndLiterals(sql);
   let keyword = leadingKeyword(cleaned);
   if (keyword === 'WITH') {
     keyword = finalCteStatementKeyword(cleaned) ?? keyword;
   }
-  if (keyword !== 'DELETE' && keyword !== 'UPDATE') return false;
 
-  return !hasTopLevelWhere(cleaned);
+  if (keyword === 'DROP') return 'drop';
+  if (keyword === 'TRUNCATE') return 'truncate';
+  if ((keyword === 'DELETE' || keyword === 'UPDATE') && !hasTopLevelWhere(cleaned)) {
+    return 'no-where';
+  }
+  return null;
 };
+
+// True when a statement should be gated behind a confirmation dialog.
+export const isDangerousQuery = (sql: string): boolean => classifyDangerousQuery(sql) !== null;
+
+// Flags DELETE/UPDATE statements with no top-level WHERE clause — the
+// classic "forgot the WHERE" accident that wipes or overwrites a whole
+// table.
+export const isDestructiveWithoutWhere = (sql: string): boolean =>
+  classifyDangerousQuery(sql) === 'no-where';
 
 // Optimized statement extractor - avoid full text scan when possible
 export const getCurrentStatement = (model: { getValue: () => string; getOffsetAt: (position: { lineNumber: number; column: number }) => number }, position: { lineNumber: number; column: number }): string => {

--- a/src/utils/sqlAnalysis.ts
+++ b/src/utils/sqlAnalysis.ts
@@ -1,5 +1,7 @@
 // SQL Analysis Utilities - Pure logic functions for parsing and analyzing SQL
 
+import { leadingKeyword } from './sqlSplitter/classify';
+
 export interface ParsedTableRef {
   name: string;
   schema?: string;
@@ -59,6 +61,70 @@ export const parseTablesFromQuery = (sql: string): Map<string, ParsedTableRef> |
   }
 
   return tableMap.size > 0 ? tableMap : null;
+};
+
+// Strips comments and quoted literals so the keyword/depth scan below never
+// matches text that only looks like SQL because it's inside a string or a
+// comment. `\\.` handles backslash-escaped quotes (MySQL's default string
+// escaping) in addition to the standard doubled-quote escaping.
+const stripCommentsAndLiterals = (sql: string): string =>
+  sql
+    .replace(/--[^\n]*/g, ' ')
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/'(?:[^'\\]|\\.|'')*'/g, "''")
+    .replace(/"(?:[^"\\]|\\.|"")*"/g, '""')
+    .replace(/`(?:[^`]|``)*`/g, '``');
+
+const CTE_STATEMENT_KEYWORDS = new Set(['SELECT', 'INSERT', 'UPDATE', 'DELETE', 'MERGE']);
+
+// A data-modifying CTE (`WITH x AS (...) DELETE FROM t ...`) carries its
+// real statement type after the CTE definitions, not at the start. Scan for
+// the first keyword that sits outside any parenthesized CTE body.
+function finalCteStatementKeyword(cleaned: string): string | null {
+  const tokenRe = /\(|\)|[A-Za-z_][A-Za-z0-9_]*/g;
+  let depth = 0;
+  let match: RegExpExecArray | null;
+  while ((match = tokenRe.exec(cleaned)) !== null) {
+    const token = match[0];
+    if (token === '(') { depth++; continue; }
+    if (token === ')') { depth = Math.max(0, depth - 1); continue; }
+    if (depth === 0) {
+      const word = token.toUpperCase();
+      if (CTE_STATEMENT_KEYWORDS.has(word)) return word;
+    }
+  }
+  return null;
+}
+
+// True if `WHERE` appears outside of any parenthesized group — a WHERE
+// nested in a subquery (e.g. an UPDATE...SET with a correlated subquery)
+// doesn't count, since it doesn't limit which rows of the target table are
+// affected.
+function hasTopLevelWhere(cleaned: string): boolean {
+  const tokenRe = /\(|\)|\bWHERE\b/gi;
+  let depth = 0;
+  let match: RegExpExecArray | null;
+  while ((match = tokenRe.exec(cleaned)) !== null) {
+    const token = match[0];
+    if (token === '(') { depth++; continue; }
+    if (token === ')') { depth = Math.max(0, depth - 1); continue; }
+    if (depth === 0) return true;
+  }
+  return false;
+}
+
+// Flags DELETE/UPDATE statements with no top-level WHERE clause — the
+// classic "forgot the WHERE" accident that wipes or overwrites a whole
+// table.
+export const isDestructiveWithoutWhere = (sql: string): boolean => {
+  const cleaned = stripCommentsAndLiterals(sql);
+  let keyword = leadingKeyword(cleaned);
+  if (keyword === 'WITH') {
+    keyword = finalCteStatementKeyword(cleaned) ?? keyword;
+  }
+  if (keyword !== 'DELETE' && keyword !== 'UPDATE') return false;
+
+  return !hasTopLevelWhere(cleaned);
 };
 
 // Optimized statement extractor - avoid full text scan when possible

--- a/tests/components/modals/ConfirmModal.test.tsx
+++ b/tests/components/modals/ConfirmModal.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { ConfirmModal } from "../../../src/components/modals/ConfirmModal";
+
+// Mock the Modal component to just render children when open
+vi.mock("../../../src/components/ui/Modal", () => ({
+  Modal: ({
+    isOpen,
+    children,
+  }: {
+    isOpen: boolean;
+    children: React.ReactNode;
+  }) => (isOpen ? <div data-testid="modal">{children}</div> : null),
+}));
+
+describe("ConfirmModal", () => {
+  const mockOnConfirm = vi.fn();
+  const mockOnClose = vi.fn();
+
+  const renderModal = (props: Partial<React.ComponentProps<typeof ConfirmModal>> = {}) =>
+    render(
+      <ConfirmModal
+        isOpen
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        title="Danger"
+        message="This is destructive"
+        confirmLabel="Run anyway"
+        {...props}
+      />,
+    );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("confirms immediately when no delay is set", () => {
+    renderModal();
+    const button = screen.getByRole("button", { name: "Run anyway" });
+    expect(button).not.toBeDisabled();
+    fireEvent.click(button);
+    expect(mockOnConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the confirm button and counts down when a delay is set", () => {
+    renderModal({ confirmDelaySeconds: 3 });
+
+    // Starts disabled with the initial countdown value.
+    let button = screen.getByRole("button", { name: /Run anyway \(3\)/ });
+    expect(button).toBeDisabled();
+
+    fireEvent.click(button);
+    expect(mockOnConfirm).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(screen.getByRole("button", { name: /Run anyway \(2\)/ })).toBeDisabled();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    // Countdown finished: label loses the counter and the button is enabled.
+    button = screen.getByRole("button", { name: "Run anyway" });
+    expect(button).not.toBeDisabled();
+    fireEvent.click(button);
+    expect(mockOnConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("restarts the countdown each time the modal reopens", () => {
+    const { rerender } = renderModal({ confirmDelaySeconds: 3 });
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(screen.getByRole("button", { name: "Run anyway" })).not.toBeDisabled();
+
+    // Close and reopen: countdown should reset.
+    rerender(
+      <ConfirmModal
+        isOpen={false}
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        title="Danger"
+        message="This is destructive"
+        confirmLabel="Run anyway"
+        confirmDelaySeconds={3}
+      />,
+    );
+    rerender(
+      <ConfirmModal
+        isOpen
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        title="Danger"
+        message="This is destructive"
+        confirmLabel="Run anyway"
+        confirmDelaySeconds={3}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /Run anyway \(3\)/ })).toBeDisabled();
+  });
+});

--- a/tests/hooks/useDangerousQueryGuard.test.ts
+++ b/tests/hooks/useDangerousQueryGuard.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useDangerousQueryGuard } from '../../src/hooks/useDangerousQueryGuard';
+
+describe('useDangerousQueryGuard', () => {
+  it('resolves immediately without opening a dialog for a safe query', async () => {
+    const { result } = renderHook(() => useDangerousQueryGuard());
+
+    let resolved: boolean | undefined;
+    await act(async () => {
+      resolved = await result.current.guardQuery('SELECT * FROM users');
+    });
+
+    expect(resolved).toBe(true);
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it('opens a pending confirmation for a destructive query with no WHERE', async () => {
+    const { result } = renderHook(() => useDangerousQueryGuard());
+
+    let guardPromise!: Promise<boolean>;
+    act(() => {
+      guardPromise = result.current.guardQuery('DELETE FROM users');
+    });
+
+    expect(result.current.isPending).toBe(true);
+
+    act(() => {
+      result.current.resolve(true);
+    });
+
+    expect(await guardPromise).toBe(true);
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it('resolves to false and closes the dialog when the user declines', async () => {
+    const { result } = renderHook(() => useDangerousQueryGuard());
+
+    let guardPromise!: Promise<boolean>;
+    act(() => {
+      guardPromise = result.current.guardQuery('UPDATE users SET active = 0');
+    });
+
+    act(() => {
+      result.current.resolve(false);
+    });
+
+    expect(await guardPromise).toBe(false);
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it('flags a batch if any query in it is destructive without WHERE', async () => {
+    const { result } = renderHook(() => useDangerousQueryGuard());
+
+    let guardPromise!: Promise<boolean>;
+    act(() => {
+      guardPromise = result.current.guardQuery([
+        'SELECT * FROM users',
+        'DELETE FROM sessions',
+      ]);
+    });
+
+    expect(result.current.isPending).toBe(true);
+
+    act(() => {
+      result.current.resolve(true);
+    });
+    expect(await guardPromise).toBe(true);
+  });
+
+  it('declines a second concurrent request instead of orphaning the first one', async () => {
+    const { result } = renderHook(() => useDangerousQueryGuard());
+
+    let firstPromise!: Promise<boolean>;
+    let secondPromise!: Promise<boolean>;
+    act(() => {
+      firstPromise = result.current.guardQuery('DELETE FROM users');
+    });
+    act(() => {
+      secondPromise = result.current.guardQuery('DELETE FROM sessions');
+    });
+
+    // The second request is declined right away — it must not replace the
+    // first request's resolver and leave it hanging forever.
+    expect(await secondPromise).toBe(false);
+    expect(result.current.isPending).toBe(true);
+
+    act(() => {
+      result.current.resolve(true);
+    });
+    expect(await firstPromise).toBe(true);
+  });
+});

--- a/tests/hooks/useDangerousQueryGuard.test.ts
+++ b/tests/hooks/useDangerousQueryGuard.test.ts
@@ -24,6 +24,11 @@ describe('useDangerousQueryGuard', () => {
     });
 
     expect(result.current.isPending).toBe(true);
+    expect(result.current.pending).toEqual({
+      kind: 'no-where',
+      sql: 'DELETE FROM users',
+      count: 1,
+    });
 
     act(() => {
       result.current.resolve(true);
@@ -31,6 +36,29 @@ describe('useDangerousQueryGuard', () => {
 
     expect(await guardPromise).toBe(true);
     expect(result.current.isPending).toBe(false);
+    expect(result.current.pending).toBe(null);
+  });
+
+  it('flags DROP and TRUNCATE statements with the matching kind', async () => {
+    const { result } = renderHook(() => useDangerousQueryGuard());
+
+    act(() => {
+      result.current.guardQuery('DROP TABLE users');
+    });
+    expect(result.current.pending?.kind).toBe('drop');
+
+    act(() => {
+      result.current.resolve(false);
+    });
+
+    act(() => {
+      result.current.guardQuery('TRUNCATE TABLE logs');
+    });
+    expect(result.current.pending?.kind).toBe('truncate');
+
+    act(() => {
+      result.current.resolve(false);
+    });
   });
 
   it('resolves to false and closes the dialog when the user declines', async () => {
@@ -57,10 +85,17 @@ describe('useDangerousQueryGuard', () => {
       guardPromise = result.current.guardQuery([
         'SELECT * FROM users',
         'DELETE FROM sessions',
+        'DROP TABLE audit',
       ]);
     });
 
     expect(result.current.isPending).toBe(true);
+    // The first flagged statement drives the preview; count reflects all of them.
+    expect(result.current.pending).toEqual({
+      kind: 'no-where',
+      sql: 'DELETE FROM sessions',
+      count: 2,
+    });
 
     act(() => {
       result.current.resolve(true);

--- a/tests/utils/sqlAnalysis.test.ts
+++ b/tests/utils/sqlAnalysis.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseTablesFromQuery, getCurrentStatement, isDestructiveWithoutWhere } from '../../src/utils/sqlAnalysis';
+import { parseTablesFromQuery, getCurrentStatement, isDestructiveWithoutWhere, classifyDangerousQuery, isDangerousQuery } from '../../src/utils/sqlAnalysis';
 
 describe('sqlAnalysis utils', () => {
   describe('parseTablesFromQuery', () => {
@@ -235,6 +235,42 @@ WHERE id = 1`;
     it('returns false for empty or whitespace-only input', () => {
       expect(isDestructiveWithoutWhere('')).toBe(false);
       expect(isDestructiveWithoutWhere('   \n\t  ')).toBe(false);
+    });
+  });
+
+  describe('classifyDangerousQuery', () => {
+    it('classifies DELETE/UPDATE without a WHERE as no-where', () => {
+      expect(classifyDangerousQuery('DELETE FROM users')).toBe('no-where');
+      expect(classifyDangerousQuery('UPDATE users SET active = 0')).toBe('no-where');
+    });
+
+    it('classifies DROP statements', () => {
+      expect(classifyDangerousQuery('DROP TABLE users')).toBe('drop');
+      expect(classifyDangerousQuery('drop database analytics;')).toBe('drop');
+      expect(classifyDangerousQuery('DROP INDEX idx_users_email')).toBe('drop');
+    });
+
+    it('classifies TRUNCATE statements', () => {
+      expect(classifyDangerousQuery('TRUNCATE TABLE users')).toBe('truncate');
+      expect(classifyDangerousQuery('truncate logs;')).toBe('truncate');
+    });
+
+    it('returns null for safe statements', () => {
+      expect(classifyDangerousQuery('SELECT * FROM users')).toBe(null);
+      expect(classifyDangerousQuery('DELETE FROM users WHERE id = 1')).toBe(null);
+      expect(classifyDangerousQuery('INSERT INTO users (id) VALUES (1)')).toBe(null);
+      expect(classifyDangerousQuery('')).toBe(null);
+    });
+
+    it('is not fooled by DROP/TRUNCATE inside comments or literals', () => {
+      expect(classifyDangerousQuery("SELECT 'DROP TABLE users'")).toBe(null);
+      expect(classifyDangerousQuery('SELECT 1 -- DROP TABLE users')).toBe(null);
+    });
+
+    it('exposes isDangerousQuery as a boolean shortcut', () => {
+      expect(isDangerousQuery('DROP TABLE users')).toBe(true);
+      expect(isDangerousQuery('DELETE FROM users')).toBe(true);
+      expect(isDangerousQuery('SELECT * FROM users')).toBe(false);
     });
   });
 });

--- a/tests/utils/sqlAnalysis.test.ts
+++ b/tests/utils/sqlAnalysis.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseTablesFromQuery, getCurrentStatement } from '../../src/utils/sqlAnalysis';
+import { parseTablesFromQuery, getCurrentStatement, isDestructiveWithoutWhere } from '../../src/utils/sqlAnalysis';
 
 describe('sqlAnalysis utils', () => {
   describe('parseTablesFromQuery', () => {
@@ -156,6 +156,85 @@ SELECT 2; -- ${padding}`;
         const expected = `SELECT * FROM users
 WHERE id = 1`;
         expect(stmt).toBe(expected);
+    });
+  });
+
+  describe('isDestructiveWithoutWhere', () => {
+    it('flags DELETE with no WHERE clause', () => {
+      expect(isDestructiveWithoutWhere('DELETE FROM users')).toBe(true);
+      expect(isDestructiveWithoutWhere('delete from users;')).toBe(true);
+    });
+
+    it('flags UPDATE with no WHERE clause', () => {
+      expect(isDestructiveWithoutWhere('UPDATE users SET active = 0')).toBe(true);
+    });
+
+    it('does not flag DELETE/UPDATE with a top-level WHERE clause', () => {
+      expect(isDestructiveWithoutWhere('DELETE FROM users WHERE id = 1')).toBe(false);
+      expect(isDestructiveWithoutWhere('UPDATE users SET active = 0 WHERE id = 1')).toBe(false);
+    });
+
+    it('does not flag SELECT/INSERT/other statement types', () => {
+      expect(isDestructiveWithoutWhere('SELECT * FROM users')).toBe(false);
+      expect(isDestructiveWithoutWhere('INSERT INTO users (id) VALUES (1)')).toBe(false);
+      expect(isDestructiveWithoutWhere('TRUNCATE TABLE users')).toBe(false);
+    });
+
+    it('ignores WHERE that only appears inside a subquery', () => {
+      const sql = "UPDATE users SET status = (SELECT status FROM defaults WHERE key = 'default')";
+      expect(isDestructiveWithoutWhere(sql)).toBe(true);
+    });
+
+    it('ignores WHERE-like text inside comments and string literals', () => {
+      expect(isDestructiveWithoutWhere("DELETE FROM users -- WHERE id = 1")).toBe(true);
+      expect(isDestructiveWithoutWhere("DELETE FROM users /* WHERE id = 1 */")).toBe(true);
+      expect(isDestructiveWithoutWhere("UPDATE users SET note = 'no WHERE here'")).toBe(true);
+    });
+
+    it('handles leading whitespace and multi-line statements', () => {
+      const sql = `\n  UPDATE users\n  SET active = 0\n`;
+      expect(isDestructiveWithoutWhere(sql)).toBe(true);
+    });
+
+    it('does not let a backslash-escaped quote hide a real WHERE, or fake one out of string content', () => {
+      // No real WHERE: the escaped quote must not prematurely close the string
+      // and expose the literal "WHERE clause" text inside it as a top-level WHERE.
+      expect(
+        isDestructiveWithoutWhere("UPDATE logs SET msg = 'don\\'t forget to add a WHERE clause'"),
+      ).toBe(true);
+      // A real WHERE after a backslash-escaped string is still detected.
+      expect(
+        isDestructiveWithoutWhere("UPDATE logs SET msg = 'it\\'s fine' WHERE id = 1"),
+      ).toBe(false);
+    });
+
+    it('flags a data-modifying CTE with no WHERE on its final statement', () => {
+      expect(
+        isDestructiveWithoutWhere('WITH ids AS (SELECT id FROM stale_users) DELETE FROM users'),
+      ).toBe(true);
+      expect(
+        isDestructiveWithoutWhere(
+          'WITH ids AS (SELECT id FROM stale_users) DELETE FROM users WHERE id IN (SELECT id FROM ids)',
+        ),
+      ).toBe(false);
+      // A CTE feeding a plain SELECT is not destructive at all.
+      expect(
+        isDestructiveWithoutWhere('WITH ids AS (SELECT id FROM stale_users) SELECT * FROM ids'),
+      ).toBe(false);
+    });
+
+    it('flags a statement wrapped in parentheses instead of silently allowing it', () => {
+      // The wrapping parens make the WHERE-depth scan treat any WHERE as
+      // nested, so a wrapped statement is conservatively flagged either way
+      // (a false positive, not a silent bypass) — that's the safe direction
+      // to err in for a "forgot the WHERE" guard.
+      expect(isDestructiveWithoutWhere('(DELETE FROM users)')).toBe(true);
+      expect(isDestructiveWithoutWhere('(DELETE FROM users WHERE id = 1)')).toBe(true);
+    });
+
+    it('returns false for empty or whitespace-only input', () => {
+      expect(isDestructiveWithoutWhere('')).toBe(false);
+      expect(isDestructiveWithoutWhere('   \n\t  ')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Why

A DELETE or UPDATE with a missing WHERE clause is one of the most common ways to accidentally destroy real data, and Tabularis had no guard against it — the query would just run. The same applies to `DROP` and `TRUNCATE`, which wipe objects or entire tables irreversibly.

## What changed

- `src/utils/sqlAnalysis.ts`: added `classifyDangerousQuery(sql)` returning `'no-where' | 'drop' | 'truncate' | null`, plus an `isDangerousQuery(sql)` shortcut. It detects DELETE/UPDATE with no top-level WHERE **and** `DROP`/`TRUNCATE` statements. It strips comments and string literals (handling both backslash- and doubled-quote escaping), unwraps leading parens, and follows data-modifying CTEs (`WITH x AS (...) DELETE FROM ...`) to find the real statement type. `isDestructiveWithoutWhere` is kept as a thin wrapper for backward compatibility.
- `src/hooks/useDangerousQueryGuard.ts`: a small hook that turns the check above into a `guardQuery()` call sites can `await` — it resolves immediately for safe queries, or opens a confirmation dialog for dangerous ones. It now exposes `pending: { kind, sql, count }` so the dialog can show kind-specific copy and a preview of the flagged statement. A second dangerous query submitted while a dialog is already open is declined outright instead of silently replacing the pending one (which would otherwise leave the first caller hanging forever).
- `src/components/modals/ConfirmModal.tsx`:
  - optional `sql` prop renders a read-only `SqlPreview` (Monaco) of the flagged statement below the message.
  - optional `confirmDelaySeconds` keeps the confirm button disabled with a live countdown (5s here), so the warning is actually read before it can be dismissed.
- Wired into the SQL editor (`runQuery`/`runMultipleQueries` in `Editor.tsx`) and into notebook cells (`NotebookView.tsx`), with per-kind titles/messages shared via `DANGEROUS_QUERY_I18N`.
- Added the confirmation copy (including new DROP/TRUNCATE keys) to all 8 locales.

## Known limitation

The check only looks at the statement it's given. If a console tab's buffer holds several `;`-separated statements and the user re-runs it via pagination (not the Run button, which always splits first), a destructive statement past the first one in that buffer won't be caught. This is a narrow, hard-to-hit path and the built-in drivers reject multi-statement payloads outright in most configurations, so I left it as a follow-up rather than reworking pagination for it.

## Test plan

- [x] `pnpm exec tsc --noEmit` — no errors
- [x] `npx eslint` on all changed files — clean
- [x] `vitest run` on the affected suites (`sqlAnalysis`, `useDangerousQueryGuard`, `ConfirmModal`) — green, incl. new DROP/TRUNCATE, `pending` shape, and countdown coverage
- [ ] Manual: run `DELETE`/`UPDATE` with no WHERE, `DROP`, and `TRUNCATE` in both the SQL editor and a notebook cell — confirm the dialog blocks execution, shows the right message + SQL preview, the button stays disabled for the countdown, and that a normal WHERE-qualified query runs without any prompt