### PR TITLE
fix(import): scope import to selected database and prevent double exe…

### DIFF
--- a/src-tauri/src/dump_commands.rs
+++ b/src-tauri/src/dump_commands.rs
@@ -443,11 +443,20 @@ pub async fn import_database<R: Runtime>(
     connection_id: String,
     file_path: String,
     schema: Option<String>,
+    database: Option<String>,
 ) -> Result<(), String> {
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
-    let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
+    let mut params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
+    // Scope the import to the selected database on connections that expose multiple
+    // databases (e.g. MySQL/MariaDB). Without this the connection pool stays bound
+    // to the primary database, so every statement in the dump file is executed
+    // against the wrong database. Mirrors the same fix already applied to
+    // `dump_database`.
+    if let Some(db) = database {
+        params.database = crate::models::DatabaseSelection::Single(db);
+    }
     let driver = saved_conn.params.driver.clone();
     let pg_schema = schema.unwrap_or_else(|| "public".to_string());
     let app_handle = app.clone();

--- a/src/components/layout/ExplorerSidebar.tsx
+++ b/src/components/layout/ExplorerSidebar.tsx
@@ -2561,6 +2561,7 @@ export const ExplorerSidebar = ({ sidebarWidth, startResize, onCollapse, sidebar
           onClose={() => setImportModal(null)}
           connectionId={activeConnectionId}
           databaseName={importModal.database || activeDatabaseName || "Database"}
+          targetDatabase={importModal.database || activeDatabaseName || undefined}
           filePath={importModal.filePath}
           onSuccess={() => {
             if (refreshTables) refreshTables();

--- a/src/components/modals/ImportDatabaseModal.tsx
+++ b/src/components/modals/ImportDatabaseModal.tsx
@@ -109,8 +109,15 @@ export const ImportDatabaseModal = ({
     }
     hasStartedRef.current = true;
     startImport();
+  }, [isOpen, startImport]);
 
-    // Listen to progress events
+  // The progress listener lives in its own effect: if it shared the starter
+  // effect above, any re-run (strict-mode double mount, startImport changing
+  // identity mid-import) would clean up the subscription and then hit the
+  // run-once guard, leaving the rest of the import without progress updates.
+  useEffect(() => {
+    if (!isOpen) return;
+
     const unlisten = listen<ImportProgress>("import_progress", (event) => {
       setProgress(event.payload);
     });
@@ -118,7 +125,7 @@ export const ImportDatabaseModal = ({
     return () => {
       unlisten.then((fn) => fn());
     };
-  }, [isOpen, startImport]);
+  }, [isOpen]);
 
   // Timer for elapsed time
   useEffect(() => {

--- a/src/components/modals/ImportDatabaseModal.tsx
+++ b/src/components/modals/ImportDatabaseModal.tsx
@@ -71,23 +71,12 @@ export const ImportDatabaseModal = ({
       if (onSuccess) {
         onSuccess();
       }
-
-      // Auto-close after 2 seconds on success
-      setTimeout(() => {
-        onClose();
-      }, 2000);
     } catch (e) {
-      const errorMsg = String(e);
-      setError(errorMsg);
+      // The error is rendered inside this modal — no extra alert dialog.
+      setError(String(e));
       setIsImporting(false);
-
-      if (!errorMsg.includes("cancelled")) {
-        showAlert(t("dump.importFailure") + ": " + errorMsg, {
-          kind: "error",
-        });
-      }
     }
-  }, [connectionId, filePath, activeSchema, targetDatabase, onSuccess, onClose, t, showAlert]);
+  }, [connectionId, filePath, activeSchema, targetDatabase, onSuccess]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -165,7 +154,6 @@ export const ImportDatabaseModal = ({
           <button
             onClick={handleCancel}
             className="text-muted hover:text-primary text-xl leading-none"
-            disabled={success}
           >
             &times;
           </button>
@@ -260,10 +248,17 @@ export const ImportDatabaseModal = ({
 
           {/* Error Message */}
           {error && !isImporting && (
-            <div className="text-center text-red-500 text-sm">
-              {error.includes("cancelled")
-                ? t("dump.importCancelled")
-                : t("dump.importFailed")}
+            <div className="space-y-2">
+              <div className="text-center text-red-500 text-sm font-medium">
+                {error.includes("cancelled")
+                  ? t("dump.importCancelled")
+                  : t("dump.importFailed")}
+              </div>
+              {!error.includes("cancelled") && (
+                <div className="max-h-40 overflow-y-auto bg-red-900/10 border border-red-900/40 rounded-lg p-3 text-xs text-red-400 font-mono whitespace-pre-wrap break-words text-left">
+                  {error}
+                </div>
+              )}
             </div>
           )}
 
@@ -287,7 +282,7 @@ export const ImportDatabaseModal = ({
               onClick={onClose}
               className="px-4 py-2 rounded hover:bg-surface-secondary transition-colors"
             >
-              {success ? t("common.close") : t("common.cancel")}
+              {success || error ? t("common.close") : t("common.cancel")}
             </button>
           )}
         </div>

--- a/src/components/modals/ImportDatabaseModal.tsx
+++ b/src/components/modals/ImportDatabaseModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
@@ -19,7 +19,10 @@ interface ImportDatabaseModalProps {
   isOpen: boolean;
   onClose: () => void;
   connectionId: string;
+  /** Display label only — may fall back to a generic string. */
   databaseName: string;
+  /** Actual database to scope the import to. Undefined when unknown. */
+  targetDatabase?: string;
   filePath: string;
   onSuccess?: () => void;
 }
@@ -29,6 +32,7 @@ export const ImportDatabaseModal = ({
   onClose,
   connectionId,
   databaseName,
+  targetDatabase,
   filePath,
   onSuccess,
 }: ImportDatabaseModalProps) => {
@@ -41,6 +45,10 @@ export const ImportDatabaseModal = ({
   const [success, setSuccess] = useState(false);
   const [elapsedTime, setElapsedTime] = useState(0); // in seconds
   const [startTime, setStartTime] = useState<number | null>(null);
+  // Guards against the effect firing the import twice: React strict-mode double
+  // mounts, and startImport being recreated when its deps change, both re-run the
+  // effect. Without this the whole dump is executed twice against the database.
+  const hasStartedRef = useRef(false);
 
   const startImport = useCallback(async () => {
     setIsImporting(true);
@@ -54,6 +62,7 @@ export const ImportDatabaseModal = ({
         connectionId,
         filePath,
         ...(activeSchema ? { schema: activeSchema } : {}),
+        ...(targetDatabase ? { database: targetDatabase } : {}),
       });
 
       setSuccess(true);
@@ -78,7 +87,7 @@ export const ImportDatabaseModal = ({
         });
       }
     }
-  }, [connectionId, filePath, activeSchema, onSuccess, onClose, t, showAlert]);
+  }, [connectionId, filePath, activeSchema, targetDatabase, onSuccess, onClose, t, showAlert]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -90,10 +99,15 @@ export const ImportDatabaseModal = ({
       setSuccess(false);
       setElapsedTime(0);
       setStartTime(null);
+      hasStartedRef.current = false;
       return;
     }
 
-    // Start import automatically when modal opens
+    // Start import automatically when the modal opens — but only once per opening.
+    if (hasStartedRef.current) {
+      return;
+    }
+    hasStartedRef.current = true;
     startImport();
 
     // Listen to progress events

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1447,7 +1447,6 @@
     "errorNoTables": "Bitte wähle mindestens eine Tabelle",
     "importStarted": "Import gestartet...",
     "importSuccess": "SQL-Datei erfolgreich ausgeführt",
-    "importFailure": "Import fehlgeschlagen: ",
     "importCancelled": "Import abgebrochen",
     "importFailed": "Import fehlgeschlagen",
     "importingFrom": "Importiere aus",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1519,7 +1519,6 @@
     "errorNoTables": "Please select at least one table",
     "importStarted": "Import started...",
     "importSuccess": "SQL file executed successfully",
-    "importFailure": "Import failed: ",
     "importCancelled": "Import cancelled",
     "importFailed": "Import failed",
     "importingFrom": "Importing from",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1443,7 +1443,6 @@
     "errorNoTables": "Selecciona al menos una tabla",
     "importStarted": "Importación iniciada...",
     "importSuccess": "Archivo SQL ejecutado correctamente",
-    "importFailure": "Error en la importación: ",
     "importCancelled": "Importación cancelada",
     "importFailed": "Importación fallida",
     "importingFrom": "Importando desde",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1513,7 +1513,6 @@
     "errorNoTables": "Veuillez sélectionner au moins une table",
     "importStarted": "Import démarré...",
     "importSuccess": "Fichier SQL exécuté avec succès",
-    "importFailure": "Échec de l’import : ",
     "importCancelled": "Import annulé",
     "importFailed": "Échec de l’import",
     "importingFrom": "Import depuis",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1469,7 +1469,6 @@
     "errorNoTables": "Seleziona almeno una tabella",
     "importStarted": "Importazione avviata...",
     "importSuccess": "File SQL eseguito con successo",
-    "importFailure": "Importazione fallita: ",
     "importCancelled": "Importazione annullata",
     "importFailed": "Importazione fallita",
     "importingFrom": "Importazione da",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1486,7 +1486,6 @@
     "errorNoTables": "少なくとも 1 つのテーブルを選択してください",
     "importStarted": "インポートを開始しました...",
     "importSuccess": "SQL ファイルを正常に実行しました",
-    "importFailure": "インポートに失敗しました: ",
     "importCancelled": "インポートをキャンセルしました",
     "importFailed": "インポートに失敗しました",
     "importingFrom": "インポート元",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1472,7 +1472,6 @@
     "errorNoTables": "테이블을 하나 이상 선택하세요",
     "importStarted": "가져오기를 시작합니다...",
     "importSuccess": "SQL 파일이 성공적으로 실행되었습니다",
-    "importFailure": "가져오기에 실패했습니다: ",
     "importCancelled": "가져오기가 취소되었습니다",
     "importFailed": "가져오기 실패",
     "importingFrom": "가져오는 중",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1480,7 +1480,6 @@
     "errorNoTables": "Выберите хотя бы одну таблицу",
     "importStarted": "Импорт начат...",
     "importSuccess": "SQL-файл выполнен",
-    "importFailure": "Ошибка импорта: ",
     "importCancelled": "Импорт отменён",
     "importFailed": "Импорт не удался",
     "importingFrom": "Импорт из",

--- a/src/i18n/locales/tl.json
+++ b/src/i18n/locales/tl.json
@@ -1505,7 +1505,6 @@
     "errorNoTables": "Pumili ng kahit isang table",
     "importStarted": "Nagsimula ang import...",
     "importSuccess": "Matagumpay na na-execute ang SQL file",
-    "importFailure": "Nabigo ang import: ",
     "importCancelled": "Kinansela ang import",
     "importFailed": "Nabigo ang import",
     "importingFrom": "Ini-import mula sa",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1391,7 +1391,6 @@
     "errorNoTables": "请至少选择一个表",
     "importStarted": "导入开始...",
     "importSuccess": "SQL 文件执行成功",
-    "importFailure": "导入失败：",
     "importCancelled": "导入已取消",
     "importFailed": "导入失败",
     "importingFrom": "从以下文件导入",


### PR DESCRIPTION
Close #512 

## Problem

Two bugs in the SQL file import, on MySQL/MariaDB connections exposing several databases:

1. **Wrong target database.** Right-clicking a database → *Run SQL file* runs the file against the connection's **primary** database, not the one that was right-clicked. The error makes it explicit:

The modal receives the target database name and displays it in its title, but never forwards it to the backend.

2. **Import runs twice.** The modal's `useEffect` re-fires `startImport` (React strict-mode double mount + `startImport` recreated when its deps change), executing the whole dump twice. On a fresh database this surfaces as `Table 'x' already exists` on the very first statement.

## Fix

- `import_database`: add a `database: Option<String>` parameter and override `params.database` before opening the pool — a line-for-line mirror of the fix already present in `dump_database` (with the same explanatory comment).
- `ImportDatabaseModal`: forward the target database (kept separate from the display label, which can fall back to a generic string), and guard the effect with a `useRef` so the import runs once per opening.

## Testing

Verified on MariaDB (`mariadb:lts`, Docker), Linux. Before: import lands in the wrong DB and/or fails with duplicate-table errors. After: importing a multi-table dump into the right-clicked database succeeds in one pass (7 tables + data loaded).

`npx tsc --noEmit` passes. **Not tested on PostgreSQL** — the change touches the shared `import_database` path, so a maintainer check on the PG import flow (where `schema` and `database` now coexist) would be welcome.