### PR TITLE
fix(postgres): cast enum values to their column type and add dropdown editing (#465)

### DIFF
--- a/demo/init/postgres/07-enum-demo.sql
+++ b/demo/init/postgres/07-enum-demo.sql
@@ -1,0 +1,38 @@
+-- =============================================================
+-- Tabularis Demo — ENUM showcase (PostgreSQL 16)
+-- Database: tabularis_demo
+-- Table:    monitored_accounts
+-- Purpose:  exercise PostgreSQL enum column handling (#465):
+--   * information_schema reports enum columns only as "USER-DEFINED";
+--     the driver must read the allowed labels from pg_enum so the UI
+--     can render a dropdown of allowed values.
+--   * UPDATE/INSERT of an enum value must cast the TEXT-bound
+--     parameter through the enum type, or PostgreSQL rejects it with
+--     SQLSTATE 42804 ("column is of type ... but expression is of
+--     type text").
+--   * `mood` includes a label with an embedded single quote to
+--     exercise the '' unescaping in parseEnumValues().
+-- =============================================================
+
+\c tabularis_demo
+
+DROP TABLE IF EXISTS monitored_accounts;
+DROP TYPE IF EXISTS plan_type;
+DROP TYPE IF EXISTS mood_type;
+
+CREATE TYPE plan_type AS ENUM ('free', 'basic', 'pro', 'enterprise');
+CREATE TYPE mood_type AS ENUM ('happy', 'it''s complicated', 'sad');
+
+CREATE TABLE monitored_accounts (
+    account_id  TEXT PRIMARY KEY,
+    account_name TEXT NOT NULL,
+    plan_type   plan_type NOT NULL DEFAULT 'free',
+    mood        mood_type DEFAULT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO monitored_accounts (account_id, account_name, plan_type, mood) VALUES
+    ('acc-001', 'Acme Corp', 'enterprise', 'happy'),
+    ('acc-002', 'Beta LLC',  'basic',      'it''s complicated'),
+    ('acc-003', 'Gamma Inc', 'free',       NULL),
+    ('acc-004', 'Delta Srl', 'pro',        'sad');

--- a/src-tauri/src/drivers/postgres/binding.rs
+++ b/src-tauri/src/drivers/postgres/binding.rs
@@ -30,6 +30,10 @@ pub(super) struct BoundValue {
 
 pub(super) struct PgValueOptions<'a> {
     pub column_type: Option<&'a str>,
+    /// Schema-qualified, already-quoted enum type name (e.g. `"public"."plan_type"`)
+    /// when the target column is a PostgreSQL enum; `None` otherwise. Drives the
+    /// `CAST($N AS <enum>)` coercion in [`bind_pg_enum_string`] (#465).
+    pub enum_type: Option<&'a str>,
     pub max_blob_size: u64,
     pub allow_default: bool,
 }
@@ -360,6 +364,28 @@ pub(super) fn bind_pg_temporal_string(
     }))
 }
 
+/// Coerce a string value into a PostgreSQL enum column.
+///
+/// The data grid editor sends every edited cell as a JSON string, which binds as
+/// `TEXT`. PostgreSQL has no implicit text-to-enum assignment cast, so the server
+/// rejects the statement with SQLSTATE 42804 — `column "x" is of type <enum> but
+/// expression is of type text` (#465). Same two-part fix as the temporal/uuid
+/// coercions above: wrap the placeholder in `CAST($N AS <enum type>)` so the
+/// server converts through the enum's own input function, and pin the wire type
+/// to `TEXT` so tokio-postgres does not reject the bound `String` client-side.
+/// `qualified_enum` comes from `pg_catalog` and is quoted via
+/// `quote_qualified_type`, so it cannot be turned into a SQL-injection vector.
+pub(super) fn bind_pg_enum_string(
+    s: &str,
+    qualified_enum: &str,
+    placeholder_idx: usize,
+) -> BoundValue {
+    BoundValue {
+        sql: format!("CAST(${} AS {})", placeholder_idx, qualified_enum),
+        param: Some((Box::new(s.to_string()) as PgParam, Type::TEXT)),
+    }
+}
+
 fn bind_pg_string(
     s: &str,
     placeholder_idx: usize,
@@ -377,6 +403,13 @@ fn bind_pg_string(
             sql: format!("${}", placeholder_idx),
             param: Some((Box::new(bytes), Type::BYTEA)),
         });
+    }
+
+    // An enum column always coerces through its own type: any of the later
+    // shape-based heuristics (uuid-shaped, function-shaped, array-shaped
+    // strings) would misinterpret a label that merely looks like one of those.
+    if let Some(enum_type) = options.enum_type {
+        return Ok(bind_pg_enum_string(s, enum_type, placeholder_idx));
     }
 
     if let Some(binding) = options

--- a/src-tauri/src/drivers/postgres/helpers.rs
+++ b/src-tauri/src/drivers/postgres/helpers.rs
@@ -43,6 +43,28 @@ pub(super) fn escape_identifier(name: &str) -> String {
     name.replace('"', "\"\"")
 }
 
+/// Quote a schema-qualified type name (e.g. `"public"."plan_type"`) so it can be
+/// spliced into a `CAST($N AS ...)` without becoming an injection vector.
+pub(super) fn quote_qualified_type(type_schema: &str, type_name: &str) -> String {
+    format!(
+        "\"{}\".\"{}\"",
+        escape_identifier(type_schema),
+        escape_identifier(type_name)
+    )
+}
+
+/// `information_schema.columns` reports enum columns only as `USER-DEFINED`.
+/// When the allowed labels could be loaded from `pg_enum` (pre-quoted and
+/// comma-joined, e.g. `'free','pro'`), surface the full definition in MySQL's
+/// `column_type` shape — `enum('free','pro')` — so the UI can offer a dropdown
+/// of the allowed values (#465). Falls back to the raw `data_type` otherwise.
+pub(super) fn enum_data_type(data_type: String, enum_values: Option<String>) -> String {
+    match enum_values {
+        Some(vals) if !vals.is_empty() => format!("enum({})", vals),
+        _ => data_type,
+    }
+}
+
 /// Checks if a string value looks like WKT (Well-Known Text) geometry format
 pub(super) fn is_wkt_geometry(s: &str) -> bool {
     let s_upper = s.trim().to_uppercase();

--- a/src-tauri/src/drivers/postgres/mod.rs
+++ b/src-tauri/src/drivers/postgres/mod.rs
@@ -21,7 +21,10 @@ use binding::{PgValueOptions, bind_pg_value, build_pk_map_predicate};
 use client::{execute, execute_typed, format_pg_error, get_client, query_all, query_one, query_one_typed};
 pub use explain::explain_query;
 use extract::extract_value;
-use helpers::{escape_identifier, extract_base_type, is_implicit_cast_compatible};
+use helpers::{
+    enum_data_type, escape_identifier, extract_base_type, is_implicit_cast_compatible,
+    quote_qualified_type,
+};
 use tokio_postgres::types::{ToSql, Type};
 
 pub async fn get_schemas(params: &ConnectionParams) -> Result<Vec<String>, String> {
@@ -100,6 +103,11 @@ pub async fn get_columns(
             c.column_default::text,
             c.is_identity::text,
             c.character_maximum_length,
+            (SELECT string_agg('''' || replace(e.enumlabel, '''', '''''') || '''', ',' ORDER BY e.enumsortorder)
+             FROM pg_enum e
+             JOIN pg_type t ON t.oid = e.enumtypid
+             JOIN pg_namespace tn ON tn.oid = t.typnamespace
+             WHERE t.typname = c.udt_name AND tn.nspname = c.udt_schema) AS enum_values,
             (SELECT COUNT(*) FROM information_schema.table_constraints tc
              JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
              AND tc.table_schema = kcu.table_schema
@@ -141,9 +149,14 @@ pub async fn get_columns(
                 None
             };
 
+            let enum_values: Option<String> = r.try_get("enum_values").ok().flatten();
+
             TableColumn {
                 name: r.try_get("column_name").unwrap_or_default(),
-                data_type: r.try_get("data_type").unwrap_or_default(),
+                data_type: enum_data_type(
+                    r.try_get("data_type").unwrap_or_default(),
+                    enum_values,
+                ),
                 is_pk,
                 is_nullable: null_str == "YES",
                 is_auto_increment: is_auto,
@@ -235,6 +248,11 @@ pub async fn get_all_columns_batch(
             c.column_default,
             c.is_identity,
             c.character_maximum_length,
+            (SELECT string_agg('''' || replace(e.enumlabel, '''', '''''') || '''', ',' ORDER BY e.enumsortorder)
+             FROM pg_enum e
+             JOIN pg_type t ON t.oid = e.enumtypid
+             JOIN pg_namespace tn ON tn.oid = t.typnamespace
+             WHERE t.typname = c.udt_name AND tn.nspname = c.udt_schema) AS enum_values,
             (SELECT COUNT(*) FROM information_schema.table_constraints tc
              JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
              AND tc.table_schema = kcu.table_schema
@@ -277,9 +295,11 @@ pub async fn get_all_columns_batch(
             None
         };
 
+        let enum_values: Option<String> = row.try_get("enum_values").ok().flatten();
+
         let column = TableColumn {
             name: row.try_get("column_name").unwrap_or_default(),
-            data_type: row.try_get("data_type").unwrap_or_default(),
+            data_type: enum_data_type(row.try_get("data_type").unwrap_or_default(), enum_values),
             is_pk,
             is_nullable: null_str == "YES",
             is_auto_increment: is_auto,
@@ -513,6 +533,48 @@ async fn get_pk_column_types(
     types
 }
 
+/// Map every enum-typed column of the table to its schema-qualified, quoted enum
+/// type name (e.g. `"public"."plan_type"`). PostgreSQL rejects a `TEXT`-bound
+/// parameter assigned to an enum column with SQLSTATE 42804 (#465), so the
+/// binding layer needs the real type to `CAST` through. On any catalog error the
+/// map is simply empty and binding falls back to the plain TEXT path.
+async fn get_enum_column_types(
+    pool: &deadpool_postgres::Pool,
+    schema: &str,
+    table: &str,
+) -> HashMap<String, String> {
+    let query = "SELECT a.attname::text AS column_name, \
+tn.nspname::text AS type_schema, t.typname::text AS type_name \
+FROM pg_attribute a \
+JOIN pg_class c ON c.oid = a.attrelid \
+JOIN pg_namespace n ON n.oid = c.relnamespace \
+JOIN pg_type t ON t.oid = a.atttypid \
+JOIN pg_namespace tn ON tn.oid = t.typnamespace \
+WHERE n.nspname = $1 AND c.relname = $2 \
+AND a.attnum > 0 AND NOT a.attisdropped AND t.typtype = 'e'";
+
+    match query_all(pool, query, &[&schema, &table]).await {
+        Ok(rows) => rows
+            .iter()
+            .filter_map(|row| {
+                let col: String = row.try_get("column_name").ok()?;
+                let type_schema: String = row.try_get("type_schema").ok()?;
+                let type_name: String = row.try_get("type_name").ok()?;
+                Some((col, quote_qualified_type(&type_schema, &type_name)))
+            })
+            .collect(),
+        Err(err) => {
+            log::debug!(
+                "Could not load PostgreSQL enum column types for {}.{}: {}",
+                schema,
+                table,
+                err
+            );
+            HashMap::new()
+        }
+    }
+}
+
 fn json_value_kind(value: &serde_json::Value) -> &'static str {
     match value {
         serde_json::Value::Null => "null",
@@ -613,6 +675,7 @@ pub async fn update_record(
             None
         }
     };
+    let enum_types = get_enum_column_types(&pool, schema, table).await;
     let new_val_for_context = new_val.clone();
     let pk_map_for_context = pk_map.clone();
 
@@ -631,6 +694,7 @@ pub async fn update_record(
         bound_params.len() + 1,
         PgValueOptions {
             column_type: column_data_type.as_deref(),
+            enum_type: enum_types.get(col_name).map(|s| s.as_str()),
             max_blob_size,
             allow_default: true,
         },
@@ -726,6 +790,8 @@ pub async fn insert_record(
             }
         };
 
+    let enum_types = get_enum_column_types(&pool, schema, table).await;
+
     let mut params: Vec<(Box<dyn ToSql + Sync + Send>, Type)> = Vec::with_capacity(entries.len());
     let mut vals_set: Vec<String> = Vec::with_capacity(entries.len());
 
@@ -736,6 +802,7 @@ pub async fn insert_record(
             params.len() + 1,
             PgValueOptions {
                 column_type,
+                enum_type: enum_types.get(&col_name).map(|s| s.as_str()),
                 max_blob_size,
                 allow_default: false,
             },
@@ -1103,6 +1170,11 @@ pub async fn get_view_columns(
             c.column_default,
             c.is_identity,
             c.character_maximum_length,
+            (SELECT string_agg('''' || replace(e.enumlabel, '''', '''''') || '''', ',' ORDER BY e.enumsortorder)
+             FROM pg_enum e
+             JOIN pg_type t ON t.oid = e.enumtypid
+             JOIN pg_namespace tn ON tn.oid = t.typnamespace
+             WHERE t.typname = c.udt_name AND tn.nspname = c.udt_schema) AS enum_values,
             (SELECT COUNT(*) FROM information_schema.table_constraints tc
              JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
              AND tc.table_schema = kcu.table_schema
@@ -1144,9 +1216,14 @@ pub async fn get_view_columns(
                 None
             };
 
+            let enum_values: Option<String> = r.try_get("enum_values").ok().flatten();
+
             TableColumn {
                 name: r.try_get("column_name").unwrap_or_default(),
-                data_type: r.try_get("data_type").unwrap_or_default(),
+                data_type: enum_data_type(
+                    r.try_get("data_type").unwrap_or_default(),
+                    enum_values,
+                ),
                 is_pk,
                 is_nullable: null_str == "YES",
                 is_auto_increment: is_auto,

--- a/src-tauri/src/drivers/postgres/tests.rs
+++ b/src-tauri/src/drivers/postgres/tests.rs
@@ -1,8 +1,11 @@
 use super::binding::{
-    PgValueOptions, bind_pg_boolean_string, bind_pg_number, bind_pg_numeric_string,
-    bind_pg_temporal_string, bind_pg_value, build_pk_map_predicate, build_pk_predicate,
+    PgValueOptions, bind_pg_boolean_string, bind_pg_enum_string, bind_pg_number,
+    bind_pg_numeric_string, bind_pg_temporal_string, bind_pg_value, build_pk_map_predicate,
+    build_pk_predicate,
 };
-use super::helpers::{extract_base_type, is_implicit_cast_compatible};
+use super::helpers::{
+    enum_data_type, extract_base_type, is_implicit_cast_compatible, quote_qualified_type,
+};
 
 mod extract_base_type_tests {
     use super::*;
@@ -393,6 +396,7 @@ mod bind_pg_value_tests {
             1,
             PgValueOptions {
                 column_type: Some("boolean"),
+                enum_type: None,
                 max_blob_size: 1024,
                 allow_default: true,
             },
@@ -410,6 +414,7 @@ mod bind_pg_value_tests {
             1,
             PgValueOptions {
                 column_type: Some("boolean"),
+                enum_type: None,
                 max_blob_size: 1024,
                 allow_default: true,
             },
@@ -427,6 +432,7 @@ mod bind_pg_value_tests {
             1,
             PgValueOptions {
                 column_type: Some("integer"),
+                enum_type: None,
                 max_blob_size: 1024,
                 allow_default: true,
             },
@@ -444,6 +450,7 @@ mod bind_pg_value_tests {
             1,
             PgValueOptions {
                 column_type: None,
+                enum_type: None,
                 max_blob_size: 1024,
                 allow_default: true,
             },
@@ -461,6 +468,7 @@ mod bind_pg_value_tests {
             1,
             PgValueOptions {
                 column_type: None,
+                enum_type: None,
                 max_blob_size: 1024,
                 allow_default: false,
             },
@@ -478,6 +486,7 @@ mod bind_pg_value_tests {
             1,
             PgValueOptions {
                 column_type: None,
+                enum_type: None,
                 max_blob_size: 1024,
                 allow_default: false,
             },
@@ -495,6 +504,7 @@ mod bind_pg_value_tests {
             1,
             PgValueOptions {
                 column_type: Some("jsonb"),
+                enum_type: None,
                 max_blob_size: 1024,
                 allow_default: false,
             },
@@ -512,6 +522,7 @@ mod bind_pg_value_tests {
             1,
             PgValueOptions {
                 column_type: Some("json"),
+                enum_type: None,
                 max_blob_size: 1024,
                 allow_default: false,
             },
@@ -529,6 +540,7 @@ mod bind_pg_value_tests {
             1,
             PgValueOptions {
                 column_type: Some("jsonb"),
+                enum_type: None,
                 max_blob_size: 1024,
                 allow_default: false,
             },
@@ -546,6 +558,7 @@ mod bind_pg_value_tests {
             1,
             PgValueOptions {
                 column_type: Some("text"),
+                enum_type: None,
                 max_blob_size: 1024,
                 allow_default: false,
             },
@@ -554,6 +567,141 @@ mod bind_pg_value_tests {
             Err(err) => err,
         };
         assert!(err.contains("JSON object"));
+    }
+}
+
+mod bind_pg_enum_string_tests {
+    use super::*;
+    use tokio_postgres::types::Type;
+
+    #[test]
+    fn casts_through_the_qualified_enum_type_pinned_as_text() {
+        let bound = bind_pg_enum_string("pro", "\"public\".\"plan_type\"", 1);
+        assert_eq!(bound.sql, "CAST($1 AS \"public\".\"plan_type\")");
+        let (_, ty) = bound.param.expect("expected a bound parameter");
+        assert_eq!(ty, Type::TEXT);
+    }
+
+    #[test]
+    fn placeholder_index_is_respected() {
+        let bound = bind_pg_enum_string("free", "\"public\".\"plan_type\"", 3);
+        assert_eq!(bound.sql, "CAST($3 AS \"public\".\"plan_type\")");
+    }
+
+    #[test]
+    fn bind_pg_value_uses_enum_coercion_for_enum_columns() {
+        let bound = bind_pg_value(
+            serde_json::json!("enterprise"),
+            1,
+            PgValueOptions {
+                column_type: Some("USER-DEFINED"),
+                enum_type: Some("\"public\".\"plan_type\""),
+                max_blob_size: 1024,
+                allow_default: true,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(bound.sql, "CAST($1 AS \"public\".\"plan_type\")");
+        assert!(bound.param.is_some());
+    }
+
+    #[test]
+    fn enum_coercion_wins_over_shape_heuristics() {
+        // A label that happens to be uuid-shaped must still cast to the enum,
+        // not to uuid.
+        let bound = bind_pg_value(
+            serde_json::json!("123e4567-e89b-12d3-a456-426614174000"),
+            1,
+            PgValueOptions {
+                column_type: Some("USER-DEFINED"),
+                enum_type: Some("\"public\".\"weird_enum\""),
+                max_blob_size: 1024,
+                allow_default: true,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(bound.sql, "CAST($1 AS \"public\".\"weird_enum\")");
+    }
+
+    #[test]
+    fn null_for_enum_column_stays_sql_null() {
+        let bound = bind_pg_value(
+            serde_json::Value::Null,
+            1,
+            PgValueOptions {
+                column_type: Some("USER-DEFINED"),
+                enum_type: Some("\"public\".\"plan_type\""),
+                max_blob_size: 1024,
+                allow_default: true,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(bound.sql, "NULL");
+        assert!(bound.param.is_none());
+    }
+
+    #[test]
+    fn default_sentinel_wins_over_enum_coercion() {
+        let bound = bind_pg_value(
+            serde_json::json!("__USE_DEFAULT__"),
+            1,
+            PgValueOptions {
+                column_type: Some("USER-DEFINED"),
+                enum_type: Some("\"public\".\"plan_type\""),
+                max_blob_size: 1024,
+                allow_default: true,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(bound.sql, "DEFAULT");
+        assert!(bound.param.is_none());
+    }
+}
+
+mod enum_helpers_tests {
+    use super::*;
+
+    #[test]
+    fn quote_qualified_type_quotes_schema_and_name() {
+        assert_eq!(
+            quote_qualified_type("public", "plan_type"),
+            "\"public\".\"plan_type\""
+        );
+    }
+
+    #[test]
+    fn quote_qualified_type_escapes_embedded_quotes() {
+        assert_eq!(
+            quote_qualified_type("pub\"lic", "plan\"type"),
+            "\"pub\"\"lic\".\"plan\"\"type\""
+        );
+    }
+
+    #[test]
+    fn enum_data_type_surfaces_allowed_values() {
+        assert_eq!(
+            enum_data_type(
+                "USER-DEFINED".to_string(),
+                Some("'free','basic','pro'".to_string())
+            ),
+            "enum('free','basic','pro')"
+        );
+    }
+
+    #[test]
+    fn enum_data_type_keeps_raw_type_without_values() {
+        assert_eq!(
+            enum_data_type("integer".to_string(), None),
+            "integer"
+        );
+        assert_eq!(
+            enum_data_type("USER-DEFINED".to_string(), Some(String::new())),
+            "USER-DEFINED"
+        );
     }
 }
 


### PR DESCRIPTION
Editing or inserting a value into a PostgreSQL enum column failed with:

```
ERROR: column "plan_type" is of type plan_type but expression is of type text (SQLSTATE 42804)
```

The grid sends every edited cell as a JSON string, which the driver bound as a plain `TEXT` parameter. PostgreSQL has no implicit text-to-enum assignment cast, so the server rejected the statement.

## What changed

**Binding fix (the actual bug)**

- `update_record` / `insert_record` now look up enum-typed columns from `pg_catalog` (`pg_attribute` joined with `pg_type` where `typtype = 'e'`) and pass the schema-qualified type name down to the binding layer.
- `bind_pg_value` wraps the placeholder in `CAST($N AS "schema"."enum_type")` while pinning the wire type to `TEXT` — the same two-part approach already used for the temporal and uuid coercions (#392, #401): the value goes over the wire as text and PostgreSQL converts it server-side through the enum's own input function. The type name comes from the catalog and is identifier-quoted, so it can't be abused for injection.
- The enum coercion runs before the shape-based heuristics, so a label that happens to look like a uuid, a function call or an array still casts to the enum. `NULL` and the `DEFAULT` sentinel keep their existing behavior.

**Dropdown editing (same treatment as the MySQL fix in #455)**

- `information_schema` reports enum columns only as `USER-DEFINED`, which told the UI nothing. `get_columns`, `get_all_columns_batch` and `get_view_columns` now aggregate the labels from `pg_enum` (in `enumsortorder`) and surface the column type as `enum('free','basic','pro')` — the same shape MySQL's `column_type` uses. The existing `EnumSetInput` dropdown (grid inline editing + row sidebar) then works for PostgreSQL out of the box, no frontend changes needed.

## Tests

- Unit tests for the new `quote_qualified_type` / `enum_data_type` helpers and for the enum binding paths (cast SQL, TEXT pinning, precedence over the uuid heuristic, NULL / DEFAULT passthrough).
- New demo script `demo/init/postgres/07-enum-demo.sql` with two enum types, including a label containing an escaped single quote, to test the dropdown and the quote unescaping manually.

Verified against PostgreSQL 16 in Docker: editing an enum cell from the grid and from the row sidebar, inserting new rows with enum values, and NULLing a nullable enum column all work; the dropdown shows the allowed labels in declaration order.

Closes #465