### PR TITLE
feat(registry): add official MongoDB Atlas plugin

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -427,6 +427,27 @@
           }
         }
       ]
+    },
+    {
+      "id": "mongodb-atlas",
+      "name": "MongoDB Atlas",
+      "description": "Official MongoDB driver with full connection URI support for mongodb:// and mongodb+srv://, including SRV, TLS, and Atlas",
+      "author": "Robbyfuu <https://github.com/Robbyfuu>",
+      "homepage": "https://github.com/TabularisDB/tabularis-mongodb-plugin",
+      "latest_version": "0.1.0",
+      "releases": [
+        {
+          "version": "0.1.0",
+          "min_tabularis_version": "0.15.0",
+          "assets": {
+            "linux-arm64": "https://github.com/TabularisDB/tabularis-mongodb-plugin/releases/download/v0.1.0/mongodb-plugin-linux-arm64.zip",
+            "linux-x64": "https://github.com/TabularisDB/tabularis-mongodb-plugin/releases/download/v0.1.0/mongodb-plugin-linux-x64.zip",
+            "darwin-arm64": "https://github.com/TabularisDB/tabularis-mongodb-plugin/releases/download/v0.1.0/mongodb-plugin-darwin-arm64.zip",
+            "darwin-x64": "https://github.com/TabularisDB/tabularis-mongodb-plugin/releases/download/v0.1.0/mongodb-plugin-darwin-x64.zip",
+            "win-x64": "https://github.com/TabularisDB/tabularis-mongodb-plugin/releases/download/v0.1.0/mongodb-plugin-win-x64.zip"
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds the official MongoDB Atlas plugin to the registry using the maintained TabularisDB repository and its published release.

- Plugin ID: `mongodb-atlas` (matches the packaged `.tabularium` manifest)
- Repository: https://github.com/TabularisDB/tabularis-mongodb-plugin
- Release: https://github.com/TabularisDB/tabularis-mongodb-plugin/releases/tag/v0.1.0
- Platforms: linux-x64, linux-arm64, darwin-x64, darwin-arm64, win-x64
- Connection URIs: `mongodb://` and `mongodb+srv://`, including Atlas, SRV, and TLS

Raw plugin URI passthrough is available through #495.