### PR TITLE
feat(ai): add Atlas Cloud provider

### DIFF
--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -7,6 +7,8 @@ use std::fs;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Manager};
 
+const ATLAS_CLOUD_BASE_URL: &str = "https://api.atlascloud.ai/v1";
+
 // --- Data Structures ---
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -271,7 +273,7 @@ fn build_api_url(base_url: &str, endpoint: &str) -> String {
     format!("{trimmed}{endpoint}")
 }
 
-async fn fetch_custom_openai_models(base_url: &str, api_key: &str) -> Vec<String> {
+async fn fetch_openai_compatible_models(base_url: &str, api_key: &str) -> Vec<String> {
     if base_url.is_empty() || api_key.is_empty() {
         return Vec::new();
     }
@@ -345,7 +347,8 @@ pub async fn get_ai_models(
                     config::get_ai_api_key(&app, "custom-openai"),
                 ) {
                     if !base_url.is_empty() && !api_key.is_empty() {
-                        let custom_models = fetch_custom_openai_models(&base_url, &api_key).await;
+                        let custom_models =
+                            fetch_openai_compatible_models(&base_url, &api_key).await;
                         if !custom_models.is_empty() {
                             cached_models.insert("custom-openai".to_string(), custom_models);
                         } else {
@@ -367,6 +370,15 @@ pub async fn get_ai_models(
                     let minimax_models = fetch_minimax_models(&key).await;
                     if !minimax_models.is_empty() {
                         cached_models.insert("minimax".to_string(), minimax_models);
+                    }
+                }
+
+                // Always refresh Atlas Cloud if an API key is present
+                if let Ok(key) = config::get_ai_api_key(&app, "atlascloud") {
+                    let atlas_models =
+                        fetch_openai_compatible_models(ATLAS_CLOUD_BASE_URL, &key).await;
+                    if !atlas_models.is_empty() {
+                        cached_models.insert("atlascloud".to_string(), atlas_models);
                     }
                 }
 
@@ -422,7 +434,20 @@ pub async fn get_ai_models(
         }
     }
 
-    // 5. OpenRouter (Dynamic public)
+    // 5. Atlas Cloud (Dynamic if key exists)
+    if let Ok(key) = config::get_ai_api_key(&app, "atlascloud") {
+        let remote_models = fetch_openai_compatible_models(ATLAS_CLOUD_BASE_URL, &key).await;
+        if !remote_models.is_empty() {
+            if let Some(static_list) = models.get_mut("atlascloud") {
+                let mut set: HashSet<String> = static_list.iter().cloned().collect();
+                set.extend(remote_models);
+                *static_list = set.into_iter().collect();
+                static_list.sort();
+            }
+        }
+    }
+
+    // 6. OpenRouter (Dynamic public)
     let openrouter_models = fetch_openrouter_models().await;
     if !openrouter_models.is_empty() {
         if let Some(static_list) = models.get_mut("openrouter") {
@@ -438,13 +463,13 @@ pub async fn get_ai_models(
         }
     }
 
-    // 6. Custom OpenAI (Dynamic if configured)
+    // 7. Custom OpenAI (Dynamic if configured)
     if let (Some(base_url), Ok(api_key)) = (
         app_config.ai_custom_openai_url,
         config::get_ai_api_key(&app, "custom-openai"),
     ) {
         if !base_url.is_empty() && !api_key.is_empty() {
-            let custom_models = fetch_custom_openai_models(&base_url, &api_key).await;
+            let custom_models = fetch_openai_compatible_models(&base_url, &api_key).await;
             if !custom_models.is_empty() {
                 models.insert("custom-openai".to_string(), custom_models);
             } else {
@@ -547,9 +572,28 @@ async fn dispatch_provider(
                 .as_ref()
                 .filter(|u| !u.is_empty())
                 .ok_or("Custom OpenAI URL not configured.")?;
-            generate_custom_openai(&client, &api_key, gen_req, system_prompt, base_url).await
+            generate_openai_compatible(
+                &client,
+                &api_key,
+                gen_req,
+                system_prompt,
+                base_url,
+                "Custom OpenAI",
+            )
+            .await
         }
         "minimax" => generate_minimax(&client, &api_key, gen_req, system_prompt).await,
+        "atlascloud" => {
+            generate_openai_compatible(
+                &client,
+                &api_key,
+                gen_req,
+                system_prompt,
+                ATLAS_CLOUD_BASE_URL,
+                "Atlas Cloud",
+            )
+            .await
+        }
         _ => Err(format!("Unsupported provider: {}", gen_req.provider)),
     }
 }
@@ -793,12 +837,13 @@ async fn generate_openai(
     Ok(clean_response(content))
 }
 
-async fn generate_custom_openai(
+async fn generate_openai_compatible(
     client: &Client,
     api_key: &str,
     req: &AiGenerateRequest,
     system_prompt: &str,
     base_url: &str,
+    provider_label: &str,
 ) -> Result<String, String> {
     let body = json!({
         "model": req.model,
@@ -823,13 +868,18 @@ async fn generate_custom_openai(
 
     if !res.status().is_success() {
         let error_text = res.text().await.unwrap_or_default();
-        return Err(format!("Custom OpenAI Error: {}", error_text));
+        return Err(format!("{} Error: {}", provider_label, error_text));
     }
 
     let json: serde_json::Value = res.json().await.map_err(|e| e.to_string())?;
     let content = json["choices"][0]["message"]["content"]
         .as_str()
-        .ok_or("Invalid response format from custom OpenAI-compatible provider")?;
+        .ok_or_else(|| {
+            format!(
+                "Invalid response format from {} OpenAI-compatible provider",
+                provider_label
+            )
+        })?;
 
     Ok(clean_response(content))
 }
@@ -1015,6 +1065,7 @@ mod tests {
         assert!(models.contains_key("anthropic"));
         assert!(models.contains_key("openrouter"));
         assert!(models.contains_key("minimax"));
+        assert!(models.contains_key("atlascloud"));
 
         // Check for new futuristic models from yaml
         let openai = models.get("openai").unwrap();
@@ -1035,8 +1086,26 @@ mod tests {
         // M3 should be listed first so it is selected as the default model
         assert_eq!(minimax.first().map(String::as_str), Some("MiniMax-M3"));
 
+        let atlascloud = models.get("atlascloud").unwrap();
+        assert_eq!(
+            atlascloud.first().map(String::as_str),
+            Some("deepseek-ai/deepseek-v4-pro")
+        );
+
         // Ollama is not in yaml, so it shouldn't be here yet
         assert!(!models.contains_key("ollama"));
+    }
+
+    #[test]
+    fn test_atlas_cloud_api_urls() {
+        assert_eq!(
+            build_api_url(ATLAS_CLOUD_BASE_URL, "/models"),
+            "https://api.atlascloud.ai/v1/models"
+        );
+        assert_eq!(
+            build_api_url(ATLAS_CLOUD_BASE_URL, "/chat/completions"),
+            "https://api.atlascloud.ai/v1/chat/completions"
+        );
     }
 
     #[test]

--- a/src-tauri/src/ai_models.yaml
+++ b/src-tauri/src/ai_models.yaml
@@ -23,6 +23,11 @@ minimax:
   - MiniMax-M2.7
   - MiniMax-M2.7-highspeed
 
+atlascloud:
+  - deepseek-ai/deepseek-v4-pro
+  - deepseek-ai/deepseek-v4-flash
+  - qwen/qwen3.5-flash
+
 openrouter:
   - openai/gpt-5.5
   - openai/gpt-5.4

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -631,6 +631,7 @@ pub fn get_ai_api_key(app: &AppHandle, provider: &str) -> Result<String, String>
         "openrouter" => "OPENROUTER_API_KEY",
         "custom-openai" => "CUSTOM_OPENAI_API_KEY",
         "minimax" => "MINIMAX_API_KEY",
+        "atlascloud" => "ATLASCLOUD_API_KEY",
         _ => "",
     };
 
@@ -667,6 +668,7 @@ pub fn get_ai_api_key_status(app: &AppHandle, provider: &str) -> AiKeyStatus {
         "openrouter" => "OPENROUTER_API_KEY",
         "custom-openai" => "CUSTOM_OPENAI_API_KEY",
         "minimax" => "MINIMAX_API_KEY",
+        "atlascloud" => "ATLASCLOUD_API_KEY",
         _ => "",
     };
 

--- a/src/components/settings/AiTab.tsx
+++ b/src/components/settings/AiTab.tsx
@@ -54,6 +54,11 @@ const PROVIDERS: Array<{
     icon: <MiniMaxIcon size={18} className="text-[#6c6cff]" />,
   },
   {
+    id: "atlascloud",
+    label: "Atlas Cloud",
+    icon: <OpenAIIcon size={18} className="text-blue-400" />,
+  },
+  {
     id: "openrouter",
     label: "OpenRouter",
     icon: <OpenRouterIcon size={18} className="text-[#9b6dff]" />,
@@ -132,6 +137,9 @@ export function AiTab() {
       const minimax = await invoke<AiKeyStatus>("check_ai_key_status", {
         provider: "minimax",
       });
+      const atlascloud = await invoke<AiKeyStatus>("check_ai_key_status", {
+        provider: "atlascloud",
+      });
       const customOpenai = await invoke<AiKeyStatus>("check_ai_key_status", {
         provider: "custom-openai",
       });
@@ -141,6 +149,7 @@ export function AiTab() {
         anthropic,
         openrouter,
         minimax,
+        atlascloud,
         "custom-openai": customOpenai,
         ollama,
       });

--- a/src/contexts/SettingsContext.ts
+++ b/src/contexts/SettingsContext.ts
@@ -9,7 +9,8 @@ export type AiProvider =
   | "openrouter"
   | "ollama"
   | "custom-openai"
-  | "minimax";
+  | "minimax"
+  | "atlascloud";
 export type ERDiagramLayout = "LR" | "TB";
 
 export interface PluginConfig {

--- a/src/contexts/SettingsProvider.tsx
+++ b/src/contexts/SettingsProvider.tsx
@@ -5,6 +5,7 @@ import {
   SettingsContext,
   DEFAULT_SETTINGS,
   type Settings,
+  type AiProvider,
 } from "./SettingsContext";
 import { getFontCSS } from "../utils/settings";
 
@@ -181,29 +182,21 @@ export const SettingsProvider = ({ children }: { children: ReactNode }) => {
           (!finalSettings.aiProvider || !finalSettings.aiModel)
         ) {
           // First, detect which provider has an API key
-          let detectedProvider: string | null = null;
-          const hasOpenAI = await invoke<boolean>("check_ai_key", {
-            provider: "openai",
-          });
-          if (hasOpenAI) {
-            detectedProvider = "openai";
-          } else {
-            const hasAnthropic = await invoke<boolean>("check_ai_key", {
-              provider: "anthropic",
+          let detectedProvider: AiProvider | null = null;
+          const providers: AiProvider[] = [
+            "openai",
+            "anthropic",
+            "openrouter",
+            "minimax",
+            "atlascloud",
+          ];
+          for (const provider of providers) {
+            const hasKey = await invoke<boolean>("check_ai_key", {
+              provider,
             });
-            if (hasAnthropic) {
-              detectedProvider = "anthropic";
-            } else {
-              const hasOpenRouter = await invoke<boolean>("check_ai_key", {
-                provider: "openrouter",
-              });
-              if (hasOpenRouter) detectedProvider = "openrouter";
-            else {
-              const hasMiniMax = await invoke<boolean>("check_ai_key", {
-                provider: "minimax",
-              });
-              if (hasMiniMax) detectedProvider = "minimax";
-            }
+            if (hasKey) {
+              detectedProvider = provider;
+              break;
             }
           }
 
@@ -216,7 +209,7 @@ export const SettingsProvider = ({ children }: { children: ReactNode }) => {
 
             // Only set provider if not already set
             if (!finalSettings.aiProvider) {
-              finalSettings.aiProvider = detectedProvider as "openai" | "anthropic" | "openrouter" | "minimax";
+              finalSettings.aiProvider = detectedProvider;
             }
             // Only set model if not already set AND we have a model available
             if (!finalSettings.aiModel && firstModel) {

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -128,7 +128,13 @@ export function detectAIProviderFromKeys(
   keyStatus: Record<AiProvider, boolean>,
   availableModels: Record<string, string[]>,
 ): DetectedAIConfig {
-  const providers: AiProvider[] = ["openai", "anthropic", "openrouter", "minimax"];
+  const providers: AiProvider[] = [
+    "openai",
+    "anthropic",
+    "openrouter",
+    "minimax",
+    "atlascloud",
+  ];
 
   for (const provider of providers) {
     if (keyStatus[provider]) {

--- a/src/utils/settingsUI.ts
+++ b/src/utils/settingsUI.ts
@@ -39,6 +39,8 @@ export function getProviderLabel(id: AiProvider): string {
       return 'OpenAI Compatible';
     case 'minimax':
       return 'MiniMax';
+    case 'atlascloud':
+      return 'Atlas Cloud';
     default:
       return String(id).charAt(0).toUpperCase() + String(id).slice(1);
   }

--- a/tests/utils/settings.test.ts
+++ b/tests/utils/settings.test.ts
@@ -328,6 +328,24 @@ describe('settings', () => {
       expect(result.model).toBe('MiniMax-M3');
     });
 
+    it('should detect Atlas Cloud when higher-priority providers are unavailable', () => {
+      const keyStatus = {
+        openai: false,
+        anthropic: false,
+        openrouter: false,
+        minimax: false,
+        atlascloud: true,
+      } as Record<AiProvider, boolean>;
+      const models: Record<string, string[]> = {
+        atlascloud: ['deepseek-ai/deepseek-v4-pro'],
+      };
+
+      const result = detectAIProviderFromKeys(keyStatus, models);
+
+      expect(result.provider).toBe('atlascloud');
+      expect(result.model).toBe('deepseek-ai/deepseek-v4-pro');
+    });
+
     it('should return null when no keys available', () => {
       const keyStatus: Record<AiProvider, boolean> = {
         openai: false,

--- a/tests/utils/settingsUI.test.ts
+++ b/tests/utils/settingsUI.test.ts
@@ -56,6 +56,10 @@ describe('settingsUI', () => {
       expect(getProviderLabel('minimax' as AiProvider)).toBe('MiniMax');
     });
 
+    it('should return correct label for Atlas Cloud', () => {
+      expect(getProviderLabel('atlascloud' as AiProvider)).toBe('Atlas Cloud');
+    });
+
     it('should capitalize unknown providers', () => {
       expect(getProviderLabel('custom' as AiProvider)).toBe('Custom');
       expect(getProviderLabel('test' as AiProvider)).toBe('Test');


### PR DESCRIPTION
## Summary

- add Atlas Cloud as a first-class AI provider in settings and automatic key detection
- reuse the existing OpenAI-compatible model discovery and chat-completions transport with `https://api.atlascloud.ai/v1`
- support `ATLASCLOUD_API_KEY` and seed currently available text models
- add provider label, detection, default-model, and endpoint-path coverage

## Validation

- `pnpm typecheck`
- `pnpm build`
- `pnpm exec vitest run tests/utils/settings.test.ts tests/utils/settingsUI.test.ts` (83 passed)
- ESLint on the modified TypeScript source files (0 errors)
- `rustfmt --edition 2021 --check src/ai.rs`
- `git diff --check`
- YAML parse and default-model assertion
- Atlas Cloud public `/v1/models` probe (121 models; all three seeded models present)

The focused Rust tests could not finish compiling Tauri dependencies in this environment because the local disk ran out of space. No test assertion failed.

## Scope

No README, documentation, logo, sponsor, credits, or partner-promotion changes.