### PR TITLE
feat(drivers): add explain capability flag to hide Visual EXPLAIN when unsupported

### DIFF
--- a/.agents/skills/tabularis-plugin-driver/references/manifest-checklist.md
+++ b/.agents/skills/tabularis-plugin-driver/references/manifest-checklist.md
@@ -41,6 +41,7 @@ Set these deliberately:
 - `create_foreign_keys`: true only if FK DDL is supported and enforced
 - `manage_tables`: false for read-only or inspection-only plugins
 - `readonly`: true if insert/update/delete and table management must be hidden
+- `explain`: true only if the plugin implements `explain_query` (otherwise the Visual EXPLAIN UI stays hidden)
 - `no_connection_required`: true only for API-style plugins
 
 ## Settings Guidance

--- a/.claude/skills/tabularis-plugin-driver/references/manifest-checklist.md
+++ b/.claude/skills/tabularis-plugin-driver/references/manifest-checklist.md
@@ -41,6 +41,7 @@ Set these deliberately:
 - `create_foreign_keys`: true only if FK DDL is supported and enforced
 - `manage_tables`: false for read-only or inspection-only plugins
 - `readonly`: true if insert/update/delete and table management must be hidden
+- `explain`: true only if the plugin implements `explain_query` (otherwise the Visual EXPLAIN UI stays hidden)
 - `no_connection_required`: true only for API-style plugins
 
 ## Settings Guidance

--- a/plugins/PLUGIN_GUIDE.md
+++ b/plugins/PLUGIN_GUIDE.md
@@ -112,6 +112,7 @@ The manifest tells Tabularis everything about your plugin.
 | `alter_primary_key` | bool | `true` if the database supports altering primary keys after table creation. |
 | `manage_tables` | bool | `true` to enable table and column management UI (Create Table, Add/Modify/Drop Column, Drop Table). Does not control index or FK operations. Defaults to `true`. |
 | `readonly` | bool | When `true`, the driver is read-only: all data modification operations (INSERT, UPDATE, DELETE) are disabled in the UI. The add/delete row buttons, inline cell editing, and context menu edit actions are hidden. Table and column management is also hidden regardless of `manage_tables`. Defaults to `false`. |
+| `explain` | bool | `true` if the driver implements the `explain_query` method (EXPLAIN / query plan support). Enables the Visual EXPLAIN button in the SQL editor and notebook cells; when `false` or omitted, the Visual EXPLAIN UI is hidden for connections using this driver. Defaults to `false`. |
 | `supports_ssl` | bool | `true` to show the SSL/TLS configuration tab (mode + CA/client cert/key) in the connection modal. The values are forwarded to the plugin as `ssl_mode`, `ssl_ca`, `ssl_cert`, and `ssl_key` in `ConnectionParams`. Network drivers only. Also accepted as camelCase `supportsSsl`. Defaults to `false`. |
 
 ### Data Types

--- a/src-tauri/src/drivers/driver_trait.rs
+++ b/src-tauri/src/drivers/driver_trait.rs
@@ -123,6 +123,12 @@ pub struct DriverCapabilities {
     /// their manifest. Defaults to `false`.
     #[serde(default, alias = "supportsSsl")]
     pub supports_ssl: bool,
+    /// Supports EXPLAIN / query plan visualization (`explain_query`).
+    /// When `false`, the Visual Explain UI is hidden for connections using
+    /// this driver. Built-in drivers set this; plugins opt in via their
+    /// manifest. Defaults to `false`.
+    #[serde(default)]
+    pub explain: bool,
     /// When `true`, the driver is read-only: all data modification operations
     /// (INSERT, UPDATE, DELETE) are disabled in the UI.
     /// Table/column management is also hidden regardless of `manage_tables`.

--- a/src-tauri/src/drivers/mysql/mod.rs
+++ b/src-tauri/src/drivers/mysql/mod.rs
@@ -1575,6 +1575,7 @@ impl MysqlDriver {
                     create_foreign_keys: true,
                     no_connection_required: false,
                     manage_tables: true,
+                    explain: true,
                     readonly: false,
                     triggers: true,
                     supports_ssl: true,

--- a/src-tauri/src/drivers/postgres/mod.rs
+++ b/src-tauri/src/drivers/postgres/mod.rs
@@ -1675,6 +1675,7 @@ impl PostgresDriver {
                     create_foreign_keys: true,
                     no_connection_required: false,
                     manage_tables: true,
+                    explain: true,
                     readonly: false,
                     triggers: true,
                     supports_ssl: true,

--- a/src-tauri/src/drivers/sqlite/mod.rs
+++ b/src-tauri/src/drivers/sqlite/mod.rs
@@ -897,6 +897,7 @@ impl SqliteDriver {
                     create_foreign_keys: false,
                     no_connection_required: false,
                     manage_tables: true,
+                    explain: true,
                     readonly: false,
                     triggers: true,
                     supports_ssl: false,

--- a/src/components/notebook/NotebookAiButtons.tsx
+++ b/src/components/notebook/NotebookAiButtons.tsx
@@ -5,6 +5,8 @@ import { AiQueryModal } from "../modals/AiQueryModal";
 import { AiExplainModal } from "../modals/AiExplainModal";
 import { VisualExplainModal } from "../modals/VisualExplainModal";
 import { AiDropdownButton } from "../ui/AiDropdownButton";
+import { useDatabase } from "../../hooks/useDatabase";
+import { supportsExplain } from "../../utils/driverCapabilities";
 
 interface NotebookAiButtonsProps {
   content: string;
@@ -20,6 +22,8 @@ export function NotebookAiButtons({
   schema,
 }: NotebookAiButtonsProps) {
   const { t } = useTranslation();
+  const { activeCapabilities } = useDatabase();
+  const driverSupportsExplain = supportsExplain(activeCapabilities);
   const [isGenerateOpen, setIsGenerateOpen] = useState(false);
   const [isExplainOpen, setIsExplainOpen] = useState(false);
   const [isVisualExplainOpen, setIsVisualExplainOpen] = useState(false);
@@ -27,6 +31,7 @@ export function NotebookAiButtons({
   return (
     <>
       <div className="absolute bottom-1 right-2 z-10 flex items-center gap-1">
+        {driverSupportsExplain && (
         <button
           type="button"
           onClick={() => setIsVisualExplainOpen(true)}
@@ -37,6 +42,7 @@ export function NotebookAiButtons({
           <Network size={10} />
           {t("editor.visualExplain.buttonShort")}
         </button>
+        )}
         <AiDropdownButton
           onGenerate={() => setIsGenerateOpen(true)}
           onExplain={() => setIsExplainOpen(true)}

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { reconstructTableQuery } from "../utils/editor";
 import { serializePkKey, buildPkMap } from "../utils/dataGrid";
 import { isMultiDatabaseCapable } from "../utils/database";
-import { isReadonly } from "../utils/driverCapabilities";
+import { isReadonly, supportsExplain } from "../utils/driverCapabilities";
 import {
   useDangerousQueryGuard,
   DANGEROUS_QUERY_I18N,
@@ -197,6 +197,7 @@ export const Editor = () => {
   const navigate = useNavigate();
 
   const driverReadonly = isReadonly(activeCapabilities);
+  const driverSupportsExplain = supportsExplain(activeCapabilities);
   const activeDialect = activeCapabilities?.sql_dialect;
 
   const [tabContextMenu, setTabContextMenu] = useState<{
@@ -459,6 +460,7 @@ export const Editor = () => {
   const runMultipleQueriesRef = useRef<typeof runMultipleQueries>(null!);
   const openExplainForQueryRef = useRef<(query: string) => void>(null!);
   const activeDialectRef = useRef<typeof activeDialect>(undefined);
+  const supportsExplainRef = useRef(false);
   const tabScrollRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
@@ -1543,6 +1545,7 @@ export const Editor = () => {
   runMultipleQueriesRef.current = runMultipleQueries;
   openExplainForQueryRef.current = openExplainForQuery;
   activeDialectRef.current = activeDialect;
+  supportsExplainRef.current = driverSupportsExplain;
 
   // Global Ctrl/Command+F5 shortcut for Run
   useEffect(() => {
@@ -2566,6 +2569,7 @@ export const Editor = () => {
       contextMenuGroupId: "navigation",
       contextMenuOrder: 1.6,
       run: (ed) => {
+        if (!supportsExplainRef.current) return;
         const selection = ed.getSelection();
         const selectedText = selection && !selection.isEmpty()
           ? ed.getModel()?.getValueInRange(selection)
@@ -3315,8 +3319,8 @@ export const Editor = () => {
             {/* Editor overlay buttons — bottom-right */}
             {tab.type !== "query_builder" && (
               <div className="absolute bottom-2 right-6 z-10 flex items-center gap-1">
-                {/* Visual Explain — hidden for read-only definition tabs */}
-                {!tab.readOnly && (
+                {/* Visual Explain — hidden for read-only definition tabs and drivers without EXPLAIN support */}
+                {!tab.readOnly && driverSupportsExplain && (
                 <button
                   onClick={handleExplainButton}
                   disabled={!activeConnectionId || !tab.query?.trim()}

--- a/src/types/plugins.ts
+++ b/src/types/plugins.ts
@@ -29,6 +29,8 @@ export interface DriverCapabilities {
   manage_tables?: boolean;
   /** When true, the driver is read-only: all data modification operations (INSERT, UPDATE, DELETE) are disabled in the UI. Table/column management is also hidden regardless of manage_tables. Defaults to false. */
   readonly?: boolean;
+  /** Supports EXPLAIN / query plan visualization. When false, the Visual Explain UI is hidden for connections using this driver. Defaults to false. */
+  explain?: boolean;
   /** Supports listing and managing database triggers. Defaults to false. */
   triggers?: boolean;
   /** Supports managing stored routines (run with parameters, create from template, edit, drop). Defaults to false. */

--- a/src/utils/driverCapabilities.ts
+++ b/src/utils/driverCapabilities.ts
@@ -20,6 +20,12 @@ export function supportsCreateForeignKeys(
   return capabilities?.create_foreign_keys === true;
 }
 
+export function supportsExplain(
+  capabilities?: DriverCapabilities | null,
+): boolean {
+  return capabilities?.explain === true;
+}
+
 export function findDriverManifest(
   driverId: string,
   drivers: PluginManifest[],

--- a/tests/utils/driverCapabilities.test.ts
+++ b/tests/utils/driverCapabilities.test.ts
@@ -3,6 +3,7 @@ import {
   isLocalDriver,
   supportsAlterColumn,
   supportsCreateForeignKeys,
+  supportsExplain,
   findDriverManifest,
   getCapabilitiesForDriver,
 } from '../../src/utils/driverCapabilities';
@@ -101,6 +102,28 @@ describe('driverCapabilities', () => {
 
     it('should return false when capabilities are undefined', () => {
       expect(supportsCreateForeignKeys(undefined)).toBe(false);
+    });
+  });
+
+  describe('supportsExplain', () => {
+    it('should return true when explain is true', () => {
+      expect(supportsExplain(makeCapabilities({ explain: true }))).toBe(true);
+    });
+
+    it('should return false when explain is false', () => {
+      expect(supportsExplain(makeCapabilities({ explain: false }))).toBe(false);
+    });
+
+    it('should return false when explain is not set (default false)', () => {
+      expect(supportsExplain(makeCapabilities())).toBe(false);
+    });
+
+    it('should return false when capabilities are null', () => {
+      expect(supportsExplain(null)).toBe(false);
+    });
+
+    it('should return false when capabilities are undefined', () => {
+      expect(supportsExplain(undefined)).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

The Visual EXPLAIN button was shown for every driver; for drivers that don't implement `explain_query` (most external plugins), users only discovered the lack of support via the error in the modal. This adds a proper capability flag so the UI is hidden up front.

## Changes

- **Backend**: new `explain: bool` field on `DriverCapabilities` (`#[serde(default)]`, so existing plugin manifests default to `false`). The postgres, mysql and sqlite built-in manifests declare `explain: true`.
- **Frontend**: mirrored `explain?: boolean` on the TS `DriverCapabilities` type, new `supportsExplain()` helper in `driverCapabilities.ts`.
- **UI gating**:
  - SQL editor: the Visual Explain overlay button is hidden when the active driver doesn't declare the capability; the `explain-selection` Monaco context-menu action becomes a no-op (same ref pattern as `activeDialectRef`).
  - Notebook cells: the EXPLAIN button in `NotebookAiButtons` is hidden as well.
- **Docs**: `plugins/PLUGIN_GUIDE.md` capabilities table and the plugin-driver skill manifest checklist updated.

Companion docs PR on the website: TabularisDB/website#12

## Testing

- `pnpm typecheck` clean
- `cargo check` clean (pre-existing warnings only)
- `pnpm vitest run tests/utils/driverCapabilities.test.ts` — 39/39 passing (5 new tests for `supportsExplain`)