### PR TITLE
fix(postgres): exclude OUT parameters from function call signature

### DIFF
--- a/src-tauri/src/drivers/postgres/routines.rs
+++ b/src-tauri/src/drivers/postgres/routines.rs
@@ -7,10 +7,12 @@ use crate::drivers::common::{quote_qualified, render_sql_literal};
 use crate::models::RoutineCallArg;
 
 /// Builds the invocation script. Functions go through `SELECT * FROM` so
-/// both scalar and set-returning functions come back as a result set.
-/// Procedures use `CALL`; OUT parameters are rendered as `NULL` placeholders
-/// (PostgreSQL requires them in the argument list) and INOUT values are
-/// echoed back by the server as the procedure's result row.
+/// both scalar and set-returning functions come back as a result set; their
+/// pure `OUT` parameters are NOT part of the call signature in PostgreSQL, so
+/// they are excluded from the argument list (passing them raises
+/// `function ... does not exist`). Procedures use `CALL`; there OUT parameters
+/// ARE required in the argument list and are rendered as `NULL` placeholders,
+/// with INOUT values echoed back by the server as the procedure's result row.
 pub(super) fn routine_call_sql(
     routine_name: &str,
     routine_type: &str,
@@ -18,9 +20,14 @@ pub(super) fn routine_call_sql(
     schema: Option<&str>,
 ) -> String {
     let name = quote_qualified(routine_name, schema, "\"");
-    let rendered: Vec<String> = args.iter().map(render_sql_literal).collect();
+    let is_function = routine_type.eq_ignore_ascii_case("FUNCTION");
+    let rendered: Vec<String> = args
+        .iter()
+        .filter(|arg| !(is_function && arg.mode.eq_ignore_ascii_case("OUT")))
+        .map(render_sql_literal)
+        .collect();
     let arg_list = rendered.join(", ");
-    if routine_type.eq_ignore_ascii_case("FUNCTION") {
+    if is_function {
         format!("SELECT * FROM {}({});", name, arg_list)
     } else {
         format!("CALL {}({});", name, arg_list)

--- a/src-tauri/src/drivers/postgres/tests.rs
+++ b/src-tauri/src/drivers/postgres/tests.rs
@@ -858,6 +858,37 @@ mod routine_management {
     }
 
     #[test]
+    fn function_call_excludes_out_params() {
+        // PostgreSQL functions do not accept pure OUT parameters in the call
+        // signature; only IN/INOUT are passed.
+        let sql = routine_call_sql(
+            "fn_split",
+            "FUNCTION",
+            &[
+                arg("p_in", "IN", Some("5"), true),
+                arg("p_lo", "OUT", None, false),
+                arg("p_hi", "OUT", None, false),
+            ],
+            Some("public"),
+        );
+        assert_eq!(sql, "SELECT * FROM \"public\".\"fn_split\"(5);");
+    }
+
+    #[test]
+    fn function_call_keeps_inout_params() {
+        let sql = routine_call_sql(
+            "fn_adjust",
+            "FUNCTION",
+            &[
+                arg("p_val", "INOUT", Some("10"), true),
+                arg("p_out", "OUT", None, false),
+            ],
+            Some("public"),
+        );
+        assert_eq!(sql, "SELECT * FROM \"public\".\"fn_adjust\"(10);");
+    }
+
+    #[test]
     fn procedure_call_renders_out_params_as_null() {
         let sql = routine_call_sql(
             "sp_test",


### PR DESCRIPTION
## Problem

When running a PostgreSQL **function** that has `OUT` parameters via the Run Routine modal, the generated call included those `OUT` parameters as `NULL` literals:

```sql
SELECT * FROM "public"."fn_split"(5, NULL, NULL);
```

PostgreSQL does not treat pure `OUT` parameters as part of a function's callable signature, so this fails with `function ... does not exist`. The modal was forwarding every parameter reported by `information_schema` (with `OUT` values sent as `null`), and the Postgres SQL builder rendered all of them into the argument list.

## Fix

In `routine_call_sql` (Postgres driver), pure `OUT` parameters are now filtered out of the argument list **for functions only**, while `IN` and `INOUT` are kept:

```sql
SELECT * FROM "public"."fn_split"(5);
```

Procedures are intentionally left unchanged: PostgreSQL **requires** `OUT` parameters in the `CALL` argument list, so they continue to be rendered as `NULL` placeholders, with `INOUT` values echoed back as the procedure's result row.

## Tests

Added unit tests in `postgres/tests.rs`:
- `function_call_excludes_out_params` — `OUT` parameters are omitted from a function call
- `function_call_keeps_inout_params` — `INOUT` parameters are retained
- existing `procedure_call_renders_out_params_as_null` still passes (procedure behavior unchanged)

## Notes

The dialect-neutral fallback used by plugin drivers (`drivers/common/routines.rs::generic_routine_call_sql`) has the same class of issue but is left untouched here, since the correct behavior depends on the plugin's SQL dialect.