### PR TITLE
fix(mcp): EXPLAIN ANALYZE bypasses read-only and the approval gate

### DIFF
--- a/src-tauri/src/ai_activity.rs
+++ b/src-tauri/src/ai_activity.rs
@@ -398,7 +398,13 @@ pub fn classify_query_kind(sql: &str) -> &'static str {
     let first = first_keyword(&peeled_upper);
 
     match first.as_str() {
-        "SELECT" | "SHOW" | "EXPLAIN" | "DESCRIBE" | "DESC" | "PRAGMA" | "VALUES" => "select",
+        // EXPLAIN needs option-aware handling: plain EXPLAIN only plans, but
+        // EXPLAIN ANALYZE (and EXPLAIN (ANALYZE ...)) *executes* the wrapped
+        // statement. Classifying it blindly as a read would let
+        // `EXPLAIN ANALYZE DELETE …` run past read-only mode and the approval
+        // gate. See `classify_explain`.
+        "EXPLAIN" => classify_explain(&peeled_upper),
+        "SELECT" | "SHOW" | "DESCRIBE" | "DESC" | "PRAGMA" | "VALUES" => "select",
         "INSERT" | "UPDATE" | "DELETE" | "MERGE" | "REPLACE" => "write",
         "CREATE" | "DROP" | "ALTER" | "TRUNCATE" | "RENAME" | "GRANT" | "REVOKE" | "COMMENT" => {
             "ddl"
@@ -513,11 +519,18 @@ fn classify_cte(stripped_upper: &str) -> &'static str {
 }
 
 fn contains_keyword(haystack: &str, needle: &str) -> bool {
+    keyword_index(haystack, needle).is_some()
+}
+
+/// Byte offset of the first whole-word occurrence of `needle` in `haystack`,
+/// or `None`. "Whole word" means the match is not flanked by an identifier
+/// byte on either side, so `ANALYZE` does not match inside `analyze_runs`.
+fn keyword_index(haystack: &str, needle: &str) -> Option<usize> {
     let bytes = haystack.as_bytes();
     let nbytes = needle.as_bytes();
     let nlen = nbytes.len();
     if nlen == 0 || bytes.len() < nlen {
-        return false;
+        return None;
     }
     let is_word = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
     for i in 0..=bytes.len() - nlen {
@@ -525,11 +538,93 @@ fn contains_keyword(haystack: &str, needle: &str) -> bool {
             let prev_ok = i == 0 || !is_word(bytes[i - 1]);
             let next_ok = i + nlen == bytes.len() || !is_word(bytes[i + nlen]);
             if prev_ok && next_ok {
-                return true;
+                return Some(i);
             }
         }
     }
-    false
+    None
+}
+
+/// Classify an `EXPLAIN …` statement, whose kind depends on its options.
+///
+/// A plain `EXPLAIN` only produces a plan and never touches data, so it is a
+/// read. But `EXPLAIN ANALYZE …` (legacy syntax) and `EXPLAIN (ANALYZE …) …`
+/// (parenthesized options) *run* the wrapped statement to gather actual timing
+/// — so an `ANALYZE` option makes the whole thing as dangerous as the wrapped
+/// statement itself. We therefore detect an `ANALYZE` option and, when present,
+/// classify the wrapped statement (`write`/`ddl`/`unknown`) instead of `select`.
+///
+/// `explain_upper` must be the stripped, upper-cased SQL whose first keyword is
+/// `EXPLAIN`.
+fn classify_explain(explain_upper: &str) -> &'static str {
+    let after = explain_upper["EXPLAIN".len()..].trim_start();
+    let (options, wrapped) = split_explain_options(after);
+
+    // Only ANALYZE causes execution; every other option (VERBOSE, BUFFERS,
+    // FORMAT …, SQLite's QUERY PLAN, MySQL's FORMAT=JSON) is plan-only.
+    if !contains_keyword(options, "ANALYZE") {
+        return "select";
+    }
+    classify_wrapped_statement(wrapped)
+}
+
+/// Split the text following `EXPLAIN` into `(options, wrapped_statement)`.
+///
+/// Handles both the parenthesized form `(ANALYZE, BUFFERS) SELECT …` and the
+/// bare form `ANALYZE VERBOSE SELECT …`. For the bare form the option list runs
+/// up to the wrapped statement's first keyword. Fails closed (everything is
+/// "options", wrapped is empty) when a leading `(` is never closed.
+fn split_explain_options(after: &str) -> (&str, &str) {
+    if after.starts_with('(') {
+        let bytes = after.as_bytes();
+        let mut depth = 0usize;
+        for (i, &b) in bytes.iter().enumerate() {
+            match b {
+                b'(' => depth += 1,
+                b')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return (&after[1..i], after[i + 1..].trim_start());
+                    }
+                }
+                _ => {}
+            }
+        }
+        return (after, "");
+    }
+    match first_wrapped_statement_index(after) {
+        Some(idx) => (&after[..idx], &after[idx..]),
+        None => (after, ""),
+    }
+}
+
+/// Byte offset of the earliest statement keyword that could begin the target of
+/// an `EXPLAIN`, used to find where a bare option list ends.
+fn first_wrapped_statement_index(upper: &str) -> Option<usize> {
+    const KEYWORDS: &[&str] = &[
+        "SELECT", "INSERT", "UPDATE", "DELETE", "MERGE", "REPLACE", "VALUES", "TABLE", "WITH",
+        "CREATE", "DROP", "ALTER", "TRUNCATE", "RENAME",
+    ];
+    KEYWORDS
+        .iter()
+        .filter_map(|kw| keyword_index(upper, kw))
+        .min()
+}
+
+/// Classify the statement wrapped by an executing `EXPLAIN ANALYZE`, as if it
+/// had been submitted directly. Unrecognized/empty input is `"unknown"` so the
+/// safety gates fail closed.
+fn classify_wrapped_statement(wrapped_upper: &str) -> &'static str {
+    let peeled = wrapped_upper.trim_start_matches(|c: char| c == '(' || c.is_whitespace());
+    match first_keyword(peeled).as_str() {
+        "SELECT" | "SHOW" | "DESCRIBE" | "DESC" | "PRAGMA" | "VALUES" | "TABLE" => "select",
+        "INSERT" | "UPDATE" | "DELETE" | "MERGE" | "REPLACE" => "write",
+        "CREATE" | "DROP" | "ALTER" | "TRUNCATE" | "RENAME" | "GRANT" | "REVOKE" | "COMMENT" => {
+            "ddl"
+        }
+        "WITH" => classify_cte(peeled),
+        _ => "unknown",
+    }
 }
 
 /// Replace string literals and SQL comments with whitespace so keyword

--- a/src-tauri/src/ai_activity_tests.rs
+++ b/src-tauri/src/ai_activity_tests.rs
@@ -505,6 +505,93 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // EXPLAIN. Plain EXPLAIN only plans and is a read, but EXPLAIN ANALYZE
+    // (and EXPLAIN (ANALYZE ...)) *executes* the wrapped statement — so a
+    // wrapped write/DDL must be gated exactly like the bare statement, or it
+    // slips past read-only mode and the write-approval prompt.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn classify_plain_explain_is_select() {
+        assert_eq!(classify_query_kind("EXPLAIN SELECT 1"), "select");
+        assert_eq!(classify_query_kind("EXPLAIN VERBOSE SELECT * FROM t"), "select");
+        assert_eq!(classify_query_kind("EXPLAIN (FORMAT JSON) SELECT 1"), "select");
+        assert_eq!(classify_query_kind("EXPLAIN QUERY PLAN SELECT 1"), "select");
+        // Plain EXPLAIN of a write does not run it — Postgres only plans.
+        assert_eq!(classify_query_kind("EXPLAIN DELETE FROM t"), "select");
+        // ANALYZE appearing as an identifier, not an option, must not trip it.
+        assert_eq!(
+            classify_query_kind("EXPLAIN SELECT * FROM analyze_runs"),
+            "select"
+        );
+    }
+
+    #[test]
+    fn classify_explain_analyze_write_is_gated_like_the_write() {
+        // Legacy bare syntax.
+        assert_eq!(classify_query_kind("EXPLAIN ANALYZE DELETE FROM t"), "write");
+        assert_eq!(
+            classify_query_kind("EXPLAIN ANALYZE INSERT INTO t VALUES (1)"),
+            "write"
+        );
+        assert_eq!(
+            classify_query_kind("EXPLAIN ANALYZE VERBOSE UPDATE t SET x = 1"),
+            "write"
+        );
+        // Parenthesized option list, ANALYZE anywhere inside it.
+        assert_eq!(
+            classify_query_kind("EXPLAIN (ANALYZE) DELETE FROM t"),
+            "write"
+        );
+        assert_eq!(
+            classify_query_kind("EXPLAIN (ANALYZE, BUFFERS) DELETE FROM t"),
+            "write"
+        );
+        assert_eq!(
+            classify_query_kind("EXPLAIN (FORMAT JSON, ANALYZE, BUFFERS) UPDATE t SET x = 1"),
+            "write"
+        );
+    }
+
+    #[test]
+    fn classify_explain_analyze_ddl_is_ddl() {
+        assert_eq!(classify_query_kind("EXPLAIN ANALYZE DROP TABLE t"), "ddl");
+        assert_eq!(
+            classify_query_kind("EXPLAIN (ANALYZE) TRUNCATE t"),
+            "ddl"
+        );
+    }
+
+    #[test]
+    fn classify_explain_analyze_select_stays_select() {
+        // ANALYZE runs the SELECT, but a SELECT is still a read.
+        assert_eq!(classify_query_kind("EXPLAIN ANALYZE SELECT 1"), "select");
+        assert_eq!(
+            classify_query_kind("EXPLAIN (ANALYZE) SELECT * FROM t"),
+            "select"
+        );
+    }
+
+    #[test]
+    fn classify_explain_analyze_cte_write_is_write() {
+        assert_eq!(
+            classify_query_kind(
+                "EXPLAIN ANALYZE WITH x AS (SELECT 1) DELETE FROM o WHERE id IN x"
+            ),
+            "write"
+        );
+    }
+
+    #[test]
+    fn classify_explain_analyze_unbalanced_options_fails_closed() {
+        // An unterminated option list must not be treated as a clean read.
+        assert_eq!(
+            classify_query_kind("EXPLAIN (ANALYZE DELETE FROM t"),
+            "unknown"
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // Parenthesized query expressions. A `(SELECT ...) UNION ALL (SELECT ...)`
     // starts with `(`, so the first keyword would come back empty and fall
     // through to "unknown" — needlessly tripping the read-only / approval


### PR DESCRIPTION
## Context

Security report received by email from an external researcher (Daniel Mertz). The MCP safety layer (`McpSafety`) guarantees two things about queries arriving from the MCP/agent surface: **read-only mode** and the **write-approval prompt**. Both guarantees could be bypassed.

## The problem

`classify_query_kind` (`src-tauri/src/ai_activity.rs`) classified **any** statement whose leading keyword is `EXPLAIN` as a read (`"select"`), without looking at the options.

But on PostgreSQL `EXPLAIN ANALYZE ...` and `EXPLAIN (ANALYZE ...) ...` **actually execute** the wrapped statement (that's how they gather real timings). So:

```sql
EXPLAIN ANALYZE DELETE FROM some_table;
EXPLAIN ANALYZE DROP TABLE some_table;
EXPLAIN (ANALYZE, BUFFERS) UPDATE some_table SET x = 1;
```

were classified `"select"` and, in `src-tauri/src/mcp/mod.rs`, skipped both gates:

- **Read-only** (`mod.rs:913`): `is_connection_readonly(...) && kind != "select"` → with `"select"` it **does not block**.
- **Approval gate** in `writes_only` mode (`mod.rs:933`): `kind != "select"` → with `"select"` **no prompt**.

Result: arbitrary writes/DDL executed past both guarantees, with no approval.

### Threat model

Relevant when the query text comes from an untrusted source — a connected MCP server or a prompt-injected agent turn — which is exactly the scenario the approval gate exists to contain. Estimated severity **High** (CVSS 3.1 ~7.0) under this model; drops to Medium for a fully-trusted local operator.

## The fix

`EXPLAIN` classification is now **option-aware** (`classify_explain` + helpers):

- **Plain EXPLAIN** (no `ANALYZE`) → `"select"`: it only plans and never touches data. This also covers `EXPLAIN DELETE ...` (Postgres does not execute without ANALYZE), `EXPLAIN (FORMAT JSON) ...`, `EXPLAIN QUERY PLAN ...` (SQLite), `EXPLAIN VERBOSE ...`.
- **EXPLAIN with the `ANALYZE` option** → the **wrapped statement** is classified as if it had been submitted directly (`write` / `ddl` / `unknown`).

Details:
- Handles both the legacy syntax (`EXPLAIN ANALYZE ...`) and the parenthesized form (`EXPLAIN (ANALYZE, BUFFERS) ...`), with `ANALYZE` anywhere in the option list.
- **Word-boundary aware**: `ANALYZE` used as an identifier (e.g. `EXPLAIN SELECT * FROM analyze_runs`) does **not** produce false positives. `contains_keyword` now reuses the new `keyword_index` helper.
- **Fail-closed**: an unbalanced parenthesized option list or an unrecognized inner statement → `"unknown"` (the gates close).
- Also covers executed CTEs: `EXPLAIN ANALYZE WITH ... DELETE ...` → `write`.

No change needed in `mcp/mod.rs`: both gates derive from `kind`, now correct both for the original query (`mod.rs:906`) and for the query edited at approval time (`mod.rs:1018`).

## Tests

Added 6 regression tests in `ai_activity_tests.rs`, including the one requested in the report (`EXPLAIN ANALYZE DELETE` handled identically to a bare `DELETE`), plus parenthesized forms, DDL, CTE-write, `EXPLAIN ANALYZE SELECT` (stays a read) and unbalanced options.

- `cargo test --lib classify` → 37 passed
- `cargo test --lib ai_activity` → 66 passed
- `cargo clippy --lib` → no warnings on ai_activity

## Impact analysis

`classify_query_kind` is called only from the two call sites in `mcp/mod.rs` plus the tests. The change **tightens** classification (moves `EXPLAIN ANALYZE` from `select` to write/ddl/unknown): it is fail-safe — no legitimate read is unblocked, only the executing EXPLAIN is now correctly subjected to the gates.

## Acknowledgements

Many thanks to **Daniel Mertz** ([danielmertz.com](https://danielmertz.com) — @daniel-mertz) for responsibly reporting this vulnerability and for reviewing the fix.
