### PR TITLE
fix(ui): make modal borders visible and clip rounded corners

### DIFF
--- a/src/components/modals/AiExplainModal.tsx
+++ b/src/components/modals/AiExplainModal.tsx
@@ -72,7 +72,7 @@ export const AiExplainModal = ({ isOpen, onClose, query }: AiExplainModalProps) 
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
-      <div className="bg-elevated border border-strong rounded-xl w-[700px] shadow-2xl flex flex-col max-h-[85vh]">
+      <div className="bg-elevated border border-strong rounded-xl w-[700px] shadow-2xl flex flex-col max-h-[85vh] overflow-hidden">
         
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-default">

--- a/src/components/modals/AiQueryModal.tsx
+++ b/src/components/modals/AiQueryModal.tsx
@@ -132,7 +132,7 @@ export const AiQueryModal = ({
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
-      <div className="bg-elevated border border-strong rounded-xl w-[600px] shadow-2xl flex flex-col max-h-[90vh]">
+      <div className="bg-elevated border border-strong rounded-xl w-[600px] shadow-2xl flex flex-col max-h-[90vh] overflow-hidden">
         
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-default">

--- a/src/components/modals/CreateForeignKeyModal.tsx
+++ b/src/components/modals/CreateForeignKeyModal.tsx
@@ -170,7 +170,7 @@ export const CreateForeignKeyModal = ({
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} overlayClassName="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-[100]">
-      <div className="bg-elevated rounded-xl shadow-2xl w-[600px] border border-strong flex flex-col max-h-[90vh]">
+      <div className="bg-elevated rounded-xl shadow-2xl w-[600px] border border-strong flex flex-col max-h-[90vh] overflow-hidden">
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-default bg-base">
           <div className="flex items-center gap-3">

--- a/src/components/modals/CreateIndexModal.tsx
+++ b/src/components/modals/CreateIndexModal.tsx
@@ -119,7 +119,7 @@ export const CreateIndexModal = ({
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} overlayClassName="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-[100]">
-      <div className="bg-elevated rounded-xl shadow-2xl w-[500px] border border-strong flex flex-col max-h-[90vh]">
+      <div className="bg-elevated rounded-xl shadow-2xl w-[500px] border border-strong flex flex-col max-h-[90vh] overflow-hidden">
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-default bg-base">
           <div className="flex items-center gap-3">

--- a/src/components/modals/CreateTableModal.tsx
+++ b/src/components/modals/CreateTableModal.tsx
@@ -159,7 +159,7 @@ export const CreateTableModal = ({ isOpen, onClose, onSuccess, schema }: CreateT
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} overlayClassName="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-[100]">
-      <div className="bg-elevated rounded-xl shadow-2xl w-[900px] border border-strong flex flex-col max-h-[90vh]">
+      <div className="bg-elevated rounded-xl shadow-2xl w-[900px] border border-strong flex flex-col max-h-[90vh] overflow-hidden">
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-default bg-base">
           <div className="flex items-center gap-3">

--- a/src/components/modals/ModifyColumnModal.tsx
+++ b/src/components/modals/ModifyColumnModal.tsx
@@ -197,7 +197,7 @@ export const ModifyColumnModal = ({
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} overlayClassName="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-[100]">
-      <div className="bg-elevated rounded-xl shadow-2xl w-[500px] border border-strong flex flex-col max-h-[90vh]">
+      <div className="bg-elevated rounded-xl shadow-2xl w-[500px] border border-strong flex flex-col max-h-[90vh] overflow-hidden">
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-default bg-base">
           <div className="flex items-center gap-3">

--- a/src/components/modals/SchemaModal.tsx
+++ b/src/components/modals/SchemaModal.tsx
@@ -53,7 +53,7 @@ export const SchemaModal = ({ isOpen, onClose, tableName, schema }: SchemaModalP
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} overlayClassName="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-[100]">
-      <div className="bg-elevated rounded-xl shadow-2xl w-[600px] border border-strong flex flex-col max-h-[90vh]">
+      <div className="bg-elevated rounded-xl shadow-2xl w-[600px] border border-strong flex flex-col max-h-[90vh] overflow-hidden">
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-default bg-base">
           <div className="flex items-center gap-3">

--- a/src/index.css
+++ b/src/index.css
@@ -109,7 +109,7 @@
 
   --border-subtle: #1e293b;
   --border-default: #334155;
-  --border-strong: #475569;
+  --border-strong: #5b6b82;
   --border-focus: #3b82f6;
   
   --semantic-string: #f87171;

--- a/src/themes/presets/tabularisDark.ts
+++ b/src/themes/presets/tabularisDark.ts
@@ -40,7 +40,7 @@ export const tabularisDark: Theme = {
     border: {
       subtle: "#1e293b",
       default: "#334155",
-      strong: "#475569",
+      strong: "#5b6b82",
       focus: "#3b82f6",
     },
     semantic: {


### PR DESCRIPTION
Closes #508

## Problem

Several modals (View Schema, Create Table, Create Index, Modify Column, Create Foreign Key, AI Query, AI Explain) looked border-less in dark themes, while the Generate SQL modal rendered correctly.

Two combined causes:

- The affected modal containers use `rounded-xl border border-strong` but were missing the `overflow-hidden` class required by `.rules/modals.md`. Their header and footer children have opaque `bg-base` backgrounds with square corners, which painted over the container's rounded border corners.
- In the Tabularis Dark theme, `--border-strong` (`#475569`) as a 1px line between the header background (`#020617`) and the dimmed overlay is barely perceptible, and `shadow-2xl` adds no separation on dark backdrops.

## Changes

- Add `overflow-hidden` to the container of `SchemaModal`, `CreateTableModal`, `CreateIndexModal`, `ModifyColumnModal`, `CreateForeignKeyModal`, `AiQueryModal`, and `AiExplainModal`. Inner scrolling is unaffected: each modal already scrolls via its own `overflow-auto`/`overflow-y-auto` body.
- Lighten `border.strong` in the Tabularis Dark preset and the `--border-strong` fallback in `index.css` from `#475569` to `#5b6b82`. Other themes keep their existing values; the remaining `#475569` occurrences (`--surface-tertiary`, `--text-disabled`) are different roles and are intentionally untouched.

## Testing

- Verified via pixel sampling of a screenshot that the 1px border was rendered but had near-zero contrast, and that header corners overlapped the rounded border.
- Manually checked that the affected modals now show a continuous rounded border consistent with the Generate SQL modal.