### PR TITLE
feat(connections): typo-tolerant fuzzy matching for the connection search

### DIFF
--- a/src/pages/Connections.tsx
+++ b/src/pages/Connections.tsx
@@ -29,6 +29,7 @@ import clsx from "clsx";
 import { ContextMenu } from "../components/ui/ContextMenu";
 import type { SavedConnection } from "../contexts/DatabaseContext";
 import { toErrorMessage } from "../utils/errors";
+import { fuzzyFilter } from "../utils/fuzzy";
 import { useOpenConnectionInNewWindow } from "../hooks/useOpenConnectionInNewWindow";
 import { GroupHeader } from "../components/connections/GroupHeader";
 import { ConnectionCard } from "../components/connections/ConnectionCard";
@@ -406,10 +407,10 @@ export const Connections = () => {
     if (!search.trim()) return groupedConnections;
     const result: Record<string, SavedConnection[]> = {};
     for (const groupId in groupedConnections) {
-      const filteredConns = groupedConnections[groupId].filter(
-        (c) =>
-          c.name.toLowerCase().includes(search.toLowerCase()) ||
-          c.params.driver.toLowerCase().includes(search.toLowerCase()),
+      const filteredConns = fuzzyFilter(
+        groupedConnections[groupId],
+        search,
+        (c) => `${c.name} ${c.params.driver}`,
       );
       if (filteredConns.length > 0) {
         result[groupId] = filteredConns;
@@ -419,11 +420,10 @@ export const Connections = () => {
   }, [groupedConnections, search]);
 
   const filteredUngroupedConnections = useMemo(() => {
-    if (!search.trim()) return ungroupedConnections;
-    return ungroupedConnections.filter(
-      (c) =>
-        c.name.toLowerCase().includes(search.toLowerCase()) ||
-        c.params.driver.toLowerCase().includes(search.toLowerCase()),
+    return fuzzyFilter(
+      ungroupedConnections,
+      search,
+      (c) => `${c.name} ${c.params.driver}`,
     );
   }, [ungroupedConnections, search]);
 


### PR DESCRIPTION
Uses the shared `fuzzyFilter` (Fuse.js) helper for the connection search, so it tolerates typos and ranks closest matches first — like the table/trigger filters (#417) and Quick Navigator (#421). Matches on name and driver, for both grouped and ungrouped lists.