### PR TITLE
fix(connections): do not gate Load Databases on username (#528)

### DIFF
--- a/src/components/modals/NewConnectionModal.tsx
+++ b/src/components/modals/NewConnectionModal.tsx
@@ -2087,9 +2087,7 @@ export const NewConnectionModal = ({
                   onClick={() => {
                     void loadDatabases();
                   }}
-                  disabled={
-                    loadingDatabases || !formData.host || !formData.username
-                  }
+                  disabled={loadingDatabases || !formData.host}
                   className="flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300 disabled:text-muted disabled:cursor-not-allowed transition-colors"
                 >
                   {loadingDatabases ? (
@@ -2264,7 +2262,7 @@ export const NewConnectionModal = ({
           onClick={() => {
             void loadDatabases();
           }}
-          disabled={loadingDatabases || !formData.host || !formData.username}
+          disabled={loadingDatabases || !formData.host}
           className="flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300 disabled:text-muted disabled:cursor-not-allowed transition-colors shrink-0"
         >
           {loadingDatabases ? (


### PR DESCRIPTION
Fixes #528

## Problem

Both "Load Databases" buttons in the connection modal were disabled unless `host` **and** `username` were non-empty:

```
disabled={loadingDatabases || !formData.host || !formData.username}
```

Redis authenticates with a password only (or with nothing at all), so the username field stays empty and the button can never be enabled. Since the modal also requires a database name to save, the connection cannot be created at all — even though "Test connection" succeeds.

The username requirement was not backed by anything else in the codebase: `validateConnectionParams` (`src/utils/connections.ts`) never checks username or password, `save_connection`/`update_connection` accept empty credentials, and `list_databases` does not validate them either. These two `disabled` props were the only place in the app where a username was treated as mandatory.

## Change

Drop the `username` condition from both buttons, keeping the `host` check, which is consistent with `validateConnectionParams` (host is required for non-local drivers).

- `src/components/modals/NewConnectionModal.tsx` — single-database "Load Databases" button
- `src/components/modals/NewConnectionModal.tsx` — multi-database selection panel button

`loadDatabases()` already passes `formData` through untouched and surfaces backend failures in `databaseLoadError`, rendered right under the button. So for engines that *do* need credentials, the user now gets the real error message from the server instead of an inert button with no explanation.

## Testing

- `pnpm typecheck` — clean
- `pnpm lint` on the touched file — clean
- Manual: Redis connection with host + password only, no username → "Load Databases" is enabled and populates the database list; the connection can be saved.
- Manual: MySQL with an empty username → button enabled, click surfaces the server's authentication error under the button.

## Not covered here

Username and password are still rendered for every network driver with no indication that they may be optional, and a plugin cannot declare per-field auth requirements in its manifest (there is no `required` / `visible_when` / `hides_username` equivalent in the capability set). That is a broader change, tracked separately.
