### PR TITLE
fix: don't restore tabs of a disconnected connection on next launch

### DIFF
--- a/src/contexts/DatabaseProvider.tsx
+++ b/src/contexts/DatabaseProvider.tsx
@@ -719,20 +719,29 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
       console.error(`[DatabaseProvider] Failed to disconnect from ${targetId}:`, error);
     }
 
-    setOpenConnectionIds(prev => prev.filter(id => id !== targetId));
+    const remainingIds = openConnectionIds.filter(id => id !== targetId);
+
+    setOpenConnectionIds(remainingIds);
     setConnectionDataMap(prev => {
       const newMap = { ...prev };
       delete newMap[targetId];
       return newMap;
     });
 
+    // Persist the updated session immediately. A disconnect is an explicit user
+    // action, so we can't rely on the reactive persistence effect below (it skips
+    // the empty list to protect the startup state) — otherwise disconnecting the
+    // last connection would leave it in `last_open_connection_ids` and the app
+    // would auto-reconnect it (and restore its tabs) on next launch.
+    invoke('set_last_open_connections', { connectionIds: remainingIds }).catch(() => {});
+
     if (activeConnectionId === targetId) {
-      const remainingIds = openConnectionIds.filter(id => id !== targetId);
       if (remainingIds.length > 0) {
         setActiveConnectionId(remainingIds[0]);
       } else {
         setActiveConnectionId(null);
         setActiveTable(null);
+        invoke('set_last_active_connection', { connectionId: null }).catch(() => {});
       }
     }
   };


### PR DESCRIPTION
## Problem

With "reconnect to the last connection on startup" enabled, closing and reopening the app restores your open connections and their editor tabs — which is the intended behavior. The catch: it also restores tabs for connections you explicitly **disconnected** before quitting. You disconnect, close the app, reopen it, and the disconnected connection comes back with all its old tabs.

## Root cause

Disconnecting a connection (`disconnect()` in `DatabaseProvider.tsx`) only updated the in-memory `openConnectionIds` state. The persisted session list (`last_open_connection_ids`) is written by a reactive effect:

```ts
useEffect(() => {
  if (openConnectionIds.length === 0) return; // guard for the startup window
  invoke('set_last_open_connections', { connectionIds: openConnectionIds });
}, [openConnectionIds]);
```

That early-return exists so the transient empty state during startup (before auto-connect kicks in) doesn't wipe the saved list. But it also means **disconnecting your last open connection never gets persisted** — the list on disk still contains it.

So on the next launch:
1. Auto-connect reads the stale `last_open_connection_ids` and reconnects the "disconnected" connection.
2. Once it becomes active, `EditorProvider` loads its saved tabs from `preferences/<id>/preferences.json`.

The tabs are back, even though the user had disconnected.

## Fix

Persist the session directly from `disconnect()` instead of relying on the reactive effect. A disconnect is an explicit user action, so it's safe (and correct) to write the new state immediately, empty list included:

- Write the remaining open connections via `set_last_open_connections` — including an empty array when the last connection is closed.
- Clear `last_active_connection` when the active connection is the one being disconnected and nothing else is open.

The per-connection tab file is deliberately **not** deleted. If the user later reconnects that connection by hand, their queries are still there — only the automatic restore after an explicit disconnect goes away.

## Scope / notes

- Single-file change in `src/contexts/DatabaseProvider.tsx`. `disconnect()` is only called from `useConnectionManager` and the plugin auto-disconnect effect, so the blast radius is small.
- `detachConnection` is left untouched — it has different multi-window semantics and isn't the "Disconnect" action users invoke here.
- `set_last_open_connections` already accepts an empty `Vec<String>` and `set_last_active_connection` already accepts `Option<String>`, so no backend changes were needed.

## Testing

- `tsc --noEmit` passes.
- Manual: enable startup reconnect, open a connection with a few tabs, disconnect it, quit and relaunch — the connection no longer reopens and its tabs stay closed. Reconnecting it manually still restores the tabs.
