### PR TITLE
Fix AI Query Assist schema loading through database drivers

### DIFF
--- a/packages/create-plugin/templates/rust-driver/src/handlers/metadata.rs
+++ b/packages/create-plugin/templates/rust-driver/src/handlers/metadata.rs
@@ -62,15 +62,9 @@ pub fn get_routine_definition(id: Value, _params: &Value) -> Value {
 }
 
 pub fn get_schema_snapshot(id: Value, _params: &Value) -> Value {
-    // Used for the ER diagram. Return tables + columns + foreign_keys in one shot.
-    ok_response(
-        id,
-        json!({
-            "tables": [],
-            "columns": {},
-            "foreign_keys": {},
-        }),
-    )
+    // Used for the ER diagram. Return
+    // [{ name, columns: [...], foreign_keys: [...] }].
+    ok_response(id, json!([]))
 }
 
 pub fn get_all_columns_batch(id: Value, _params: &Value) -> Value {

--- a/plugins/PLUGIN_GUIDE.md
+++ b/plugins/PLUGIN_GUIDE.md
@@ -946,6 +946,47 @@ Delete a row from a table.
 
 ---
 
+### AI Schema Context (Optional)
+
+AI Query Assist obtains metadata through the active database driver. Plugins
+that already implement `get_tables`, `get_columns`, and `get_foreign_keys` work
+without changes: Tabularis calls those standard methods, limits the result, and
+formats the provider-agnostic system prompt in the host.
+
+Plugins may optionally implement `get_ai_schema_context` to replace those
+per-table calls with a database-specific batch query. Return JSON-RPC error
+`-32601` when the method is not implemented; Tabularis then uses the standard
+metadata fallback automatically.
+
+**Params:**
+```json
+{
+  "params": ConnectionParams,
+  "schema": "public",
+  "max_tables": 20
+}
+```
+
+**Result:**
+```json
+{
+  "tables": [
+    {
+      "name": "users",
+      "columns": [ /* standard get_columns entries */ ],
+      "foreign_keys": [ /* standard get_foreign_keys entries */ ]
+    }
+  ],
+  "total_table_count": 42
+}
+```
+
+The plugin must respect `max_tables`, but `total_table_count` reports the
+number of tables before truncation. Plugins return structured metadata only;
+the host owns prompt wording, identifier quoting, and provider dispatch.
+
+---
+
 ### Batch / ER Diagram Methods
 
 These methods are used to build ER diagrams efficiently by loading all metadata in one call.
@@ -958,11 +999,13 @@ Return the complete schema structure (tables + columns + foreign keys).
 
 **Result:**
 ```json
-{
-  "tables": [{ "name": "users", "schema": "public", "comment": null }],
-  "columns": { "users": [ /* column list */ ] },
-  "foreign_keys": { "users": [ /* FK list */ ] }
-}
+[
+  {
+    "name": "users",
+    "columns": [ /* column list */ ],
+    "foreign_keys": [ /* FK list */ ]
+  }
+]
 ```
 
 ---

--- a/src-tauri/src/ai_schema_context.rs
+++ b/src-tauri/src/ai_schema_context.rs
@@ -1,0 +1,88 @@
+use futures::future::join_all;
+
+use crate::drivers::driver_trait::DatabaseDriver;
+use crate::models::{AiSchemaContext, ConnectionParams, TableSchema};
+
+pub const DEFAULT_MAX_TABLES: usize = 20;
+const MAX_ALLOWED_TABLES: usize = 100;
+
+/// Builds a bounded schema context from the common driver metadata API.
+/// Plugin drivers inherit this behavior automatically through `RpcDriver`.
+pub async fn load_from_driver<D: DatabaseDriver + ?Sized>(
+    driver: &D,
+    params: &ConnectionParams,
+    schema: Option<&str>,
+    max_tables: usize,
+) -> Result<AiSchemaContext, String> {
+    let tables = driver.get_tables(params, schema).await?;
+    let total_table_count = tables.len();
+    let limit = max_tables.clamp(1, MAX_ALLOWED_TABLES);
+
+    let table_loads = tables.into_iter().take(limit).map(|table| async move {
+        let (columns, foreign_keys) = tokio::join!(
+            driver.get_columns(params, &table.name, schema),
+            driver.get_foreign_keys(params, &table.name, schema),
+        );
+
+        Ok::<TableSchema, String>(TableSchema {
+            name: table.name,
+            columns: columns?,
+            // Relationships enrich join generation, but a driver that cannot
+            // expose them should still provide useful table/column context.
+            foreign_keys: foreign_keys.unwrap_or_default(),
+        })
+    });
+
+    let tables = join_all(table_loads)
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(AiSchemaContext {
+        tables,
+        total_table_count,
+    })
+}
+
+/// Renders driver-provided metadata into the stable prompt format shared by
+/// every AI provider. Drivers never control the surrounding system prompt.
+pub fn format_for_prompt(context: &AiSchemaContext, identifier_quote: &str) -> String {
+    let quote = if identifier_quote.is_empty() {
+        "\""
+    } else {
+        identifier_quote
+    };
+    let mut lines = Vec::new();
+
+    for table in &context.tables {
+        lines.push(format!("Table: {quote}{}{quote}", table.name));
+        for column in &table.columns {
+            let mut description = format!("  - {} {}", column.name, column.data_type);
+            if column.is_pk {
+                description.push_str(" PK");
+            }
+            if !column.is_nullable {
+                description.push_str(" NOT NULL");
+            }
+            if let Some(default) = &column.default_value {
+                description.push_str(&format!(" DEFAULT {default}"));
+            }
+            lines.push(description);
+        }
+        for foreign_key in &table.foreign_keys {
+            lines.push(format!(
+                "  FK: {} -> {}.{}",
+                foreign_key.column_name, foreign_key.ref_table, foreign_key.ref_column
+            ));
+        }
+    }
+
+    let omitted = context
+        .total_table_count
+        .saturating_sub(context.tables.len());
+    if omitted > 0 {
+        lines.push(format!("... and {omitted} more tables (not shown)"));
+    }
+
+    lines.join("\n")
+}

--- a/src-tauri/src/ai_schema_context_tests.rs
+++ b/src-tauri/src/ai_schema_context_tests.rs
@@ -1,0 +1,57 @@
+use crate::ai_schema_context::format_for_prompt;
+use crate::models::{AiSchemaContext, ForeignKey, TableColumn, TableSchema};
+
+fn column(name: &str, data_type: &str, is_pk: bool, is_nullable: bool) -> TableColumn {
+    TableColumn {
+        name: name.to_string(),
+        data_type: data_type.to_string(),
+        is_pk,
+        is_nullable,
+        is_auto_increment: false,
+        default_value: None,
+        character_maximum_length: None,
+    }
+}
+
+#[test]
+fn formats_columns_relationships_and_truncation() {
+    let context = AiSchemaContext {
+        tables: vec![TableSchema {
+            name: "users".to_string(),
+            columns: vec![
+                column("id", "bigint", true, false),
+                column("team_id", "bigint", false, false),
+            ],
+            foreign_keys: vec![ForeignKey {
+                name: "users_team_id_fkey".to_string(),
+                column_name: "team_id".to_string(),
+                ref_table: "teams".to_string(),
+                ref_column: "id".to_string(),
+                on_delete: None,
+                on_update: None,
+            }],
+        }],
+        total_table_count: 3,
+    };
+
+    let prompt = format_for_prompt(&context, "\"");
+
+    assert!(prompt.contains("Table: \"users\""));
+    assert!(prompt.contains("  - id bigint PK NOT NULL"));
+    assert!(prompt.contains("  FK: team_id -> teams.id"));
+    assert!(prompt.contains("... and 2 more tables (not shown)"));
+}
+
+#[test]
+fn uses_double_quotes_when_driver_quote_is_empty() {
+    let context = AiSchemaContext {
+        tables: vec![TableSchema {
+            name: "events".to_string(),
+            columns: Vec::new(),
+            foreign_keys: Vec::new(),
+        }],
+        total_table_count: 1,
+    };
+
+    assert_eq!(format_for_prompt(&context, ""), "Table: \"events\"");
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -694,6 +694,32 @@ pub async fn get_schema_snapshot<R: Runtime>(
 }
 
 #[tauri::command]
+pub async fn get_ai_schema_context<R: Runtime>(
+    app: AppHandle<R>,
+    connection_id: String,
+    schema: Option<String>,
+) -> Result<String, String> {
+    let saved_conn = find_connection_by_id(&app, &connection_id)?;
+    let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
+    let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
+    let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
+    let driver = driver_for(&saved_conn.params.driver).await?;
+    let identifier_quote = driver.manifest().capabilities.identifier_quote.as_str();
+    let context = driver
+        .get_ai_schema_context(
+            &params,
+            schema.as_deref(),
+            crate::ai_schema_context::DEFAULT_MAX_TABLES,
+        )
+        .await?;
+
+    Ok(crate::ai_schema_context::format_for_prompt(
+        &context,
+        identifier_quote,
+    ))
+}
+
+#[tauri::command]
 pub async fn save_connection<R: Runtime>(
     app: AppHandle<R>,
     name: String,

--- a/src-tauri/src/drivers/driver_trait.rs
+++ b/src-tauri/src/drivers/driver_trait.rs
@@ -7,10 +7,9 @@ use sqlx::{AnyConnection, Connection};
 use std::str::FromStr;
 
 use crate::models::{
-    BatchStatementResult, ColumnDefinition, ConnectionParams, DataTypeInfo, ExplainPlan,
-    ForeignKey, Index, QueryResult, RoutineCallArg, RoutineInfo, RoutineParameter, TableColumn,
-    TableInfo,
-    TableSchema, TriggerInfo, ViewInfo,
+    AiSchemaContext, BatchStatementResult, ColumnDefinition, ConnectionParams, DataTypeInfo,
+    ExplainPlan, ForeignKey, Index, QueryResult, RoutineCallArg, RoutineInfo, RoutineParameter,
+    TableColumn, TableInfo, TableSchema, TriggerInfo, ViewInfo,
 };
 
 /// Callback invoked the moment each statement in a batch finishes, with the
@@ -291,6 +290,20 @@ pub trait DatabaseDriver: Send + Sync {
         table: &str,
         schema: Option<&str>,
     ) -> Result<Vec<TableColumn>, String>;
+
+    /// Returns a bounded, structured schema context for AI features.
+    ///
+    /// Drivers may override this to use a database-specific batch query. The
+    /// default implementation composes the context from the standard metadata
+    /// methods, so existing external plugins work without a protocol update.
+    async fn get_ai_schema_context(
+        &self,
+        params: &ConnectionParams,
+        schema: Option<&str>,
+        max_tables: usize,
+    ) -> Result<AiSchemaContext, String> {
+        crate::ai_schema_context::load_from_driver(self, params, schema, max_tables).await
+    }
 
     async fn get_foreign_keys(
         &self,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,9 @@ pub mod ai_commands;
 pub mod ai_notebook_export;
 #[cfg(test)]
 pub mod ai_notebook_export_tests;
+pub mod ai_schema_context;
+#[cfg(test)]
+pub mod ai_schema_context_tests;
 pub mod askpass;
 pub mod cli;
 pub mod clipboard_import;
@@ -424,6 +427,7 @@ pub fn run() {
             ai::get_ai_models,
             // Clipboard Import
             clipboard_import::execute_clipboard_import,
+            commands::get_ai_schema_context,
             commands::get_schema_snapshot,
             // DDL generation
             commands::get_create_table_sql,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -488,6 +488,15 @@ pub struct TableSchema {
     pub foreign_keys: Vec<ForeignKey>,
 }
 
+/// Bounded schema metadata prepared by a database driver for AI features.
+/// The host remains responsible for rendering this structured data into a
+/// provider-agnostic prompt.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AiSchemaContext {
+    pub tables: Vec<TableSchema>,
+    pub total_table_count: usize,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RoutineInfo {
     pub name: String,

--- a/src-tauri/src/plugins/driver.rs
+++ b/src-tauri/src/plugins/driver.rs
@@ -12,8 +12,9 @@ use tokio::sync::{mpsc, oneshot};
 
 use crate::drivers::driver_trait::{DatabaseDriver, PluginManifest};
 use crate::models::{
-    ColumnDefinition, ConnectionParams, DataTypeInfo, ExplainPlan, ForeignKey, Index, QueryResult,
-    RoutineInfo, RoutineParameter, TableColumn, TableInfo, TableSchema, TriggerInfo, ViewInfo,
+    AiSchemaContext, ColumnDefinition, ConnectionParams, DataTypeInfo, ExplainPlan, ForeignKey,
+    Index, QueryResult, RoutineInfo, RoutineParameter, TableColumn, TableInfo, TableSchema,
+    TriggerInfo, ViewInfo,
 };
 use crate::plugins::rpc::{JsonRpcRequest, JsonRpcResponse};
 
@@ -895,6 +896,32 @@ impl DatabaseDriver for RpcDriver {
         serde_json::from_value(res).map_err(|e| e.to_string())
     }
 
+    async fn get_ai_schema_context(
+        &self,
+        params: &ConnectionParams,
+        schema: Option<&str>,
+        max_tables: usize,
+    ) -> Result<AiSchemaContext, String> {
+        match self
+            .process
+            .call(
+                "get_ai_schema_context",
+                json!({
+                    "params": params,
+                    "schema": schema,
+                    "max_tables": max_tables,
+                }),
+            )
+            .await
+        {
+            Ok(value) => serde_json::from_value(value).map_err(|e| e.to_string()),
+            Err(error) if is_method_not_found(&error) => {
+                crate::ai_schema_context::load_from_driver(self, params, schema, max_tables).await
+            }
+            Err(error) => Err(error),
+        }
+    }
+
     async fn get_all_columns_batch(
         &self,
         params: &ConnectionParams,
@@ -1016,6 +1043,86 @@ mod tests {
             }),
             data_types: Vec::new(),
         }
+    }
+
+    fn test_driver_result<F>(mut handle_request: F) -> RpcDriver
+    where
+        F: FnMut(JsonRpcRequest) -> Result<Value, String> + Send + 'static,
+    {
+        let (tx, mut rx) = mpsc::channel::<PluginCommand>(8);
+        tokio::spawn(async move {
+            while let Some(command) = rx.recv().await {
+                if let PluginCommand::Call(request, response_tx) = command {
+                    let result = handle_request(request);
+                    let _ = response_tx.send(result);
+                }
+            }
+        });
+
+        let (shutdown_tx, _shutdown_rx) = oneshot::channel();
+        RpcDriver {
+            manifest: test_manifest(),
+            process: Arc::new(PluginProcess {
+                sender: tx,
+                next_id: AtomicU64::new(1),
+                shutdown_tx: tokio::sync::Mutex::new(Some(shutdown_tx)),
+                pid: None,
+            }),
+            data_types: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn rpc_driver_uses_custom_ai_schema_context_when_available() {
+        let driver = test_driver(|request| {
+            assert_eq!(request.method, "get_ai_schema_context");
+            assert_eq!(request.params["schema"], "public");
+            assert_eq!(request.params["max_tables"], 20);
+            json!({
+                "tables": [{
+                    "name": "users",
+                    "columns": [],
+                    "foreign_keys": []
+                }],
+                "total_table_count": 1
+            })
+        });
+
+        let context = driver
+            .get_ai_schema_context(&test_connection_params(), Some("public"), 20)
+            .await
+            .expect("get_ai_schema_context");
+
+        assert_eq!(context.tables.len(), 1);
+        assert_eq!(context.tables[0].name, "users");
+        assert_eq!(context.total_table_count, 1);
+    }
+
+    #[tokio::test]
+    async fn rpc_driver_builds_ai_schema_context_from_standard_metadata_as_fallback() {
+        let driver = test_driver_result(|request| match request.method.as_str() {
+            "get_ai_schema_context" => Err("Method not found (-32601)".to_string()),
+            "get_tables" => Ok(json!([{ "name": "users" }])),
+            "get_columns" => Ok(json!([{
+                "name": "id",
+                "data_type": "bigint",
+                "is_pk": true,
+                "is_nullable": false,
+                "is_auto_increment": true
+            }])),
+            "get_foreign_keys" => Ok(json!([])),
+            method => Err(format!("Unexpected method: {method}")),
+        });
+
+        let context = driver
+            .get_ai_schema_context(&test_connection_params(), Some("public"), 20)
+            .await
+            .expect("fallback schema context");
+
+        assert_eq!(context.tables.len(), 1);
+        assert_eq!(context.tables[0].name, "users");
+        assert_eq!(context.tables[0].columns[0].name, "id");
+        assert_eq!(context.total_table_count, 1);
     }
 
     #[tokio::test]

--- a/src/components/modals/AiQueryModal.tsx
+++ b/src/components/modals/AiQueryModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { X, Sparkles, Loader2 } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { useDatabase } from "../../hooks/useDatabase";
@@ -9,62 +9,95 @@ interface AiQueryModalProps {
   isOpen: boolean;
   onClose: () => void;
   onInsert: (sql: string) => void;
+  connectionId?: string;
+  schema?: string;
 }
 
-interface TableColumn {
-  name: string;
-  data_type: string;
+interface SchemaLoadState {
+  key: string;
+  context: string;
+  error: string | null;
 }
 
-export const AiQueryModal = ({ isOpen, onClose, onInsert }: AiQueryModalProps) => {
-  const { activeConnectionId, tables, activeSchema } = useDatabase();
+export const AiQueryModal = ({
+  isOpen,
+  onClose,
+  onInsert,
+  connectionId,
+  schema,
+}: AiQueryModalProps) => {
+  const { activeConnectionId, activeSchema } = useDatabase();
   const { settings } = useSettings();
+  const resolvedConnectionId = connectionId ?? activeConnectionId;
+  const resolvedSchema = schema ?? activeSchema ?? undefined;
+  const schemaKey = `${resolvedConnectionId ?? ""}:${resolvedSchema ?? ""}`;
   
   const [prompt, setPrompt] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [schemaContext, setSchemaContext] = useState<string>("");
-  const [isSchemaLoading, setIsSchemaLoading] = useState(false);
+  const [schemaLoad, setSchemaLoad] = useState<SchemaLoadState>({
+    key: "",
+    context: "",
+    error: null,
+  });
+  const inFlightSchemaLoad = useRef<{
+    key: string;
+    promise: Promise<string>;
+  } | null>(null);
+  const isSchemaLoading = Boolean(
+    isOpen && resolvedConnectionId && schemaLoad.key !== schemaKey,
+  );
 
-  const loadSchema = useCallback(async () => {
-    setIsSchemaLoading(true);
-    setError(null);
-    try {
-      // Parallel fetch of columns for all tables
-      // Limit to first 20 tables to prevent massive overhead for now
-      // TODO: Implement smart schema selection or backend-side schema dump
-      const tablesToFetch = tables.slice(0, 20); 
-      
-      const promises = tablesToFetch.map(async (table) => {
-        const cols = await invoke<TableColumn[]>("get_columns", {
-          connectionId: activeConnectionId,
-          tableName: table.name,
-          ...(activeSchema ? { schema: activeSchema } : {}),
-        });
-        return `Table: ${table.name} (${cols.map(c => `${c.name} ${c.data_type}`).join(", ")})`;
-      });
-
-      const schemas = await Promise.all(promises);
-      let context = schemas.join("\n");
-      
-      if (tables.length > 20) {
-          context += `\n... and ${tables.length - 20} more tables (names: ${tables.slice(20).map(t => t.name).join(", ")})`;
-      }
-      
-      setSchemaContext(context);
-    } catch (err) {
-      console.error("Failed to load schema:", err);
-      setError("Failed to load database schema context");
-    } finally {
-      setIsSchemaLoading(false);
+  const loadSchema = useCallback((): Promise<string> => {
+    if (!resolvedConnectionId) {
+      return Promise.resolve("");
     }
-  }, [activeConnectionId, tables, activeSchema]);
+
+    if (inFlightSchemaLoad.current?.key === schemaKey) {
+      return inFlightSchemaLoad.current.promise;
+    }
+
+    const promise = invoke<string>("get_ai_schema_context", {
+      connectionId: resolvedConnectionId,
+      ...(resolvedSchema ? { schema: resolvedSchema } : {}),
+    });
+    inFlightSchemaLoad.current = { key: schemaKey, promise };
+    const clearInFlight = () => {
+      if (inFlightSchemaLoad.current?.promise === promise) {
+        inFlightSchemaLoad.current = null;
+      }
+    };
+    void promise.then(clearInFlight, clearInFlight);
+    return promise;
+  }, [resolvedConnectionId, resolvedSchema, schemaKey]);
 
   useEffect(() => {
-    if (isOpen && activeConnectionId && tables.length > 0) {
-      loadSchema();
+    if (!isOpen || !resolvedConnectionId) {
+      return;
     }
-  }, [isOpen, activeConnectionId, tables, loadSchema]);
+
+    let cancelled = false;
+    void loadSchema()
+      .then((context) => {
+        if (!cancelled) {
+          setSchemaLoad({ key: schemaKey, context, error: null });
+        }
+      })
+      .catch((loadError: unknown) => {
+        console.error("Failed to load schema:", loadError);
+        if (!cancelled) {
+          setSchemaLoad({
+            key: schemaKey,
+            context: "",
+            error: "Failed to load database schema context",
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, resolvedConnectionId, schemaKey, loadSchema]);
 
   const handleGenerate = async () => {
     if (!prompt.trim() || !settings.aiProvider) {
@@ -76,12 +109,16 @@ export const AiQueryModal = ({ isOpen, onClose, onInsert }: AiQueryModalProps) =
     setError(null);
 
     try {
+      const schemaContext =
+        schemaLoad.key === schemaKey && schemaLoad.error === null
+          ? schemaLoad.context
+          : await loadSchema();
       const sql = await invoke<string>("generate_ai_query", {
         req: {
           provider: settings.aiProvider,
           model: settings.aiModel || "", // Default fallback handled by backend (first model in list)
           prompt,
-          schema: schemaContext
+          schema: schemaContext,
         }
       });
       onInsert(sql);
@@ -134,9 +171,9 @@ export const AiQueryModal = ({ isOpen, onClose, onInsert }: AiQueryModalProps) =
             />
           </div>
 
-          {error && (
+          {(error || schemaLoad.error) && (
             <div className="text-error-text text-sm bg-error-bg p-2 rounded border border-error-border">
-              {error}
+              {error || schemaLoad.error}
             </div>
           )}
 

--- a/src/components/notebook/NotebookAiButtons.tsx
+++ b/src/components/notebook/NotebookAiButtons.tsx
@@ -49,6 +49,8 @@ export function NotebookAiButtons({
       <AiQueryModal
         isOpen={isGenerateOpen}
         onClose={() => setIsGenerateOpen(false)}
+        connectionId={connectionId}
+        schema={schema}
         onInsert={(sql) => {
           onInsert(sql);
           setIsGenerateOpen(false);

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -3985,6 +3985,8 @@ export const Editor = () => {
       <AiQueryModal
         isOpen={isAiModalOpen}
         onClose={() => setIsAiModalOpen(false)}
+        connectionId={activeConnectionId ?? undefined}
+        schema={activeTab?.schema ?? activeSchema ?? undefined}
         onInsert={(q) => {
           updateActiveTab({ query: q });
           runQuery(q, 1);

--- a/tests/components/modals/AiQueryModal.test.tsx
+++ b/tests/components/modals/AiQueryModal.test.tsx
@@ -1,0 +1,112 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AiQueryModal } from "../../../src/components/modals/AiQueryModal";
+
+const { invokeMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
+vi.mock("../../../src/hooks/useDatabase", () => ({
+  useDatabase: () => ({
+    activeConnectionId: "active-connection",
+    activeSchema: "public",
+  }),
+}));
+
+vi.mock("../../../src/hooks/useSettings", () => ({
+  useSettings: () => ({
+    settings: {
+      aiProvider: "custom-openai",
+      aiModel: "test-model",
+    },
+  }),
+}));
+
+vi.mock("../../../src/components/ui/Modal", () => ({
+  Modal: ({
+    isOpen,
+    children,
+  }: {
+    isOpen: boolean;
+    children: React.ReactNode;
+  }) => (isOpen ? <div>{children}</div> : null),
+}));
+
+describe("AiQueryModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("waits for the driver schema context before generating SQL", async () => {
+    let resolveSchema: ((value: string) => void) | undefined;
+    const schemaPromise = new Promise<string>((resolve) => {
+      resolveSchema = resolve;
+    });
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "get_ai_schema_context") return schemaPromise;
+      if (command === "generate_ai_query") return Promise.resolve("SELECT 1");
+      return Promise.reject(new Error(`Unexpected command: ${command}`));
+    });
+    const onInsert = vi.fn();
+
+    render(
+      <AiQueryModal
+        isOpen
+        onClose={vi.fn()}
+        onInsert={onInsert}
+        connectionId="plugin-connection"
+        schema="analytics"
+      />,
+    );
+
+    fireEvent.change(
+      screen.getByPlaceholderText(/Find all users/i),
+      { target: { value: "Count users" } },
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Generate SQL/i }));
+
+    expect(
+      invokeMock.mock.calls.filter(([command]) => command === "generate_ai_query"),
+    ).toHaveLength(0);
+
+    resolveSchema?.('Table: "users"\n  - id bigint PK NOT NULL');
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith("generate_ai_query", {
+        req: {
+          provider: "custom-openai",
+          model: "test-model",
+          prompt: "Count users",
+          schema: 'Table: "users"\n  - id bigint PK NOT NULL',
+        },
+      });
+    });
+    expect(onInsert).toHaveBeenCalledWith("SELECT 1");
+  });
+
+  it("loads schema context for the connection and schema passed by the caller", async () => {
+    invokeMock.mockResolvedValue("");
+
+    render(
+      <AiQueryModal
+        isOpen
+        onClose={vi.fn()}
+        onInsert={vi.fn()}
+        connectionId="plugin-connection"
+        schema="warehouse"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith("get_ai_schema_context", {
+        connectionId: "plugin-connection",
+        schema: "warehouse",
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What changed

AI Query Assist now asks the active database driver for a bounded schema context instead of rebuilding it from frontend table state. This fixes the empty context seen with schema-scoped connections such as PostgreSQL and makes generation wait for metadata even when Generate SQL is clicked immediately.

The default driver implementation composes the context from tables, columns, and foreign keys. Existing external plugins get that behavior automatically, while plugins with a more efficient metadata query can implement the optional get_ai_schema_context JSON-RPC method. Prompt formatting and table limits remain in the host so built-in and plugin drivers behave consistently.

The modal now receives the connection and schema owned by its editor or notebook, preventing context from being loaded from a different active tab.

Fixes #477

## Validation

- cargo check
- cargo test ai_schema_context --lib
- pnpm typecheck
- pnpm lint
- pnpm test --run tests/components/modals/AiQueryModal.test.tsx
- pnpm build:create-plugin
- GitNexus change detection: medium risk, expected driver and command registration paths only