### PR TITLE
Prune dropped databases from the sidebar and saved selection

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -623,10 +623,13 @@ pub async fn get_available_databases<R: Runtime>(
 pub async fn set_selected_databases<R: Runtime>(
     app: AppHandle<R>,
     connection_id: String,
-    databases: Vec<String>,
+    mut databases: Vec<String>,
 ) -> Result<(), String> {
     if databases.is_empty() {
         return Err("Database selection cannot be empty".to_string());
+    }
+    if databases.iter().any(|db| db.trim().is_empty()) {
+        return Err("Database names cannot be empty".to_string());
     }
 
     log::info!(
@@ -645,7 +648,7 @@ pub async fn set_selected_databases<R: Runtime>(
         .ok_or("Connection not found")?;
 
     conn.params.database = if databases.len() == 1 {
-        crate::models::DatabaseSelection::Single(databases.into_iter().next().unwrap_or_default())
+        crate::models::DatabaseSelection::Single(databases.remove(0))
     } else {
         crate::models::DatabaseSelection::Multiple(databases)
     };

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -620,6 +620,40 @@ pub async fn get_available_databases<R: Runtime>(
 }
 
 #[tauri::command]
+pub async fn set_selected_databases<R: Runtime>(
+    app: AppHandle<R>,
+    connection_id: String,
+    databases: Vec<String>,
+) -> Result<(), String> {
+    if databases.is_empty() {
+        return Err("Database selection cannot be empty".to_string());
+    }
+
+    log::info!(
+        "Persisting database selection for connection {}: {} database(s)",
+        connection_id,
+        databases.len()
+    );
+
+    let path = get_config_path(&app)?;
+    let mut conn_file = persistence::load_connections_file(&path)?;
+
+    let conn = conn_file
+        .connections
+        .iter_mut()
+        .find(|c| c.id == connection_id)
+        .ok_or("Connection not found")?;
+
+    conn.params.database = if databases.len() == 1 {
+        crate::models::DatabaseSelection::Single(databases.into_iter().next().unwrap_or_default())
+    } else {
+        crate::models::DatabaseSelection::Multiple(databases)
+    };
+
+    save_connections_and_invalidate(&app, &path, &conn_file)
+}
+
+#[tauri::command]
 pub async fn get_routines<R: Runtime>(
     app: AppHandle<R>,
     connection_id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -425,6 +425,7 @@ pub fn run() {
             connection_import_commands::apply_tabularis_import,
             commands::get_schemas,
             commands::get_available_databases,
+            commands::set_selected_databases,
             commands::get_tables,
             commands::get_columns,
             commands::get_foreign_keys,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -569,6 +569,7 @@ pub fn run() {
             updater::get_installation_source,
             // Logs
             log_commands::get_logs,
+            log_commands::log_frontend_event,
             log_commands::clear_logs,
             log_commands::get_log_settings,
             log_commands::set_log_enabled,

--- a/src-tauri/src/log_commands.rs
+++ b/src-tauri/src/log_commands.rs
@@ -107,6 +107,8 @@ pub fn log_frontend_event(level: String, message: String) {
     match level.as_str() {
         "error" => log::error!(target: "frontend", "{}", message),
         "warn" => log::warn!(target: "frontend", "{}", message),
+        "debug" => log::debug!(target: "frontend", "{}", message),
+        "trace" => log::trace!(target: "frontend", "{}", message),
         _ => log::info!(target: "frontend", "{}", message),
     }
 }

--- a/src-tauri/src/log_commands.rs
+++ b/src-tauri/src/log_commands.rs
@@ -100,6 +100,17 @@ pub fn export_logs(log_buffer: State<SharedLogBuffer>, file_path: String) -> Res
     Ok(())
 }
 
+/// Lets the frontend record user-relevant events (e.g. a database pruned from
+/// a connection's selection) in the activity log shown in Settings → Logs.
+#[tauri::command]
+pub fn log_frontend_event(level: String, message: String) {
+    match level.as_str() {
+        "error" => log::error!(target: "frontend", "{}", message),
+        "warn" => log::warn!(target: "frontend", "{}", message),
+        _ => log::info!(target: "frontend", "{}", message),
+    }
+}
+
 #[tauri::command]
 pub fn test_log() -> Result<(), String> {
     log::info!("Test log message from frontend");

--- a/src/components/layout/ExplorerSidebar.tsx
+++ b/src/components/layout/ExplorerSidebar.tsx
@@ -85,7 +85,7 @@ import { groupRoutinesByType } from "../../utils/routines";
 import { formatObjectCount } from "../../utils/schema";
 import { groupByDate, formatHistoryTime } from "../../utils/dateGroups";
 import { SqlHighlight } from "../ui/SqlHighlight";
-import { isMultiDatabaseCapable } from "../../utils/database";
+import { isMultiDatabaseCapable, reconcileDatabaseSelection } from "../../utils/database";
 import { supportsManageTables } from "../../utils/driverCapabilities";
 import { newConsoleForDatabase, newConsoleForTable } from "../../utils/newConsole";
 import {
@@ -1212,6 +1212,9 @@ export const ExplorerSidebar = ({ sidebarWidth, startResize, onCollapse, sidebar
                             try {
                               const all = await invoke<string[]>("get_available_databases", { connectionId: activeConnectionId });
                               setAllAvailableDatabases(all);
+                              // A database dropped on the server has no row to
+                              // untick: drop it from the pending set too (#518).
+                              setPendingDbSelection(new Set(reconcileDatabaseSelection(selectedDatabases, all).selection));
                             } catch (e) {
                               console.error("Failed to load available databases:", e);
                             } finally {

--- a/src/components/ui/ToastContainer.tsx
+++ b/src/components/ui/ToastContainer.tsx
@@ -1,0 +1,62 @@
+import { useTranslation } from "react-i18next";
+import { AlertTriangle, CheckCircle2, Info, X, XCircle } from "lucide-react";
+import type { ToastKind } from "../../contexts/ToastContext";
+
+export interface ToastItem {
+  id: number;
+  message: string;
+  title?: string;
+  kind: ToastKind;
+}
+
+interface ToastContainerProps {
+  toasts: ToastItem[];
+  onDismiss: (id: number) => void;
+}
+
+const kindConfig: Record<ToastKind, { Icon: typeof Info; iconClass: string; boxClass: string }> = {
+  info: { Icon: Info, iconClass: "text-blue-400", boxClass: "bg-blue-900/30" },
+  success: { Icon: CheckCircle2, iconClass: "text-green-400", boxClass: "bg-green-900/30" },
+  warning: { Icon: AlertTriangle, iconClass: "text-yellow-400", boxClass: "bg-yellow-900/30" },
+  error: { Icon: XCircle, iconClass: "text-red-400", boxClass: "bg-red-900/30" },
+};
+
+export const ToastContainer = ({ toasts, onDismiss }: ToastContainerProps) => {
+  const { t } = useTranslation();
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-[120] flex flex-col items-end gap-2">
+      {toasts.map((toast) => {
+        const { Icon, iconClass, boxClass } = kindConfig[toast.kind];
+        return (
+          <div
+            key={toast.id}
+            role="status"
+            className="animate-slide-in-right flex items-start gap-3 w-[340px] p-3 bg-elevated border border-strong rounded-lg shadow-2xl"
+          >
+            <div className={`p-1.5 rounded-lg shrink-0 ${boxClass}`}>
+              <Icon size={16} className={iconClass} />
+            </div>
+            <div className="flex-1 min-w-0">
+              {toast.title && (
+                <div className="text-sm font-medium text-primary">{toast.title}</div>
+              )}
+              <div className="text-xs text-secondary leading-relaxed break-words">
+                {toast.message}
+              </div>
+            </div>
+            <button
+              onClick={() => onDismiss(toast.id)}
+              className="text-secondary hover:text-primary transition-colors shrink-0"
+              aria-label={t("common.close")}
+            >
+              <X size={14} />
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/contexts/DatabaseProvider.tsx
+++ b/src/contexts/DatabaseProvider.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import {
@@ -17,6 +18,7 @@ import type { PluginManifest } from '../types/plugins';
 import { clearAutocompleteCache } from '../utils/autocomplete';
 import { toErrorMessage } from '../utils/errors';
 import { useSettings } from '../hooks/useSettings';
+import { useToast } from '../hooks/useToast';
 import { findConnectionsForDrivers } from '../utils/connectionManager';
 import { isMultiDatabaseCapable, getEffectiveDatabase, getDatabaseList, reconcileDatabaseSelection } from '../utils/database';
 
@@ -47,6 +49,8 @@ const createEmptyConnectionData = (driver: string = '', name: string = '', dbNam
 
 export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
   const { settings } = useSettings();
+  const { showToast } = useToast();
+  const { t } = useTranslation();
   const [activeConnectionId, setActiveConnectionId] = useState<string | null>(null);
   const [openConnectionIds, setOpenConnectionIds] = useState<string[]>([]);
   const [connectionDataMap, setConnectionDataMap] = useState<Record<string, ConnectionData>>({});
@@ -569,13 +573,20 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
           const available = await invoke<string[]>('get_available_databases', { connectionId });
           const { selection, removed } = reconcileDatabaseSelection(dbList, available);
           if (removed.length > 0 && selection.length > 0) {
-            console.warn(`Pruning dropped database(s) from selection: ${removed.join(', ')}`);
             dbList = selection;
             isMultiDb = selection.length > 1;
             invoke('set_selected_databases', {
               connectionId,
               databases: selection,
             }).catch(e => console.error('Failed to persist reconciled database selection:', e));
+            showToast(t('sidebar.droppedDatabasesRemoved', { names: removed.join(', ') }), {
+              title: t('sidebar.databaseSelectionUpdated'),
+              kind: 'warning',
+            });
+            invoke('log_frontend_event', {
+              level: 'warn',
+              message: `Connection "${conn.name}": removed ${removed.join(', ')} from the database selection (no longer on the server)`,
+            }).catch(() => {});
           }
         } catch (e) {
           // Server list unavailable: keep the saved selection.

--- a/src/contexts/DatabaseProvider.tsx
+++ b/src/contexts/DatabaseProvider.tsx
@@ -18,7 +18,7 @@ import { clearAutocompleteCache } from '../utils/autocomplete';
 import { toErrorMessage } from '../utils/errors';
 import { useSettings } from '../hooks/useSettings';
 import { findConnectionsForDrivers } from '../utils/connectionManager';
-import { isMultiDatabaseCapable, getEffectiveDatabase, getDatabaseList } from '../utils/database';
+import { isMultiDatabaseCapable, getEffectiveDatabase, getDatabaseList, reconcileDatabaseSelection } from '../utils/database';
 
 const createEmptyConnectionData = (driver: string = '', name: string = '', dbName: string = ''): ConnectionData => ({
   driver,
@@ -458,7 +458,22 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
     const currentData = connectionDataMap[connId];
     if (!currentData) return;
 
-    updateConnectionData(connId, { selectedDatabases: newDatabases });
+    // Drop cached data for databases that left the selection.
+    const prunedDataMap = Object.fromEntries(
+      Object.entries(currentData.databaseDataMap).filter(([db]) => newDatabases.includes(db))
+    );
+
+    updateConnectionData(connId, {
+      selectedDatabases: newDatabases,
+      databaseDataMap: prunedDataMap,
+    });
+
+    if (newDatabases.length > 0) {
+      invoke('set_selected_databases', {
+        connectionId: connId,
+        databases: newDatabases,
+      }).catch(e => console.error('Failed to persist selected databases:', e));
+    }
 
     for (const db of newDatabases) {
       const existing = currentData.databaseDataMap[db];
@@ -544,10 +559,31 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
       // Register for health-check pinging.
       await invoke('register_active_connection', { connectionId });
 
-      const isMultiDb = isMultiDatabaseCapable(capabilities) && Array.isArray(dbParam) && dbParam.length > 1;
+      let isMultiDb = isMultiDatabaseCapable(capabilities) && Array.isArray(dbParam) && dbParam.length > 1;
+      let dbList = isMultiDb ? getDatabaseList(dbParam) : [];
 
       if (isMultiDb) {
-        const dbList = getDatabaseList(dbParam);
+        // Reconcile the saved selection against the server so databases
+        // dropped outside the app don't linger in the sidebar (#518).
+        try {
+          const available = await invoke<string[]>('get_available_databases', { connectionId });
+          const { selection, removed } = reconcileDatabaseSelection(dbList, available);
+          if (removed.length > 0 && selection.length > 0) {
+            console.warn(`Pruning dropped database(s) from selection: ${removed.join(', ')}`);
+            dbList = selection;
+            isMultiDb = selection.length > 1;
+            invoke('set_selected_databases', {
+              connectionId,
+              databases: selection,
+            }).catch(e => console.error('Failed to persist reconciled database selection:', e));
+          }
+        } catch (e) {
+          // Server list unavailable: keep the saved selection.
+          console.error('Failed to reconcile database selection:', e);
+        }
+      }
+
+      if (isMultiDb) {
         const firstDb = dbList[0] ?? '';
 
         // Pre-load first database inline

--- a/src/contexts/DatabaseProvider.tsx
+++ b/src/contexts/DatabaseProvider.tsx
@@ -571,22 +571,30 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
         // dropped outside the app don't linger in the sidebar (#518).
         try {
           const available = await invoke<string[]>('get_available_databases', { connectionId });
-          const { selection, removed } = reconcileDatabaseSelection(dbList, available);
-          if (removed.length > 0 && selection.length > 0) {
-            dbList = selection;
-            isMultiDb = selection.length > 1;
-            invoke('set_selected_databases', {
-              connectionId,
-              databases: selection,
-            }).catch(e => console.error('Failed to persist reconciled database selection:', e));
-            showToast(t('sidebar.droppedDatabasesRemoved', { names: removed.join(', ') }), {
-              title: t('sidebar.databaseSelectionUpdated'),
-              kind: 'warning',
-            });
-            invoke('log_frontend_event', {
-              level: 'warn',
-              message: `Connection "${conn.name}": removed ${removed.join(', ')} from the database selection (no longer on the server)`,
-            }).catch(() => {});
+          // The primary database must exist while this connection is open: if
+          // the server list doesn't include it, the list is unreliable (e.g.
+          // filtered by privileges) and pruning from it would drop valid
+          // entries. This also guarantees the selection never ends up empty.
+          if (available.includes(dbList[0])) {
+            const { selection, removed } = reconcileDatabaseSelection(dbList, available);
+            if (removed.length > 0) {
+              dbList = selection;
+              isMultiDb = selection.length > 1;
+              invoke('set_selected_databases', {
+                connectionId,
+                databases: selection,
+              }).catch(e => console.error('Failed to persist reconciled database selection:', e));
+              showToast(t('sidebar.droppedDatabasesRemoved', { names: removed.join(', ') }), {
+                title: t('sidebar.databaseSelectionUpdated'),
+                kind: 'warning',
+              });
+              invoke('log_frontend_event', {
+                level: 'warn',
+                message: `Connection "${conn.name}": removed ${removed.join(', ')} from the database selection (no longer on the server)`,
+              }).catch(() => {});
+            }
+          } else {
+            console.warn('Skipping database selection reconciliation: server list does not include the primary database');
           }
         } catch (e) {
           // Server list unavailable: keep the saved selection.

--- a/src/contexts/ToastContext.ts
+++ b/src/contexts/ToastContext.ts
@@ -1,0 +1,18 @@
+import { createContext } from "react";
+
+export type ToastKind = "info" | "success" | "warning" | "error";
+
+export interface ToastOptions {
+  title?: string;
+  kind?: ToastKind;
+  /** Auto-dismiss delay in ms. Pass 0 to keep the toast until dismissed. */
+  duration?: number;
+}
+
+export interface ToastContextType {
+  showToast: (message: string, options?: ToastOptions) => void;
+}
+
+export const ToastContext = createContext<ToastContextType>({
+  showToast: () => {},
+});

--- a/src/contexts/ToastProvider.tsx
+++ b/src/contexts/ToastProvider.tsx
@@ -1,0 +1,35 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import { ToastContext, type ToastOptions } from "./ToastContext";
+import { ToastContainer, type ToastItem } from "../components/ui/ToastContainer";
+
+const DEFAULT_DURATION_MS = 6000;
+
+export const ToastProvider = ({ children }: { children: React.ReactNode }) => {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const nextIdRef = useRef(1);
+
+  const dismissToast = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((toast) => toast.id !== id));
+  }, []);
+
+  const showToast = useCallback((message: string, options?: ToastOptions) => {
+    const id = nextIdRef.current++;
+    setToasts((prev) => [
+      ...prev,
+      { id, message, title: options?.title, kind: options?.kind ?? "info" },
+    ]);
+    const duration = options?.duration ?? DEFAULT_DURATION_MS;
+    if (duration > 0) {
+      setTimeout(() => dismissToast(id), duration);
+    }
+  }, [dismissToast]);
+
+  const contextValue = useMemo(() => ({ showToast }), [showToast]);
+
+  return (
+    <ToastContext.Provider value={contextValue}>
+      {children}
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
+    </ToastContext.Provider>
+  );
+};

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,0 +1,4 @@
+import { useContext } from "react";
+import { ToastContext } from "../contexts/ToastContext";
+
+export const useToast = () => useContext(ToastContext);

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -150,6 +150,8 @@
     "noTablesMatch": "Keine passende Tabelle",
     "filterDatabases": "Datenbanken filtern...",
     "manageDatabases": "Datenbanken verwalten",
+    "databaseSelectionUpdated": "Datenbankauswahl aktualisiert",
+    "droppedDatabasesRemoved": "Entfernt, da nicht mehr auf dem Server vorhanden: {{names}}",
     "structure": "Struktur",
     "favorites": "Favoriten",
     "queryHistory": "Verlauf",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -163,6 +163,8 @@
     "noTablesMatch": "No tables match",
     "filterDatabases": "Filter databases...",
     "manageDatabases": "Manage Databases",
+    "databaseSelectionUpdated": "Database selection updated",
+    "droppedDatabasesRemoved": "Removed because no longer on the server: {{names}}",
     "structure": "Structure",
     "favorites": "Favorites",
     "queryHistory": "History",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -150,6 +150,8 @@
     "noTablesMatch": "No hay tablas que coincidan",
     "filterDatabases": "Filtrar bases de datos...",
     "manageDatabases": "Gestionar Bases de Datos",
+    "databaseSelectionUpdated": "Selección de bases de datos actualizada",
+    "droppedDatabasesRemoved": "Se eliminaron porque ya no existen en el servidor: {{names}}",
     "structure": "Estructura",
     "favorites": "Favoritos",
     "queryHistory": "Historial",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -163,6 +163,8 @@
     "noTablesMatch": "Aucune table correspondante",
     "filterDatabases": "Filtrer les bases de données...",
     "manageDatabases": "Gérer les bases de données",
+    "databaseSelectionUpdated": "Sélection des bases de données mise à jour",
+    "droppedDatabasesRemoved": "Supprimées car absentes du serveur : {{names}}",
     "structure": "Structure",
     "favorites": "Favoris",
     "queryHistory": "Historique",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -150,6 +150,8 @@
     "noTablesMatch": "Nessuna tabella trovata",
     "filterDatabases": "Filtra database...",
     "manageDatabases": "Gestisci Database",
+    "databaseSelectionUpdated": "Selezione database aggiornata",
+    "droppedDatabasesRemoved": "Rimossi perché non più presenti sul server: {{names}}",
     "structure": "Struttura",
     "favorites": "Preferiti",
     "queryHistory": "Cronologia",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -163,6 +163,8 @@
     "noTablesMatch": "一致するテーブルがありません",
     "filterDatabases": "データベースをフィルター...",
     "manageDatabases": "データベースを管理",
+    "databaseSelectionUpdated": "データベースの選択を更新しました",
+    "droppedDatabasesRemoved": "サーバーに存在しないため削除されました: {{names}}",
     "structure": "構造",
     "favorites": "お気に入り",
     "queryHistory": "履歴",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -163,6 +163,8 @@
     "noTablesMatch": "일치하는 테이블이 없습니다",
     "filterDatabases": "데이터베이스 필터...",
     "manageDatabases": "데이터베이스 관리",
+    "databaseSelectionUpdated": "데이터베이스 선택이 업데이트되었습니다",
+    "droppedDatabasesRemoved": "서버에 더 이상 존재하지 않아 제거되었습니다: {{names}}",
     "structure": "구조",
     "favorites": "즐겨찾기",
     "queryHistory": "기록",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -163,6 +163,8 @@
     "noTablesMatch": "Таблицы не найдены",
     "filterDatabases": "Фильтр баз данных...",
     "manageDatabases": "Управление базами данных",
+    "databaseSelectionUpdated": "Выбор баз данных обновлён",
+    "droppedDatabasesRemoved": "Удалены, так как больше не существуют на сервере: {{names}}",
     "structure": "Структура",
     "favorites": "Избранное",
     "queryHistory": "История",

--- a/src/i18n/locales/tl.json
+++ b/src/i18n/locales/tl.json
@@ -163,6 +163,8 @@
     "noTablesMatch": "Walang table na tumugma",
     "filterDatabases": "I-filter ang mga database...",
     "manageDatabases": "Pamahalaan ang mga Database",
+    "databaseSelectionUpdated": "Na-update ang pagpili ng database",
+    "droppedDatabasesRemoved": "Inalis dahil wala na sa server: {{names}}",
     "structure": "Istruktura",
     "favorites": "Mga Paborito",
     "queryHistory": "Kasaysayan",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -149,6 +149,8 @@
     "noTablesMatch": "无匹配的表",
     "filterDatabases": "筛选数据库...",
     "manageDatabases": "管理数据库",
+    "databaseSelectionUpdated": "数据库选择已更新",
+    "droppedDatabasesRemoved": "已移除服务器上不再存在的数据库：{{names}}",
     "structure": "结构",
     "favorites": "收藏",
     "queryHistory": "历史",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import { App } from './App';
 import './index.css';
 import './i18n/config';
 import { DatabaseProvider } from './contexts/DatabaseProvider';
+import { ToastProvider } from './contexts/ToastProvider';
 import { SettingsProvider } from './contexts/SettingsProvider';
 import { SavedQueriesProvider } from './contexts/SavedQueriesProvider';
 import { QueryHistoryProvider } from './contexts/QueryHistoryProvider';
@@ -19,15 +20,17 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <UpdateProvider>
       <ThemeProvider>
         <SettingsProvider>
-          <DatabaseProvider>
-            <SavedQueriesProvider>
+          <ToastProvider>
+            <DatabaseProvider>
+              <SavedQueriesProvider>
               <QueryHistoryProvider>
                 <EditorProvider>
                   <App />
                 </EditorProvider>
               </QueryHistoryProvider>
             </SavedQueriesProvider>
-          </DatabaseProvider>
+            </DatabaseProvider>
+          </ToastProvider>
         </SettingsProvider>
       </ThemeProvider>
     </UpdateProvider>

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -44,3 +44,25 @@ export function getEffectiveDatabase(db: string | string[]): string {
   }
   return db;
 }
+
+/**
+ * Reconciles a saved database selection against the databases that actually
+ * exist on the server. Preserves the saved order; entries that no longer
+ * exist are reported in `removed` so callers can persist the pruned list.
+ */
+export function reconcileDatabaseSelection(
+  saved: string[],
+  available: string[],
+): { selection: string[]; removed: string[] } {
+  const availableSet = new Set(available);
+  const selection: string[] = [];
+  const removed: string[] = [];
+  for (const db of saved) {
+    if (availableSet.has(db)) {
+      selection.push(db);
+    } else {
+      removed.push(db);
+    }
+  }
+  return { selection, removed };
+}

--- a/tests/components/ui/ToastContainer.test.tsx
+++ b/tests/components/ui/ToastContainer.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, act, cleanup } from "@testing-library/react";
+import { ToastContainer, type ToastItem } from "../../../src/components/ui/ToastContainer";
+import { ToastProvider } from "../../../src/contexts/ToastProvider";
+import { useToast } from "../../../src/hooks/useToast";
+import type { ToastOptions } from "../../../src/contexts/ToastContext";
+
+const Trigger = ({ message, options }: { message: string; options?: ToastOptions }) => {
+  const { showToast } = useToast();
+  return <button onClick={() => showToast(message, options)}>trigger</button>;
+};
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("ToastContainer", () => {
+  it("renders nothing when there are no toasts", () => {
+    const { container } = render(<ToastContainer toasts={[]} onDismiss={() => {}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders title and message", () => {
+    const toasts: ToastItem[] = [
+      { id: 1, title: "Selection updated", message: "vins was removed", kind: "warning" },
+    ];
+    render(<ToastContainer toasts={toasts} onDismiss={() => {}} />);
+    expect(screen.getByText("Selection updated")).toBeInTheDocument();
+    expect(screen.getByText("vins was removed")).toBeInTheDocument();
+  });
+
+  it("renders a toast without a title", () => {
+    const toasts: ToastItem[] = [{ id: 1, message: "plain message", kind: "info" }];
+    render(<ToastContainer toasts={toasts} onDismiss={() => {}} />);
+    expect(screen.getByText("plain message")).toBeInTheDocument();
+  });
+
+  it("calls onDismiss with the toast id when the close button is clicked", () => {
+    const onDismiss = vi.fn();
+    const toasts: ToastItem[] = [{ id: 7, message: "bye", kind: "error" }];
+    render(<ToastContainer toasts={toasts} onDismiss={onDismiss} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onDismiss).toHaveBeenCalledWith(7);
+  });
+
+  it("stacks multiple toasts", () => {
+    const toasts: ToastItem[] = [
+      { id: 1, message: "first", kind: "info" },
+      { id: 2, message: "second", kind: "success" },
+    ];
+    render(<ToastContainer toasts={toasts} onDismiss={() => {}} />);
+    expect(screen.getAllByRole("status")).toHaveLength(2);
+  });
+});
+
+describe("ToastProvider", () => {
+  it("shows a toast when showToast is called", () => {
+    render(
+      <ToastProvider>
+        <Trigger message="hello" />
+      </ToastProvider>,
+    );
+    fireEvent.click(screen.getByText("trigger"));
+    expect(screen.getByText("hello")).toBeInTheDocument();
+  });
+
+  it("auto-dismisses a toast after the default duration", () => {
+    vi.useFakeTimers();
+    render(
+      <ToastProvider>
+        <Trigger message="ephemeral" />
+      </ToastProvider>,
+    );
+    fireEvent.click(screen.getByText("trigger"));
+    expect(screen.getByText("ephemeral")).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(6000);
+    });
+    expect(screen.queryByText("ephemeral")).not.toBeInTheDocument();
+  });
+
+  it("keeps a toast with duration 0 until it is dismissed manually", () => {
+    vi.useFakeTimers();
+    render(
+      <ToastProvider>
+        <Trigger message="sticky" options={{ duration: 0 }} />
+      </ToastProvider>,
+    );
+    fireEvent.click(screen.getByText("trigger"));
+    act(() => {
+      vi.advanceTimersByTime(60000);
+    });
+    expect(screen.getByText("sticky")).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("common.close"));
+    expect(screen.queryByText("sticky")).not.toBeInTheDocument();
+  });
+
+  it("dismissing one toast keeps the others visible", () => {
+    render(
+      <ToastProvider>
+        <Trigger message="first" options={{ duration: 0 }} />
+      </ToastProvider>,
+    );
+    const trigger = screen.getByText("trigger");
+    fireEvent.click(trigger);
+    fireEvent.click(trigger);
+    const closeButtons = screen.getAllByLabelText("common.close");
+    expect(closeButtons).toHaveLength(2);
+    fireEvent.click(closeButtons[0]);
+    expect(screen.getAllByLabelText("common.close")).toHaveLength(1);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -108,6 +108,7 @@ vi.mock("lucide-react", () => ({
   ShieldCheck: () => null,
   Download: () => null,
   AlertTriangle: () => null,
+  Info: () => null,
   Trash2: () => null,
   Edit: () => null,
   Edit2: () => null,

--- a/tests/utils/database.test.ts
+++ b/tests/utils/database.test.ts
@@ -4,6 +4,7 @@ import {
   isMultiDatabaseSelection,
   getDatabaseList,
   getEffectiveDatabase,
+  reconcileDatabaseSelection,
 } from '../../src/utils/database';
 import type { DriverCapabilities } from '../../src/types/plugins';
 
@@ -92,6 +93,58 @@ describe('getDatabaseList', () => {
 
   it('returns single-element array for single-element array input', () => {
     expect(getDatabaseList(['only'])).toEqual(['only']);
+  });
+});
+
+describe('reconcileDatabaseSelection', () => {
+  it('keeps the selection unchanged when every database exists', () => {
+    expect(reconcileDatabaseSelection(['a', 'b'], ['a', 'b', 'c'])).toEqual({
+      selection: ['a', 'b'],
+      removed: [],
+    });
+  });
+
+  it('removes databases that no longer exist on the server', () => {
+    expect(reconcileDatabaseSelection(['a', 'vins', 'b'], ['a', 'b', 'c'])).toEqual({
+      selection: ['a', 'b'],
+      removed: ['vins'],
+    });
+  });
+
+  it('preserves the saved order of the surviving selection', () => {
+    expect(reconcileDatabaseSelection(['z', 'a', 'm'], ['a', 'm', 'z']).selection).toEqual([
+      'z',
+      'a',
+      'm',
+    ]);
+  });
+
+  it('reports everything as removed when the server list is empty', () => {
+    expect(reconcileDatabaseSelection(['a', 'b'], [])).toEqual({
+      selection: [],
+      removed: ['a', 'b'],
+    });
+  });
+
+  it('returns empty results for an empty saved selection', () => {
+    expect(reconcileDatabaseSelection([], ['a', 'b'])).toEqual({
+      selection: [],
+      removed: [],
+    });
+  });
+
+  it('matches database names case-sensitively', () => {
+    expect(reconcileDatabaseSelection(['Vins'], ['vins'])).toEqual({
+      selection: [],
+      removed: ['Vins'],
+    });
+  });
+
+  it('keeps duplicate saved entries that exist on the server', () => {
+    expect(reconcileDatabaseSelection(['a', 'a'], ['a'])).toEqual({
+      selection: ['a', 'a'],
+      removed: [],
+    });
   });
 });
 


### PR DESCRIPTION
Fixes #518

When a database in a multi-database connection is dropped on the server, its entry stays in the sidebar forever: the selection stored in `connections.json` is never reconciled against the server, so the stale entry even survives an app restart. The "Manage databases" popover can't remove it either — the list only shows databases that still exist, so a dropped one has no row to untick, and confirming quietly re-saves it.

What changed:

- On connect, multi-database connections compare the saved selection with the server's database list and drop entries that no longer exist. The pruned selection is written back through a new `set_selected_databases` command, so the cleanup sticks across restarts. If the server list can't be fetched, the saved selection is kept as-is.
- The cleanup is no longer silent: a toast in the bottom-right corner lists the removed databases, and the removal is recorded in the activity log (Settings → Logs) through a new `log_frontend_event` command.
- Since the app had no toast component, this adds one (`ToastProvider` / `useToast` / `ToastContainer`), mirroring the existing Alert pattern: stacked bottom-right, auto-dismiss after 6s, info/success/warning/error variants.
- `setSelectedDatabases` now persists the selection to the saved connection (it previously lived only in React state) and drops cached schema data for databases that left the selection.
- The popover intersects its pending selection with the live list, so a dropped database can no longer be re-confirmed into the selection by accident.

If the selection shrinks to a single database, the connection falls back to the regular single-database layout on the next connect.

The reconciliation logic is a pure helper in `src/utils/database.ts`, covered by `tests/utils/database.test.ts`; the toast component has its own tests in `tests/components/ui/ToastContainer.test.tsx`. Toast strings are translated in all 10 locales.

Verified with `pnpm test` (3127 passing), `npx tsc -b --force` and `cargo check`. I didn't reproduce the scenario against a real MySQL server yet — worth a quick manual pass before merging (drop one of several selected databases, reconnect, check the toast, the sidebar, the log entry and `connections.json`).

## Follow-ups (separate PRs, once this is merged)

This PR only reconciles at connect time and in the popover. Two more pieces are needed for the full picture:

1. **React to `DROP DATABASE` executed inside the app.** Detect the statement after it succeeds (`execute_query`, `execute_query_batch` and the MCP path), extract the database name, and compare it with the connection's selection: single-database connection → tear down the session (close pools including the per-database ones, unregister the health check, remove from the UI, tell the user why); multi-database → remove just that database and close its pool; not selected → refresh the database list at most. Needs a small dedicated parser — the existing classifier only buckets statements as select/write/ddl and doesn't extract names. Also worth fixing here: `disconnect_connection` currently closes only the primary pool, so per-database pools of a multi-db session leak until app shutdown.
2. **Recognize externally-dropped databases from errors and the health check.** Drivers currently stringify every error, so a missing database is indistinguishable from a typo. Add a structured "database not found" classification in the drivers (MySQL errno 1049/1046, Postgres SQLSTATE 3D000, SQLite unable-to-open) and have query/metadata failures trigger the same flow as point 1. Make the health check see it too: MySQL pings with COM_PING, which keeps succeeding after the current database is dropped, and SQLite pings through the still-open file handle — the MySQL ping should touch the current database and the SQLite ping should check the file still exists. The health check must also distinguish "server unreachable" (tear down the connection) from "one database missing" (prune just that one), instead of tearing everything down after two failed pings.

In both cases "disconnected" means the session, not the saved connection: if the database is recreated later, the saved connection must work again unchanged.