### PR TITLE
i18n(fr): add missing French translations

### DIFF
--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -114,6 +114,19 @@
     "procedures": "Procédures",
     "noRoutines": "Aucune routine trouvée",
     "refreshRoutines": "Actualiser les routines",
+    "triggers": "Triggers",
+    "noTriggers": "Aucun trigger trouvé",
+    "filterTriggers": "Filtrer les triggers...",
+    "noTriggersMatch": "Aucun trigger ne correspond à votre filtre",
+    "createTrigger": "Créer un nouveau trigger",
+    "editTrigger": "Modifier le trigger",
+    "dropTrigger": "Supprimer le trigger",
+    "dropTriggerConfirm": "Êtes-vous sûr de vouloir supprimer le trigger « {{trigger}} » ?",
+    "viewTriggerDefinition": "Voir la définition",
+    "failDropTrigger": "Échec de la suppression du trigger : ",
+    "failGetTriggerDefinition": "Échec de la récupération de la définition du trigger : ",
+    "refreshTriggers": "Actualiser les triggers",
+    "onTable": "sur {{table}}",
     "objectSummary": "Objets",
     "databases": "Bases de données",
     "failGetRoutineDefinition": "Échec de récupération de la définition de la routine : ",
@@ -272,6 +285,11 @@
       "emoji": "Emoji",
       "image": "Image"
     },
+    "previewLabel": "Aperçu",
+    "defaultHint": "Icône par défaut du driver utilisée.",
+    "emojiSelected": "Emoji sélectionné",
+    "emojiHint": "Cliquez sur un autre emoji ci-dessous pour changer.",
+    "removeEmoji": "Effacer",
     "chooseImage": "Choisir une image…",
     "removeImage": "Supprimer",
     "imageHint": "PNG, JPG, WebP ou SVG · max. 512 Ko",
@@ -317,6 +335,18 @@
     "fontSizeDesc": "Ajustez la taille de police de base utilisée dans toute l’application (10-20 px).",
     "preview": "Aperçu",
     "fontPreviewText": "Voix ambiguë d’un cœur qui au zéphyr préfère les jattes de kiwis",
+    "resultColors": {
+      "title": "Couleurs des résultats",
+      "enable": "Colorer les valeurs par type",
+      "enableDesc": "Colore les cellules des résultats de requête selon leur type de données.",
+      "number": "Nombre",
+      "string": "Texte",
+      "date": "Date / Heure",
+      "boolean": "Booléen",
+      "reset": "Réinitialiser au thème",
+      "confirm": "Confirmer",
+      "cancel": "Annuler"
+    },
     "appearance_general": "Général",
     "appearance_sqlEditor": "Éditeur SQL",
     "appearance_editorTheme": "Thème de l’éditeur",
@@ -346,6 +376,9 @@
     "language": "Langue",
     "languageDesc": "Choisissez votre langue préférée. \"Auto\" utilisera la langue de votre système.",
     "auto": "Auto (Système)",
+    "timezone": "Fuseau horaire",
+    "timezoneDesc": "Fuseau horaire utilisé pour afficher les horodatages et les exports. « Auto » suit le fuseau horaire de votre système.",
+    "timezoneSearch": "Rechercher un fuseau horaire...",
     "english": "Anglais",
     "italian": "Italien",
     "spanish": "Espagnol",
@@ -584,6 +617,7 @@
       "closeTab": "Fermer l’onglet",
       "nextPage": "Page suivante",
       "prevPage": "Page précédente",
+      "saveGridChanges": "Enregistrer les modifications en attente",
       "switchConnection": "Passer à la connexion 1-9",
       "resetToDefault": "Réinitialiser par défaut",
       "notOverridable": "Intégré, non personnalisable",
@@ -771,6 +805,8 @@
     "deleteTitle": "Supprimer la ligne",
     "updateFailed": "Échec de la mise à jour : ",
     "deleteFailed": "Échec de la suppression de la ligne : ",
+    "columnNotEditable": "La colonne « {{column}} » ne peut pas être modifiée — ce n'est pas une colonne directe de la table « {{table}} » (probablement un alias ou une valeur calculée).",
+    "pkRequiredToEdit": "Pour modifier ce résultat, incluez la colonne de clé primaire « {{pk}} » dans votre SELECT.",
     "null": "null",
     "sortByAsc": "Trier par {{col}} ASC",
     "sortByDesc": "Trier par {{col}} DESC",
@@ -823,26 +859,6 @@
     "auto": "Auto"
   },
   "editor": {
-    "quickNavigator": {
-      "placeholder": "Rechercher tables, vues, routines, triggers...",
-      "noResults": "Aucun élément correspondant trouvé",
-      "count_one": "1 élément",
-      "count_other": "{{count}} éléments",
-      "navigationHint": "↑↓ pour naviguer, Entrée pour ouvrir",
-      "escHint": "Échap pour fermer",
-      "type_table": "table",
-      "type_view": "vue",
-      "type_routine": "routine",
-      "type_trigger": "trigger",
-      "actions": {
-        "inspect": "Inspecter la structure",
-        "newConsole": "Nouvelle console",
-        "generateSql": "Générer des modèles SQL",
-        "countRows": "Compter les lignes",
-        "query": "Exécuter une requête SELECT",
-        "copyName": "Copier le nom"
-      }
-    },
     "noTabs": "Aucun onglet ouvert pour cette connexion.",
     "newConsole": "Nouvelle console",
     "noActiveSession": "Aucune session active. Veuillez sélectionner une connexion.",
@@ -863,6 +879,7 @@
     "loadRowCount": "Charger le nombre de lignes",
     "rowCount": "{{total}} lignes",
     "executePrompt": "Exécutez une requête pour voir les résultats",
+    "tableRunPrompt": "Appuyez sur Exécuter (Ctrl/Commande+F5) pour charger les données de la table",
     "results": {
       "minimize": "Réduire",
       "maximize": "Agrandir (masquer l’éditeur)",
@@ -872,7 +889,6 @@
       "detached": "Résultats détachés dans une fenêtre séparée",
       "reattach": "Rattacher"
     },
-    "tableRunPrompt": "Appuyez sur Exécuter (Ctrl/Commande+F5) pour charger les données de la table",
     "closeTab": "Fermer l’onglet",
     "closeOthers": "Fermer les autres onglets",
     "closeRight": "Fermer les onglets à droite",
@@ -907,6 +923,26 @@
       "tabs_one": "{{count}} onglet",
       "tabs_other": "{{count}} onglets",
       "escHint": "Esc pour fermer"
+    },
+    "quickNavigator": {
+      "placeholder": "Rechercher tables, vues, routines, triggers...",
+      "noResults": "Aucun élément correspondant trouvé",
+      "count_one": "1 élément",
+      "count_other": "{{count}} éléments",
+      "navigationHint": "↑↓ pour naviguer, Entrée pour ouvrir",
+      "escHint": "Échap pour fermer",
+      "type_table": "table",
+      "type_view": "vue",
+      "type_routine": "routine",
+      "type_trigger": "trigger",
+      "actions": {
+        "inspect": "Inspecter la structure",
+        "newConsole": "Nouvelle console",
+        "generateSql": "Générer des modèles SQL",
+        "countRows": "Compter les lignes",
+        "query": "Exécuter une requête SELECT",
+        "copyName": "Copier le nom"
+      }
     },
     "submitChanges": "Soumettre les modifications",
     "rollbackChanges": "Annuler les modifications",
@@ -1245,10 +1281,38 @@
     "createSuccess": "Vue créée avec succès",
     "alterSuccess": "Vue mise à jour avec succès",
     "saveError": "Échec de l’enregistrement de la vue : ",
+    "confirmAlter": "Voulez-vous vraiment modifier la vue \"{{view}}\" ?",
     "refreshSuccess": "Vue matérialisée \"{{view}}\" actualisée",
     "refreshError": "Échec de l’actualisation de la vue matérialisée : ",
-    "failGetDefinition": "Échec de la récupération de la définition : ",
-    "confirmAlter": "Voulez-vous vraiment modifier la vue \"{{view}}\" ?"
+    "failGetDefinition": "Échec de la récupération de la définition : "
+  },
+  "triggers": {
+    "createTrigger": "Créer un trigger",
+    "editTrigger": "Modifier le trigger",
+    "createSubtitle": "Créer un nouveau trigger de base de données",
+    "editSubtitle": "Modification du trigger : {{name}}",
+    "triggerName": "Nom du trigger",
+    "triggerNamePlaceholder": "ex. before_insert_user",
+    "tableName": "Nom de la table",
+    "tableNamePlaceholder": "ex. users",
+    "timing": "Moment",
+    "events": "Événements",
+    "body": "Corps du trigger (SQL)",
+    "sqlPreview": "Aperçu du SQL généré",
+    "rawSql": "SQL brut",
+    "guidedMode": "Guidé",
+    "rawSqlMode": "SQL brut",
+    "loading": "Chargement de la définition du trigger...",
+    "create": "Créer le trigger",
+    "save": "Enregistrer les modifications",
+    "sqlRequired": "Le SQL du trigger est requis",
+    "failLoadDefinition": "Échec du chargement de la définition du trigger : ",
+    "dropError": "Échec de la suppression du trigger existant : ",
+    "saveError": "Échec de l'enregistrement du trigger : ",
+    "createSuccess": "Trigger créé avec succès",
+    "updateSuccess": "Trigger mis à jour avec succès",
+    "recreateTrigger": "Recréer le trigger",
+    "confirmRecreate": "Modifier un trigger nécessite de le supprimer puis de le recréer. Continuer la modification de « {{trigger}} » ?"
   },
   "community": {
     "title": "Rejoindre la communauté",
@@ -1320,7 +1384,9 @@
     "copyPath": "Copier le chemin",
     "copyValue": "Copier la valeur",
     "addItem": "Ajouter un élément",
-    "removeItem": "Supprimer l'élément"
+    "removeItem": "Supprimer l'élément",
+    "diff": "Diff",
+    "sideBySide": "Côte à côte"
   },
   "jsonViewer": {
     "close": "Fermer",
@@ -1329,6 +1395,16 @@
   "jsonCell": {
     "expand": "Afficher/masquer l'arbre JSON",
     "openViewer": "Ouvrir le visualiseur JSON"
+  },
+  "textCell": {
+    "expand": "Basculer l'éditeur de texte intégré"
+  },
+  "textInput": {
+    "diff": "Diff",
+    "sideBySide": "Côte à côte"
+  },
+  "textViewer": {
+    "save": "Enregistrer"
   },
   "rowEditor": {
     "title": "Modifier la ligne",


### PR DESCRIPTION
French locale was missing 66 keys present in en.json: the triggers module (sidebar + editor), settings.resultColors, timezone settings, connection appearance, data grid edit messages, and misc labels (Diff, Side by side, Save…).

This PR adds all missing French translations and reorders fr.json to follow en.json key order (the quickNavigator block moves under editor to match, content unchanged). fr.json is now at full key parity with en.json (1538/1538 keys).