### PR TITLE
fix(editor): skip string literals and comments in query param detection

### DIFF
--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -760,7 +760,7 @@ export const Editor = () => {
       if (!(await guardDangerousQuery(textToRun))) return;
 
       // Check for parameters
-      const params = extractQueryParams(textToRun);
+      const params = extractQueryParams(textToRun, activeDialect);
       if (params.length > 0) {
         const storedParams = paramsOverride || targetTab.queryParams || {};
         const missingParams = params.filter(
@@ -785,7 +785,7 @@ export const Editor = () => {
         }
 
         // Interpolate parameters before execution
-        textToRun = interpolateQueryParams(textToRun, storedParams);
+        textToRun = interpolateQueryParams(textToRun, storedParams, activeDialect);
       }
 
       // Automatically open the results panel when running a query — but only
@@ -985,6 +985,7 @@ export const Editor = () => {
       activeDatabaseName,
       addHistoryEntry,
       guardDangerousQuery,
+      activeDialect,
     ],
   );
 
@@ -1000,7 +1001,7 @@ export const Editor = () => {
 
       // Collect all unique parameters across all queries
       const allParams = [
-        ...new Set(queries.flatMap((q) => extractQueryParams(q))),
+        ...new Set(queries.flatMap((q) => extractQueryParams(q, activeDialect))),
       ];
       if (allParams.length > 0) {
         const storedParams =
@@ -1022,7 +1023,9 @@ export const Editor = () => {
           return;
         }
         // Interpolate all queries with the stored params
-        queries = queries.map((q) => interpolateQueryParams(q, storedParams));
+        queries = queries.map((q) =>
+          interpolateQueryParams(q, storedParams, activeDialect),
+        );
       }
 
       const pageSize =
@@ -1168,7 +1171,7 @@ export const Editor = () => {
       });
       updateTab(targetTabId, { isLoading: false });
     },
-    [activeConnectionId, updateTab, patchResultEntry, settings.resultPageSize, activeSchema, t, isMultiDb, activeDatabaseName, addHistoryEntry, guardDangerousQuery],
+    [activeConnectionId, updateTab, patchResultEntry, settings.resultPageSize, activeSchema, t, isMultiDb, activeDatabaseName, addHistoryEntry, guardDangerousQuery, activeDialect],
   );
 
   // Auto-run entry point for navigation-initiated executions (sidebar "open
@@ -2574,7 +2577,7 @@ export const Editor = () => {
   const handleEditParams = useCallback(() => {
     if (!activeTab || !activeTab.query) return;
 
-    const params = extractQueryParams(activeTab.query);
+    const params = extractQueryParams(activeTab.query, activeDialect);
     if (params.length === 0) return;
 
     setQueryParamsModal({
@@ -2585,7 +2588,17 @@ export const Editor = () => {
       pendingTabId: activeTab.id,
       mode: "save",
     });
-  }, [activeTab]);
+  }, [activeTab, activeDialect]);
+
+  // Drives the Params button. Memoized because it lives in the render
+  // path (a `disabled` prop) and would otherwise rescan the whole query
+  // text (tokenizer + regex) on every keystroke.
+  const hasQueryParams = useMemo(
+    () =>
+      !!activeTab?.query &&
+      extractQueryParams(activeTab.query, activeDialect).length > 0,
+    [activeTab?.query, activeDialect],
+  );
 
   const handleRollbackChanges = useCallback(() => {
     if (!activeTab) return;
@@ -3297,10 +3310,7 @@ export const Editor = () => {
         {!isTableTab && (
           <button
             onClick={handleEditParams}
-            disabled={
-              !activeTab?.query ||
-              extractQueryParams(activeTab.query).length === 0
-            }
+            disabled={!hasQueryParams}
             className="flex items-center gap-2 px-2 @[640px]:px-3 py-1.5 bg-surface-secondary hover:bg-surface text-primary rounded text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed border border-strong shrink-0"
             title={t("editor.queryParameters")}
           >

--- a/src/utils/queryParameters.ts
+++ b/src/utils/queryParameters.ts
@@ -1,3 +1,5 @@
+import { scanNonCodeSpans } from "./sqlSplitter";
+
 /**
  * Converts an arbitrary identifier (e.g. a column name) into a valid named
  * bind-parameter name compatible with the editor's `:param` syntax.
@@ -14,28 +16,63 @@ export const toBindParamName = (name: string): string => {
   return sanitized;
 };
 
-export const extractQueryParams = (sql: string): string[] => {
+// Matches :paramName but ignores ::cast (Postgres)
+// Look for colon followed by word characters, ensuring it's not preceded by a colon
+const PARAM_RE = /(?<!:):([a-zA-Z_][a-zA-Z0-9_]*)(?!\w)/g;
+
+/**
+ * Returns `sql` with every string literal and comment replaced by spaces
+ * so the parameter regex only ever sees executable SQL (issue #458). The
+ * mask is length-preserving: a match index on it is valid on the
+ * original. Without a known dialect there is nothing to mask (see
+ * scanNonCodeSpans) and detection behaves exactly as it did before
+ * dialects were threaded through.
+ */
+const maskNonCode = (sql: string, dialect?: string): string => {
+  const spans = scanNonCodeSpans(sql, dialect);
+  if (spans.length === 0) return sql;
+  let masked = "";
+  let cursor = 0;
+  for (const { start, end } of spans) {
+    masked += sql.slice(cursor, start) + " ".repeat(end - start);
+    cursor = end;
+  }
+  return masked + sql.slice(cursor);
+};
+
+export const extractQueryParams = (sql: string, dialect?: string): string[] => {
   if (!sql) return [];
-  // Matches :paramName but ignores ::cast (Postgres)
-  // Look for colon followed by word characters, ensuring it's not preceded by a colon
-  const regex = /(?<!:):([a-zA-Z_][a-zA-Z0-9_]*)(?!\w)/g;
-  const matches = sql.match(regex);
+  const matches = maskNonCode(sql, dialect).match(PARAM_RE);
   if (!matches) return [];
-  
+
   // Remove duplicate parameters and the leading colon
-  const uniqueParams = new Set(matches.map(m => m.substring(1)));
+  const uniqueParams = new Set(matches.map((m) => m.substring(1)));
   return Array.from(uniqueParams);
 };
 
-export const interpolateQueryParams = (sql: string, params: Record<string, string>): string => {
+export const interpolateQueryParams = (
+  sql: string,
+  params: Record<string, string>,
+  dialect?: string,
+): string => {
   if (!sql) return "";
-  
+
   // Values are substituted verbatim; callers are responsible for quoting.
   // SQL injection risk is accepted at the UI layer — this is a developer tool.
-  return sql.replace(/(?<!:):([a-zA-Z_][a-zA-Z0-9_]*)(?!\w)/g, (match, paramName) => {
-    if (params[paramName] !== undefined) {
-      return params[paramName];
-    }
-    return match; // Leave it if no value found (though logic should prevent this)
-  });
+  // Matches are found on the masked text so a `:name` inside a string
+  // literal or comment is never rewritten; the output is assembled from
+  // slices of the original (the mask is length-preserving, so indices
+  // transfer 1:1).
+  const masked = maskNonCode(sql, dialect);
+  let result = "";
+  let cursor = 0;
+  for (const match of masked.matchAll(PARAM_RE)) {
+    // Own-property check: a plain `params[name]` lookup would resolve
+    // names like :toString via Object.prototype and splice function
+    // source into the SQL.
+    if (!Object.hasOwn(params, match[1])) continue; // Leave it if no value found (though logic should prevent this)
+    result += sql.slice(cursor, match.index) + params[match[1]];
+    cursor = match.index + match[0].length;
+  }
+  return result + sql.slice(cursor);
 };

--- a/src/utils/sqlSplitter/index.ts
+++ b/src/utils/sqlSplitter/index.ts
@@ -1,4 +1,5 @@
 import { splitInto } from './splitter';
+import { collectNonCodeSpans } from './nonCodeSpans';
 
 export type Dialect =
   | 'postgres'
@@ -26,6 +27,15 @@ export type Dialect =
  * need byte positions (e.g. a Rust backend) must re-encode.
  */
 export interface StatementRange {
+  readonly start: number;
+  readonly end: number;
+}
+
+/**
+ * String-index span (same coordinate system as `StatementRange`) of a
+ * single string literal or comment in the source.
+ */
+export interface NonCodeSpan {
   readonly start: number;
   readonly end: number;
 }
@@ -75,6 +85,13 @@ export interface DialectOptions {
   readonly lineComments: boolean;
   readonly blockComments: boolean;
   /**
+   * MySQL/MariaDB `#` line comments (run to end of line, from any
+   * position outside a string, no whitespace requirement). Kept off
+   * for dialects where `#` is a valid identifier character (e.g.
+   * Oracle's `emp#`).
+   */
+  readonly hashComments: boolean;
+  /**
    * Treat MySQL/MariaDB conditional comments (the ones opening with
    * `/*!`) as meaningful statements instead of noop comments. The
    * server evaluates them when the embedded version directive
@@ -115,6 +132,7 @@ const POSTGRES: DialectOptions = {
   qQuoting: false,
   lineComments: true,
   blockComments: true,
+  hashComments: false,
   executableComments: false,
   nestedBlockComments: true,
   lineCommentRequiresSpace: false,
@@ -135,6 +153,7 @@ const MYSQL: DialectOptions = {
   qQuoting: false,
   lineComments: true,
   blockComments: true,
+  hashComments: true,
   executableComments: true,
   nestedBlockComments: false,
   lineCommentRequiresSpace: true,
@@ -145,6 +164,10 @@ const MSSQL: DialectOptions = {
     { open: "'", close: "'", doubleClose: true },
     // T-SQL: `]]` inside `[...]` is the literal `]` escape.
     { open: '[', close: ']', doubleClose: true },
+    // Double quotes delimit identifiers under the default
+    // QUOTED_IDENTIFIER ON (and strings when it is OFF) — non-code
+    // either way.
+    { open: '"', close: '"', doubleClose: true },
   ],
   eString: false,
   dollarQuoting: false,
@@ -155,8 +178,10 @@ const MSSQL: DialectOptions = {
   qQuoting: false,
   lineComments: true,
   blockComments: true,
+  hashComments: false,
   executableComments: false,
-  nestedBlockComments: false,
+  // T-SQL block comments nest (documented behavior).
+  nestedBlockComments: true,
   lineCommentRequiresSpace: false,
 };
 
@@ -176,6 +201,7 @@ const SQLITE: DialectOptions = {
   qQuoting: false,
   lineComments: true,
   blockComments: true,
+  hashComments: false,
   executableComments: false,
   nestedBlockComments: false,
   lineCommentRequiresSpace: false,
@@ -192,6 +218,7 @@ const ORACLE: DialectOptions = {
   qQuoting: true,
   lineComments: true,
   blockComments: true,
+  hashComments: false,
   executableComments: false,
   nestedBlockComments: false,
   lineCommentRequiresSpace: false,
@@ -208,6 +235,7 @@ const GENERIC: DialectOptions = {
   qQuoting: false,
   lineComments: true,
   blockComments: true,
+  hashComments: false,
   executableComments: false,
   nestedBlockComments: false,
   lineCommentRequiresSpace: false,
@@ -235,7 +263,11 @@ export function dialectOptions(dialect: Dialect): DialectOptions {
 
 function normalizeDialect(dialect: Dialect | string | undefined): Dialect {
   if (dialect === undefined) return 'postgres';
-  return dialect in DIALECT_TABLE ? (dialect as Dialect) : 'generic';
+  // Own-property check: `in` would also accept prototype members such
+  // as '__proto__' or 'toString' and return a non-DialectOptions value.
+  return Object.hasOwn(DIALECT_TABLE, dialect)
+    ? (dialect as Dialect)
+    : 'generic';
 }
 
 /**
@@ -256,6 +288,31 @@ export function splitQueries(
   dialect?: Dialect | string,
 ): string[] {
   return splitStatements(sql, dialect).map((s) => s.text);
+}
+
+/**
+ * Spans of every string literal and comment in `sql` — the regions
+ * where a `:name` is data, not a potential bind parameter.
+ *
+ * When `dialect` is undefined or unknown this returns `[]` (nothing is
+ * treated as non-code) instead of guessing a dialect: lexing with the
+ * wrong quote rules can hide real SQL — e.g. the generic rules read
+ * MySQL's `'a\'b'` as an unterminated string and would swallow every
+ * parameter after it — so degrading to "no spans" keeps callers exactly
+ * as accurate as they were before they knew about dialects. Pass an
+ * explicit `'generic'` to scan with the ANSI-ish fallback rules.
+ */
+export function scanNonCodeSpans(
+  sql: string,
+  dialect?: Dialect | string,
+): NonCodeSpan[] {
+  // Own-property check: `in` would also accept prototype members such
+  // as '__proto__' or 'toString' and hand a non-DialectOptions value to
+  // the scanner.
+  if (dialect === undefined || !Object.hasOwn(DIALECT_TABLE, dialect)) {
+    return [];
+  }
+  return collectNonCodeSpans(sql, DIALECT_TABLE[dialect as Dialect]);
 }
 
 export {

--- a/src/utils/sqlSplitter/nonCodeSpans.ts
+++ b/src/utils/sqlSplitter/nonCodeSpans.ts
@@ -1,0 +1,149 @@
+// Collects the spans of string literals and comments so callers can
+// treat everything inside them as data rather than SQL (issue #458).
+// Reuses the splitter's tokenizer so the quote/comment dialect rules
+// stay defined in exactly one place; the driver loop mirrors
+// collectSegments in splitter.ts (same state updates), minus the
+// statement bookkeeping.
+
+import { scanToken, type TokenizerState } from './tokenizer';
+import type { DialectOptions, NonCodeSpan } from './index';
+
+/**
+ * A region of source text queued for scanning. Executable-comment
+ * payloads are queued here instead of being recursed into: a
+ * pathological chain of `/*!` markers arrives as one giant data token
+ * whose payload starts with another `/*!`, so native recursion would
+ * grow the call stack linearly with input length and overflow at
+ * roughly 15KB of pasted text.
+ */
+interface PendingRegion {
+  readonly text: string;
+  /** Offset of `text` within the original source. */
+  readonly offset: number;
+  /** How many executable-comment payloads enclose this region. */
+  readonly depth: number;
+  readonly state: TokenizerState;
+}
+
+// A real dump nests executable comments one or two levels deep;
+// anything deeper is adversarial garbage. Past this depth the payload
+// is left unscanned, degrading to "nothing masked" for that tail —
+// the same fail-safe direction as the unknown-dialect fallback.
+const MAX_EXECUTABLE_COMMENT_DEPTH = 8;
+
+export function collectNonCodeSpans(
+  source: string,
+  options: DialectOptions,
+): NonCodeSpan[] {
+  const spans: NonCodeSpan[] = [];
+  const pending: PendingRegion[] = [
+    {
+      text: source,
+      offset: 0,
+      depth: 0,
+      state: { delimiter: ';', lineLeading: true },
+    },
+  ];
+
+  while (pending.length > 0) {
+    const region = pending.pop();
+    if (region === undefined) break;
+    const { text, offset, depth, state } = region;
+    let position = 0;
+
+    // Queues the payload of an executable comment (everything between
+    // the opening marker of `headerLength` chars and the closing
+    // star-slash, if present) for its own scan.
+    const queuePayload = (
+      tokenStart: number,
+      tokenLength: number,
+      headerLength: number,
+    ): void => {
+      const innerStart = tokenStart + headerLength;
+      const closed = text.startsWith('*/', tokenStart + tokenLength - 2);
+      const innerEnd = tokenStart + tokenLength - (closed ? 2 : 0);
+      pending.push({
+        text: text.slice(innerStart, innerEnd),
+        offset: offset + innerStart,
+        depth: depth + 1,
+        state: { delimiter: state.delimiter, lineLeading: false },
+      });
+    };
+
+    while (position < text.length) {
+      const token = scanToken(text, position, options, state);
+      if (token === null) break;
+
+      switch (token.kind) {
+        case 'string':
+        case 'lineComment':
+          spans.push({
+            start: offset + position,
+            end: offset + position + token.length,
+          });
+          state.lineLeading = false;
+          break;
+        case 'blockComment':
+          // MariaDB executes `/*M! ... */` conditional comments (MySQL
+          // proper skips them as plain comments), so a `:param` inside
+          // may be real. Rescan the payload like `/*!` instead of
+          // masking it wholesale; for MySQL proper this merely keeps
+          // the pre-masking detection behavior inside a comment the
+          // server ignores.
+          if (
+            options.executableComments &&
+            text.startsWith('/*M!', position) &&
+            depth < MAX_EXECUTABLE_COMMENT_DEPTH
+          ) {
+            queuePayload(position, token.length, 4);
+          } else {
+            spans.push({
+              start: offset + position,
+              end: offset + position + token.length,
+            });
+          }
+          state.lineLeading = false;
+          break;
+        case 'data':
+          // A multi-character data token is a MySQL executable comment
+          // (`/*! ... */`, see scanToken): the server runs its payload,
+          // so a `:param` inside it is real. Queue the payload for its
+          // own scan of strings and comments instead of skipping it
+          // wholesale.
+          if (
+            token.length > 1 &&
+            text.startsWith('/*!', position) &&
+            depth < MAX_EXECUTABLE_COMMENT_DEPTH
+          ) {
+            queuePayload(position, token.length, 3);
+          }
+          state.lineLeading = false;
+          break;
+        case 'setDelimiter':
+          if (token.value !== undefined) state.delimiter = token.value;
+          state.lineLeading = false;
+          break;
+        case 'delimiter':
+        case 'goDelimiter':
+        case 'slashDelimiter':
+          state.lineLeading = false;
+          break;
+        case 'eoln':
+          state.lineLeading = true;
+          break;
+        case 'whitespace':
+          break;
+      }
+
+      // Every token advances the cursor, whatever its kind — a kind
+      // that skipped this line would loop forever.
+      position += token.length;
+    }
+  }
+
+  // Queued payload regions are scanned after the rest of their parent
+  // region, so their spans arrive out of document order; consumers
+  // (e.g. a left-to-right mask builder) rely on sorted spans.
+  spans.sort((a, b) => a.start - b.start);
+  return spans;
+}

--- a/src/utils/sqlSplitter/tokenizer.ts
+++ b/src/utils/sqlSplitter/tokenizer.ts
@@ -53,6 +53,14 @@ export function scanToken(
     return { kind: 'lineComment', length: end - position };
   }
 
+  if (options.hashComments && ch === '#') {
+    // MySQL/MariaDB `#` starts a comment anywhere outside a string,
+    // with no whitespace requirement (unlike `--`).
+    let end = position + 1;
+    while (end < source.length && source[end] !== '\n') end++;
+    return { kind: 'lineComment', length: end - position };
+  }
+
   if (options.blockComments && ch === '/' && source[position + 1] === '*') {
     const length = scanBlockCommentLength(
       source,
@@ -198,6 +206,10 @@ function scanEString(source: string, position: number): Token {
 const DOLLAR_TAG_RE = /\$([A-Za-z0-9_]*)\$/y;
 
 function scanDollarQuoted(source: string, position: number): Token | null {
+  // PostgreSQL requires a dollar quote that follows an identifier or
+  // keyword to be separated from it by whitespace; `foo$tag$` is a
+  // single identifier, not an opener.
+  if (isIdentBoundary(source, position - 1)) return null;
   DOLLAR_TAG_RE.lastIndex = position;
   const match = DOLLAR_TAG_RE.exec(source);
   if (!match) return null;

--- a/tests/utils/queryParameters.test.ts
+++ b/tests/utils/queryParameters.test.ts
@@ -90,4 +90,217 @@ describe('queryParameters', () => {
         expect(result).toBe('SELECT val::text FROM t WHERE id = 10');
     });
   });
+
+  describe('extractQueryParams with dialect (issue #458)', () => {
+    it('ignores :name inside single-quoted literals', () => {
+      const sql = "SELECT * FROM categories WHERE value = 'x:y'";
+      expect(extractQueryParams(sql, 'postgres')).toEqual([]);
+      expect(extractQueryParams(sql, 'mysql')).toEqual([]);
+    });
+
+    it('still detects a real param next to a literal', () => {
+      const sql = "SELECT * FROM t WHERE a = 'x:y' AND b = :real";
+      expect(extractQueryParams(sql, 'postgres')).toEqual(['real']);
+    });
+
+    it('ignores params inside comments', () => {
+      expect(extractQueryParams('SELECT 1 -- :ghost', 'postgres')).toEqual([]);
+      expect(
+        extractQueryParams('SELECT 1 /* :ghost */, :real', 'postgres'),
+      ).toEqual(['real']);
+    });
+
+    it('keeps the ::cast exclusion when a dialect is passed', () => {
+      expect(extractQueryParams("SELECT 'x'::text, :id", 'postgres')).toEqual([
+        'id',
+      ]);
+    });
+
+    it('handles boundary cases around masked regions', () => {
+      // Param immediately after a comment, and a comment splitting what
+      // would otherwise read as one name.
+      expect(extractQueryParams('/*c*/:id', 'postgres')).toEqual(['id']);
+      expect(extractQueryParams(':na/*c*/me', 'postgres')).toEqual(['na']);
+      expect(extractQueryParams("'x':y", 'postgres')).toEqual(['y']);
+    });
+
+    it('handles postgres dollar quotes, E-strings and nested comments', () => {
+      expect(
+        extractQueryParams('SELECT $tag$:hidden$tag$, :visible', 'postgres'),
+      ).toEqual(['visible']);
+      expect(
+        extractQueryParams("SELECT E'it\\'s :hidden', :visible", 'postgres'),
+      ).toEqual(['visible']);
+      expect(
+        extractQueryParams('SELECT /* a /* :inner */ :after */ :visible', 'postgres'),
+      ).toEqual(['visible']);
+    });
+
+    it('handles mysql backslash escapes and backticks', () => {
+      expect(
+        extractQueryParams("SELECT 'it\\'s :hidden', :visible", 'mysql'),
+      ).toEqual(['visible']);
+      expect(
+        extractQueryParams('SELECT `weird:col` FROM t WHERE id = :id', 'mysql'),
+      ).toEqual(['id']);
+    });
+
+    it('treats mysql -- without a space as subtraction, keeping the param', () => {
+      expect(
+        extractQueryParams('SELECT qty--:threshold FROM stock', 'mysql'),
+      ).toEqual(['threshold']);
+    });
+
+    it('detects params inside mysql executable comments but not their literals', () => {
+      expect(
+        extractQueryParams("SELECT /*!50700 CONCAT('x:y'), :exec */ :outer", 'mysql'),
+      ).toEqual(['exec', 'outer']);
+    });
+
+    it('survives pathological chains of executable-comment markers', () => {
+      // Regression: this used to overflow the call stack around 15KB.
+      expect(() => extractQueryParams('/*!'.repeat(10000), 'mysql')).not.toThrow();
+      // Past the rescan depth cap, detection degrades to plain text and
+      // still sees the real parameter.
+      expect(extractQueryParams('/*!'.repeat(10000) + ':id', 'mysql')).toEqual([
+        'id',
+      ]);
+    });
+
+    it('treats Object.prototype member names as unknown dialects', () => {
+      const sql = "SELECT 'x:y', :real";
+      expect(extractQueryParams(sql, '__proto__')).toEqual(['y', 'real']);
+      expect(extractQueryParams(sql, 'toString')).toEqual(['y', 'real']);
+    });
+
+    it('handles oracle q-quotes and mssql bracket identifiers', () => {
+      expect(
+        extractQueryParams("SELECT q'{it's :hidden}' FROM dual WHERE id = :id", 'oracle'),
+      ).toEqual(['id']);
+      expect(
+        extractQueryParams('SELECT [weird:col] FROM t WHERE id = :id', 'mssql'),
+      ).toEqual(['id']);
+    });
+
+    it('suppresses params inside an unterminated string while typing', () => {
+      expect(extractQueryParams("WHERE v = 'x:y", 'postgres')).toEqual([]);
+    });
+
+    it('falls back to maskless detection without a known dialect', () => {
+      const sql = "SELECT 'x:y', :real";
+      // Pre-#458 behavior is preserved verbatim when no dialect is known…
+      expect(extractQueryParams(sql)).toEqual(['y', 'real']);
+      expect(extractQueryParams(sql, 'does-not-exist')).toEqual(['y', 'real']);
+      // …because guessing wrong is worse: generic quote rules would read
+      // MySQL's escaped quote as a string end and swallow :x entirely.
+      expect(extractQueryParams("SELECT 'a\\'b', :x", 'mysql')).toEqual(['x']);
+      expect(extractQueryParams("SELECT 'a\\'b', :x")).toEqual(['x']);
+    });
+
+    it('ignores params inside mysql # comments', () => {
+      expect(extractQueryParams('SELECT 1 # :ghost\n, :real', 'mysql')).toEqual([
+        'real',
+      ]);
+    });
+
+    it('detects params inside mariadb /*M! comments but not their literals', () => {
+      expect(
+        extractQueryParams("SELECT 1 /*M! + :inside */ + :real", 'mysql'),
+      ).toEqual(['inside', 'real']);
+      expect(
+        extractQueryParams("SELECT /*M! CONCAT('x:y'), :m */ :real", 'mysql'),
+      ).toEqual(['m', 'real']);
+    });
+
+    it('handles mssql double-quoted identifiers and nested comments', () => {
+      expect(extractQueryParams('SELECT ":ghost", :real', 'mssql')).toEqual([
+        'real',
+      ]);
+      expect(
+        extractQueryParams('/* a /* b */ :ghost */ SELECT :real', 'mssql'),
+      ).toEqual(['real']);
+    });
+
+    it('does not treat postgres identifiers containing $tag$ as strings', () => {
+      expect(
+        extractQueryParams('SELECT foo$tag$ + :real + bar$tag$', 'postgres'),
+      ).toEqual(['real']);
+    });
+  });
+
+  describe('interpolateQueryParams with dialect (issue #458)', () => {
+    it('never rewrites inside string literals', () => {
+      const sql = "SELECT ':id', :id";
+      expect(interpolateQueryParams(sql, { id: '9' }, 'postgres')).toBe(
+        "SELECT ':id', 9",
+      );
+    });
+
+    it('never rewrites inside comments', () => {
+      const sql = 'SELECT :id -- :id in comment';
+      expect(interpolateQueryParams(sql, { id: '5' }, 'postgres')).toBe(
+        'SELECT 5 -- :id in comment',
+      );
+    });
+
+    it('replaces every occurrence by position', () => {
+      expect(interpolateQueryParams(':id + :id', { id: '7' }, 'postgres')).toBe(
+        '7 + 7',
+      );
+      expect(
+        interpolateQueryParams(':first + :last', { first: '1', last: '2' }, 'postgres'),
+      ).toBe('1 + 2');
+    });
+
+    it('keeps indices aligned after astral characters', () => {
+      const sql = "SELECT '😀:id', :id";
+      expect(interpolateQueryParams(sql, { id: '11' }, 'postgres')).toBe(
+        "SELECT '😀:id', 11",
+      );
+    });
+
+    it('leaves unknown params untouched around replaced ones', () => {
+      expect(
+        interpolateQueryParams('SELECT :known, :unknown', { known: '1' }, 'postgres'),
+      ).toBe('SELECT 1, :unknown');
+    });
+
+    it('leaves params named after Object.prototype members untouched', () => {
+      // A plain `params[name]` lookup would resolve :toString via the
+      // prototype chain and splice function source into the SQL.
+      expect(
+        interpolateQueryParams('SELECT :toString, :id', { id: '1' }, 'postgres'),
+      ).toBe('SELECT :toString, 1');
+      expect(interpolateQueryParams('SELECT :__proto__', {})).toBe(
+        'SELECT :__proto__',
+      );
+    });
+
+    it('handles values shorter and longer than the placeholder', () => {
+      expect(
+        interpolateQueryParams(
+          'a = :long_parameter_name',
+          { long_parameter_name: '1' },
+          'postgres',
+        ),
+      ).toBe('a = 1');
+      expect(
+        interpolateQueryParams('a = :x', { x: "'quite a long value'" }, 'postgres'),
+      ).toBe("a = 'quite a long value'");
+    });
+
+    it('keeps ::cast adjacency intact', () => {
+      expect(
+        interpolateQueryParams('SELECT :id::text, val::text', { id: "'abc'" }, 'postgres'),
+      ).toBe("SELECT 'abc'::text, val::text");
+    });
+
+    it('preserves pre-dialect behavior when dialect is omitted', () => {
+      // Matches the old full-text replace — including its literal-corruption
+      // flaw — so existing callers see zero change until they pass a dialect.
+      expect(interpolateQueryParams("SELECT ':id', :id", { id: '9' })).toBe(
+        "SELECT '9', 9",
+      );
+    });
+  });
 });

--- a/tests/utils/sqlSplitter/dialects.test.ts
+++ b/tests/utils/sqlSplitter/dialects.test.ts
@@ -14,6 +14,24 @@ describe('dialect canaries', () => {
     expect(result[0]).toContain('`col;name`');
   });
 
+  it('mysql shields semicolons inside # line comments', () => {
+    const sql = 'SELECT 1; # note; with semicolon\nSELECT 2';
+    expect(splitQueries(sql, 'mysql')).toHaveLength(2);
+  });
+
+  it('mssql shields semicolons inside double-quoted identifiers', () => {
+    const sql = 'SELECT "a;b" FROM t; SELECT 2';
+    const result = splitQueries(sql, 'mssql');
+    expect(result).toHaveLength(2);
+    expect(result[0]).toContain('"a;b"');
+  });
+
+  it('mssql shields semicolons inside nested block comments', () => {
+    expect(
+      splitQueries('/* o /* i */ ; */ SELECT 1', 'mssql'),
+    ).toHaveLength(1);
+  });
+
   it('mssql shields semicolons inside [bracketed identifiers]', () => {
     const sql = 'SELECT [col;name] FROM t; SELECT 2';
     const result = splitQueries(sql, 'mssql');
@@ -41,5 +59,16 @@ describe('dialect canaries', () => {
       'unknown-driver-from-plugin',
     );
     expect(result).toEqual(['SELECT 1', 'SELECT 2']);
+  });
+
+  it('treats Object.prototype member names as unknown dialects', () => {
+    // `in`-style lookups would resolve these via the prototype chain and
+    // hand a non-DialectOptions value to the tokenizer.
+    for (const dialect of ['__proto__', 'toString', 'constructor']) {
+      expect(splitQueries('SELECT 1; SELECT 2', dialect)).toEqual([
+        'SELECT 1',
+        'SELECT 2',
+      ]);
+    }
   });
 });

--- a/tests/utils/sqlSplitter/nonCodeSpans.test.ts
+++ b/tests/utils/sqlSplitter/nonCodeSpans.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from 'vitest';
+import { scanNonCodeSpans } from '../../../src/utils/sqlSplitter';
+
+/** Rebuilds the length-preserving mask a consumer would apply. */
+const maskOf = (sql: string, dialect?: string): string => {
+  const spans = scanNonCodeSpans(sql, dialect);
+  let masked = '';
+  let cursor = 0;
+  for (const { start, end } of spans) {
+    masked += sql.slice(cursor, start) + ' '.repeat(end - start);
+    cursor = end;
+  }
+  return masked + sql.slice(cursor);
+};
+
+describe('scanNonCodeSpans', () => {
+  describe('basic spans', () => {
+    it('covers a single-quoted literal exactly', () => {
+      expect(scanNonCodeSpans("SELECT 'x:y'", 'postgres')).toEqual([
+        { start: 7, end: 12 },
+      ]);
+    });
+
+    it('covers line and block comments', () => {
+      expect(scanNonCodeSpans('SELECT 1 -- :ghost', 'postgres')).toEqual([
+        { start: 9, end: 18 },
+      ]);
+      expect(scanNonCodeSpans('/* :ghost */ SELECT 1', 'postgres')).toEqual([
+        { start: 0, end: 12 },
+      ]);
+    });
+
+    it('returns sorted, non-overlapping, in-bounds spans', () => {
+      const sql = "SELECT 'a', /* c */ 'b' -- tail";
+      const spans = scanNonCodeSpans(sql, 'postgres');
+      let previousEnd = 0;
+      for (const { start, end } of spans) {
+        expect(start).toBeGreaterThanOrEqual(previousEnd);
+        expect(end).toBeGreaterThan(start);
+        expect(end).toBeLessThanOrEqual(sql.length);
+        previousEnd = end;
+      }
+      // Two literals, one block comment, one line comment.
+      expect(spans).toHaveLength(4);
+    });
+
+    it('produces a length-preserving mask, including astral characters', () => {
+      const sql = "SELECT '😀:id', :id";
+      expect(maskOf(sql, 'postgres')).toHaveLength(sql.length);
+      // The emoji sits inside the literal, so the whole literal is masked
+      // (UTF-16 code-unit indices, same contract as StatementRange).
+      expect(maskOf(sql, 'postgres')).toBe('SELECT        , :id');
+    });
+
+    it('runs unterminated strings and comments to end of input', () => {
+      expect(scanNonCodeSpans("WHERE v = 'x:y", 'postgres')).toEqual([
+        { start: 10, end: 14 },
+      ]);
+      expect(scanNonCodeSpans('/* open :ghost', 'postgres')).toEqual([
+        { start: 0, end: 14 },
+      ]);
+    });
+  });
+
+  describe('dialect fallback', () => {
+    it('returns no spans when the dialect is undefined or unknown', () => {
+      expect(scanNonCodeSpans("SELECT 'x:y'")).toEqual([]);
+      expect(scanNonCodeSpans("SELECT 'x:y'", 'does-not-exist')).toEqual([]);
+    });
+
+    it('scans with the ANSI-ish rules for an explicit generic', () => {
+      expect(scanNonCodeSpans("SELECT 'x:y'", 'generic')).toEqual([
+        { start: 7, end: 12 },
+      ]);
+    });
+
+    it('returns no spans for Object.prototype member names', () => {
+      // An `in` check would resolve these via the prototype chain and
+      // crash the scanner on a non-DialectOptions value.
+      expect(scanNonCodeSpans("SELECT 'x:y'", '__proto__')).toEqual([]);
+      expect(scanNonCodeSpans("SELECT 'x:y'", 'toString')).toEqual([]);
+      expect(scanNonCodeSpans("SELECT 'x:y'", 'constructor')).toEqual([]);
+    });
+  });
+
+  describe('postgres', () => {
+    it('covers dollar-quoted strings', () => {
+      expect(maskOf('SELECT $tag$:hidden$tag$, :visible', 'postgres')).toBe(
+        'SELECT                  , :visible',
+      );
+      expect(maskOf('SELECT $$key:value$$, :visible', 'postgres')).toBe(
+        'SELECT              , :visible',
+      );
+    });
+
+    it('honours E-string backslash escapes', () => {
+      expect(maskOf("SELECT E'it\\'s :hidden', :visible", 'postgres')).toBe(
+        'SELECT                 , :visible',
+      );
+    });
+
+    it('tracks nested block comments to the outermost close', () => {
+      expect(
+        maskOf('SELECT /* a /* :inner */ :after */ :visible', 'postgres'),
+      ).toBe('SELECT                             :visible');
+    });
+  });
+
+  describe('mysql', () => {
+    it('honours backslash escapes in strings', () => {
+      expect(maskOf("SELECT 'it\\'s :hidden', :visible", 'mysql')).toBe(
+        'SELECT                , :visible',
+      );
+    });
+
+    it('covers backtick-quoted identifiers', () => {
+      expect(maskOf('SELECT `weird:col` FROM t', 'mysql')).toBe(
+        'SELECT             FROM t',
+      );
+    });
+
+    it('treats -- without trailing space as data (subtraction)', () => {
+      expect(scanNonCodeSpans('SELECT qty--:threshold FROM stock', 'mysql')).toEqual(
+        [],
+      );
+    });
+
+    it('covers # line comments from any position to end of line', () => {
+      expect(scanNonCodeSpans('SELECT 1 # :ghost', 'mysql')).toEqual([
+        { start: 9, end: 17 },
+      ]);
+      // No whitespace requirement, unlike `--`.
+      expect(scanNonCodeSpans('SELECT qty#:ghost\n, :real', 'mysql')).toEqual([
+        { start: 10, end: 17 },
+      ]);
+    });
+
+    it('rescans MariaDB /*M! conditional comments instead of masking them', () => {
+      // MariaDB executes the payload, so :m must stay visible while the
+      // literal inside is still masked.
+      const sql = "SELECT /*M!100500 CONCAT('x:y'), :m */ :real";
+      const start = sql.indexOf("'x:y'");
+      expect(scanNonCodeSpans(sql, 'mysql')).toEqual([
+        { start, end: start + 5 },
+      ]);
+    });
+
+    it('rescans executable comment payloads instead of masking them', () => {
+      const sql = "SELECT /*!50700 CONCAT('x:y'), :exec */ :outer";
+      // Only the inner literal is non-code; the payload (incl. :exec) stays.
+      expect(scanNonCodeSpans(sql, 'mysql')).toEqual([{ start: 23, end: 28 }]);
+      expect(maskOf(sql, 'mysql')).toBe(
+        'SELECT /*!50700 CONCAT(     ), :exec */ :outer',
+      );
+    });
+
+    it('keeps spans sorted when a payload literal precedes a later outer literal', () => {
+      // The payload region is scanned after the rest of its parent, so
+      // its span arrives out of document order and must be re-sorted.
+      const sql = "SELECT /*!50700 'a' */ 'b'";
+      expect(scanNonCodeSpans(sql, 'mysql')).toEqual([
+        { start: 16, end: 19 },
+        { start: 23, end: 26 },
+      ]);
+      expect(maskOf(sql, 'mysql')).toBe('SELECT /*!50700     */    ');
+    });
+
+    it('survives pathological chains of executable-comment markers', () => {
+      // Regression: this used to recurse once per `/*!` header and
+      // overflow the native call stack at roughly 15KB of input.
+      expect(() => scanNonCodeSpans('/*!'.repeat(10000), 'mysql')).not.toThrow();
+      expect(() =>
+        scanNonCodeSpans('/*!'.repeat(10000) + 'x' + '*/', 'mysql'),
+      ).not.toThrow();
+    });
+
+    it('stops rescanning executable-comment payloads past the depth cap', () => {
+      // Eight nested headers: the innermost literal is still masked…
+      expect(scanNonCodeSpans('/*!'.repeat(8) + "'x:y'", 'mysql')).toHaveLength(1);
+      // …nine: the depth-9 payload is left unscanned (nothing masked),
+      // degrading to plain-text behavior for the pathological tail.
+      expect(scanNonCodeSpans('/*!'.repeat(9) + "'x:y'", 'mysql')).toEqual([]);
+    });
+
+    it('does not honour a DELIMITER directive in the middle of a line', () => {
+      // Mid-line DELIMITER is plain data, so the quoted part is a string.
+      expect(
+        scanNonCodeSpans("SELECT DELIMITER ':ghost' AS d, :real", 'mysql'),
+      ).toEqual([{ start: 17, end: 25 }]);
+    });
+
+    it('applies a custom delimiter that collides with a comment opener', () => {
+      // After `DELIMITER /*`, the `/*` sequence is the statement delimiter,
+      // not a block-comment opener — nothing here is non-code.
+      expect(
+        scanNonCodeSpans('DELIMITER /*\nSELECT :before/*\nSELECT :after;\n', 'mysql'),
+      ).toEqual([]);
+    });
+  });
+
+  describe('postgres identifier boundaries', () => {
+    it('does not treat a dollar quote glued to an identifier as an opener', () => {
+      // `foo$tag$` is a single PostgreSQL identifier, not a string start.
+      expect(
+        scanNonCodeSpans('SELECT foo$tag$ + :real + bar$tag$ FROM t', 'postgres'),
+      ).toEqual([]);
+    });
+  });
+
+  describe('oracle and mssql', () => {
+    it('covers oracle q-quoted strings', () => {
+      expect(maskOf("SELECT q'{it's :hidden}' FROM dual", 'oracle')).toBe(
+        'SELECT                   FROM dual',
+      );
+    });
+
+    it('covers mssql bracket identifiers', () => {
+      expect(maskOf('SELECT [weird:col] FROM t', 'mssql')).toBe(
+        'SELECT             FROM t',
+      );
+    });
+
+    it('covers mssql double-quoted identifiers', () => {
+      expect(maskOf('SELECT ":ghost" FROM t WHERE id = :id', 'mssql')).toBe(
+        'SELECT          FROM t WHERE id = :id',
+      );
+    });
+
+    it('tracks nested t-sql block comments to the outermost close', () => {
+      expect(
+        scanNonCodeSpans('/* outer /* inner */ :ghost */ SELECT :real', 'mssql'),
+      ).toEqual([{ start: 0, end: 30 }]);
+    });
+
+    it('advances past GO and slash delimiter lines without stalling', () => {
+      expect(scanNonCodeSpans('SELECT 1\nGO\nSELECT 2', 'mssql')).toEqual([]);
+      expect(scanNonCodeSpans('SELECT 1\n/\nSELECT 2', 'oracle')).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #458

## Problem

`extractQueryParams` / `interpolateQueryParams` ran a plain regex over the whole SQL text, so `:y` in

```sql
SELECT * FROM categories WHERE value = 'x:y'
```

popped the Query Parameters modal — and filling in a value silently rewrote the *inside of the string literal*, corrupting the query. Anything with colons in data hit this: URLs, timestamps, `key:value` pairs, JSON stored as text.

## Approach

Instead of adding a second scanner, this reuses the dialect-aware tokenizer that already powers the statement splitter (#225):

- **`scanNonCodeSpans(sql, dialect?)`** (new export from `src/utils/sqlSplitter`) returns the spans of every string literal and comment, driving `scanToken` with the same state updates as the splitter. `tokenizer.ts` internals stay private; the collector is an iterative worklist (see Hardening below).
- **`queryParameters.ts`** runs detection and interpolation on a **length-preserving mask** (non-code spans blanked with spaces) with the existing regex unchanged, so the `::cast` exclusion behaves exactly as before. Interpolation is position-based over the *original* text (mask indices transfer 1:1), so values can never land inside a literal — including after astral characters like `'😀:id'`, which the old full-text replace corrupted.
- **`Editor.tsx`** threads the driver's `sql_dialect` capability (introduced in #225) into all six call sites, and the Params-button probe is memoized since it runs in the render path on every keystroke.

**Fallback semantics.** With an `undefined`/unknown dialect nothing is masked: behavior is byte-for-byte the old one (the optional `dialect` argument keeps both functions backward compatible; the pre-existing tests pass unmodified). Guessing a dialect is measurably worse than not masking — e.g. generic quote rules read MySQL's `'a\'b'` as an unterminated string and would swallow every *real* parameter after it. Masking with the correct dialect only ever removes false positives; masking with a wrong one can hide real parameters.

MySQL executable comments (`/*!50700 ... */`) are **rescanned rather than masked**, so `:params` in the executable payload stay live while literals inside it are still protected. MariaDB's `/*M! ... */` gets the same treatment at the masking layer only — the splitter still folds it as a comment, so MySQL proper never receives a comment-only statement.

## Hardening

- The executable-comment rescan is an **iterative worklist with a depth cap** instead of native recursion: a pasted ~15KB chain of `/*!` markers used to overflow the call stack (reachable from the render path on MySQL connections). Past the cap the tail is left unmasked — the same fail-safe direction as the unknown-dialect fallback.
- Dialect lookup uses `Object.hasOwn`, so prototype member names (`'__proto__'`, `'toString'`) fall back cleanly instead of handing a non-`DialectOptions` value to the tokenizer. `normalizeDialect` had the same latent issue and got the same fix.
- Interpolation ignores parameter names that only resolve through `Object.prototype` (`:toString` no longer splices function source into the SQL).

## Dialect-preset corrections

Building the masking layer surfaced preset gaps that also affect statement splitting; each is fixed with splitter canary tests:

| Dialect | Fix | Reference |
|---|---|---|
| MySQL/MariaDB | `#` line comments recognized (any position, no whitespace requirement). Previously a `;` inside `# note;` mis-split the script. | [MySQL comment syntax](https://dev.mysql.com/doc/refman/8.0/en/comments.html) |
| MSSQL | `"double-quoted"` identifiers added to the quote rules (identifiers under default `QUOTED_IDENTIFIER ON`, strings when `OFF` — non-code either way). | [SET QUOTED_IDENTIFIER](https://learn.microsoft.com/en-us/sql/t-sql/statements/set-quoted-identifier-transact-sql) |
| MSSQL | Block comments now nest, per T-SQL semantics. | [Slash-star comments](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/slash-star-comment-transact-sql) |
| PostgreSQL | A dollar quote glued to an identifier (`foo$tag$`) is no longer treated as a string opener. | [Lexical structure](https://www.postgresql.org/docs/current/sql-syntax-lexical.html) |
| MariaDB | `/*M! ... */` payloads rescanned at the masking layer (see above). | [Comment syntax](https://mariadb.com/docs/server/reference/sql-statements/comment-syntax) |

## Known limitations (follow-up)

- **A dedicated MariaDB dialect**: tokenizer-level `/*M!` statement semantics (executing them as statements is only correct for MariaDB, and both servers currently share the `mysql` dialect).
- **`NO_BACKSLASH_ESCAPES`**: the sql_mode is per-session server state a static lexer cannot know; under that mode `'a\'` is a closed literal. Handling it would require reading `@@sql_mode` through the driver.

I'll open a follow-up issue for these after this lands.

## Tests

59 new cases: 28 in `tests/utils/sqlSplitter/nonCodeSpans.test.ts` (span exactness and sorted/non-overlapping/in-bounds invariants, UTF-16 indices with astral chars, unterminated strings/comments, dialect fallback incl. prototype-key names, per-dialect matrix, `DELIMITER` collision cases, `GO`/slash advancement, the depth-cap boundary, and a regression test for the 15KB `/*!` chain), 27 in `tests/utils/queryParameters.test.ts` (issue repro, boundary cases like `'x'::text` / `/*c*/:id` / `:na/*c*/me`, maskless-fallback equivalence, position-based interpolation incl. unknown-param preservation), and 4 splitter canaries in `tests/utils/sqlSplitter/dialects.test.ts`.

Full suite: **3170 passed**, `tsc --noEmit` clean, `eslint` clean. The pre-existing `queryParameters` tests pass unmodified.
