### PR TITLE
Database switcher palette (Ctrl/Cmd+K), capability-gated

### DIFF
--- a/src/components/layout/ExplorerSidebar.tsx
+++ b/src/components/layout/ExplorerSidebar.tsx
@@ -35,6 +35,7 @@ import {
   Clock,
   Clipboard,
   BookOpen,
+  ArrowLeftRight,
 } from "lucide-react";
 import { ask, open } from "@tauri-apps/plugin-dialog";
 import { toErrorMessage } from "../../utils/errors";
@@ -1211,6 +1212,19 @@ export const ExplorerSidebar = ({ sidebarWidth, startResize, onCollapse, sidebar
                       {t("sidebar.databases")} ({selectedDatabases.length})
                     </span>
                     <div className="flex items-center gap-1">
+                    <button
+                      onClick={() =>
+                        window.dispatchEvent(
+                          new CustomEvent("tabularis:open-database-switcher"),
+                        )
+                      }
+                      className="p-1 rounded text-muted hover:text-secondary hover:bg-surface-secondary transition-colors"
+                      title={t("databaseSwitcher.open", {
+                        defaultValue: "Switch database",
+                      })}
+                    >
+                      <ArrowLeftRight size={14} />
+                    </button>
                     <div className="relative">
                       <button
                         onClick={async () => {
@@ -1475,7 +1489,8 @@ export const ExplorerSidebar = ({ sidebarWidth, startResize, onCollapse, sidebar
                 <>
                   {/* MySQL/SQLite: Flat layout */}
                   {(() => {
-                    const dbLabel = isMultiDatabaseCapable(activeCapabilities) && selectedDatabases.length === 1
+                    const canSwitch = isMultiDatabaseCapable(activeCapabilities);
+                    const dbLabel = canSwitch && selectedDatabases.length === 1
                       ? selectedDatabases[0]
                       : activeDatabaseName;
                     return dbLabel ? (
@@ -1484,6 +1499,21 @@ export const ExplorerSidebar = ({ sidebarWidth, startResize, onCollapse, sidebar
                         <span className="text-sm font-medium text-secondary truncate">
                           {dbLabel}
                         </span>
+                        {canSwitch && (
+                          <button
+                            onClick={() =>
+                              window.dispatchEvent(
+                                new CustomEvent("tabularis:open-database-switcher"),
+                              )
+                            }
+                            className="ml-auto p-1 rounded text-muted hover:text-secondary hover:bg-surface-secondary transition-colors"
+                            title={t("databaseSwitcher.open", {
+                              defaultValue: "Switch database",
+                            })}
+                          >
+                            <ArrowLeftRight size={13} />
+                          </button>
+                        )}
                       </div>
                     ) : null;
                   })()}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -18,8 +18,10 @@ import { ExplorerSidebar, type SidebarTab } from "./ExplorerSidebar";
 import { PanelDatabaseProvider } from "./PanelDatabaseProvider";
 import { DiscordCommunityCallout } from "./sidebar/DiscordCommunityCallout";
 import { QuickNavigatorModal } from "../modals/QuickNavigatorModal";
+import { DatabaseSwitcherModal } from "../modals/DatabaseSwitcherModal";
 import { GenerateSQLModal } from "../modals/GenerateSQLModal";
 import { SchemaModal } from "../modals/SchemaModal";
+import { isMultiDatabaseCapable } from "../../utils/database";
 
 // Hooks & Utils
 import { useSidebarResize } from "../../hooks/useSidebarResize";
@@ -37,6 +39,7 @@ export const Sidebar = () => {
   const isDarkTheme = !currentTheme?.id?.includes("-light");
   const {
     activeConnectionId,
+    activeCapabilities,
     connections,
   } = useDatabase();
   const navigate = useNavigate();
@@ -46,6 +49,7 @@ export const Sidebar = () => {
   const [sidebarTab, setSidebarTab] = useState<SidebarTab>("structure");
   const [showShortcutHints, setShowShortcutHints] = useState(false);
   const [isQuickNavigatorOpen, setIsQuickNavigatorOpen] = useState(false);
+  const [isDatabaseSwitcherOpen, setIsDatabaseSwitcherOpen] = useState(false);
   const [generateSQLTable, setGenerateSQLTable] = useState<string | null>(null);
   const [inspectTable, setInspectTable] = useState<{ tableName: string; schema?: string } | null>(null);
   const { isMac } = useKeybindings();
@@ -65,6 +69,18 @@ export const Sidebar = () => {
     window.addEventListener("tabularis:open-quick-navigator", handler);
     return () => window.removeEventListener("tabularis:open-quick-navigator", handler);
   }, [activeConnectionId]);
+
+  // Database switcher: only meaningful for multi-database-capable drivers.
+  useEffect(() => {
+    const handler = () => {
+      if (activeConnectionId && isMultiDatabaseCapable(activeCapabilities)) {
+        setIsDatabaseSwitcherOpen((prev) => !prev);
+      }
+    };
+    window.addEventListener("tabularis:open-database-switcher", handler);
+    return () =>
+      window.removeEventListener("tabularis:open-database-switcher", handler);
+  }, [activeConnectionId, activeCapabilities]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -411,6 +427,12 @@ export const Sidebar = () => {
           onClose={() => setIsQuickNavigatorOpen(false)}
           onGenerateSql={(tableName) => setGenerateSQLTable(tableName)}
           onInspect={(tableName, schema) => setInspectTable({ tableName, schema })}
+        />
+      )}
+      {activeConnectionId && isDatabaseSwitcherOpen && (
+        <DatabaseSwitcherModal
+          isOpen={isDatabaseSwitcherOpen}
+          onClose={() => setIsDatabaseSwitcherOpen(false)}
         />
       )}
       {generateSQLTable && (

--- a/src/components/modals/DatabaseSwitcherModal.tsx
+++ b/src/components/modals/DatabaseSwitcherModal.tsx
@@ -1,0 +1,268 @@
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  AlertCircle,
+  Check,
+  Database,
+  Loader2,
+  RefreshCw,
+  Search,
+  X,
+} from "lucide-react";
+import { invoke } from "@tauri-apps/api/core";
+import { useDatabase } from "../../hooks/useDatabase";
+import { isMultiDatabaseCapable } from "../../utils/database";
+import { fuzzyFilter } from "../../utils/fuzzy";
+import { toErrorMessage } from "../../utils/errors";
+
+interface DatabaseSwitcherModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Quick database switcher (Ctrl/Cmd+K): lists every database on the server,
+ * filters as you type, and jumps to the picked one — adding it to the
+ * sidebar selection when it is not part of it yet.
+ *
+ * Only rendered for multi-database-capable drivers (see
+ * `isMultiDatabaseCapable`); schema-based, single-database and file-based
+ * drivers have nothing to switch.
+ */
+export const DatabaseSwitcherModal = ({
+  isOpen,
+  onClose,
+}: DatabaseSwitcherModalProps) => {
+  const { t } = useTranslation();
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const {
+    activeConnectionId,
+    activeCapabilities,
+    activeSchema,
+    selectedDatabases,
+    setSelectedDatabases,
+    setActiveTable,
+  } = useDatabase();
+
+  const [search, setSearch] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [allDatabases, setAllDatabases] = useState<string[] | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const loadDatabases = useCallback(async () => {
+    if (!activeConnectionId) return;
+    setIsLoading(true);
+    setLoadError(null);
+    try {
+      const all = await invoke<string[]>("get_available_databases", {
+        connectionId: activeConnectionId,
+      });
+      setAllDatabases([...all].sort((a, b) => a.localeCompare(b)));
+    } catch (err) {
+      setLoadError(toErrorMessage(err));
+      setAllDatabases(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [activeConnectionId]);
+
+  const canSwitch = isMultiDatabaseCapable(activeCapabilities);
+
+  useEffect(() => {
+    if (!isOpen || !canSwitch) return;
+    setSearch("");
+    setSelectedIndex(0);
+    void loadDatabases();
+  }, [isOpen, canSwitch, loadDatabases]);
+
+  const filteredDatabases = useMemo(
+    () => fuzzyFilter(allDatabases ?? [], search, (name) => name),
+    [allDatabases, search],
+  );
+
+  // Scroll the highlighted row into view while navigating with the keyboard.
+  useEffect(() => {
+    const activeEl = listRef.current?.querySelector('[data-active="true"]');
+    activeEl?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  const handleSelect = useCallback(
+    (database: string) => {
+      onClose();
+      if (!selectedDatabases.includes(database)) {
+        setSelectedDatabases([...selectedDatabases, database]);
+      }
+      // Makes it the active database: the sidebar auto-expands its node.
+      setActiveTable(null, database);
+    },
+    [onClose, selectedDatabases, setSelectedDatabases, setActiveTable],
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelectedIndex((prev) =>
+          filteredDatabases.length > 0
+            ? (prev + 1) % filteredDatabases.length
+            : 0,
+        );
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelectedIndex((prev) =>
+          filteredDatabases.length > 0
+            ? (prev - 1 + filteredDatabases.length) % filteredDatabases.length
+            : 0,
+        );
+        return;
+      }
+      if (e.key === "Enter") {
+        e.preventDefault();
+        const database = filteredDatabases[selectedIndex];
+        if (database) handleSelect(database);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [isOpen, filteredDatabases, selectedIndex, handleSelect, onClose]);
+
+  if (!isOpen || !canSwitch) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-start justify-center z-[100] backdrop-blur-sm pt-[15vh]"
+      onClick={onClose}
+    >
+      <div
+        className="bg-elevated border border-strong rounded-xl shadow-2xl w-[480px] max-h-[60vh] overflow-hidden flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Search header */}
+        <div className="flex items-center gap-3 px-4 py-3.5 border-b border-default bg-base">
+          <Search size={18} className="text-secondary shrink-0" />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              setSelectedIndex(0);
+            }}
+            className="flex-1 bg-transparent text-primary placeholder-muted outline-none text-sm"
+            placeholder={t("databaseSwitcher.placeholder", {
+              defaultValue: "Search databases...",
+            })}
+            autoFocus
+          />
+          <button
+            onClick={onClose}
+            className="text-secondary hover:text-primary transition-colors"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* List */}
+        <div ref={listRef} className="overflow-y-auto flex-1 flex flex-col py-1">
+          {isLoading ? (
+            <div className="px-4 py-8 flex items-center justify-center gap-2 text-muted text-sm">
+              <Loader2 size={14} className="animate-spin" />
+              {t("databaseSwitcher.loading", {
+                defaultValue: "Loading databases...",
+              })}
+            </div>
+          ) : loadError ? (
+            <div className="px-4 py-6 flex flex-col items-center gap-3 text-center">
+              <p className="text-xs text-red-400 flex items-start gap-1.5 max-w-full">
+                <AlertCircle size={13} className="shrink-0 mt-0.5" />
+                <span className="break-words min-w-0">{loadError}</span>
+              </p>
+              <button
+                type="button"
+                onClick={() => void loadDatabases()}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-strong bg-base text-xs font-medium text-secondary hover:text-primary hover:bg-surface-secondary transition-colors"
+              >
+                <RefreshCw size={12} />
+                {t("sidebar.retry")}
+              </button>
+            </div>
+          ) : filteredDatabases.length === 0 ? (
+            <div className="px-4 py-8 text-center text-muted text-sm">
+              {search
+                ? t("databaseSwitcher.noResults", {
+                    query: search,
+                    defaultValue: 'No databases match "{{query}}"',
+                  })
+                : t("databaseSwitcher.empty", {
+                    defaultValue: "No databases found",
+                  })}
+            </div>
+          ) : (
+            filteredDatabases.map((database, idx) => {
+              const isActive = idx === selectedIndex;
+              const isCurrent = database === activeSchema;
+              const isSelected = selectedDatabases.includes(database);
+              return (
+                <div
+                  key={database}
+                  onClick={() => handleSelect(database)}
+                  data-active={isActive}
+                  className={`flex items-center justify-between gap-3 px-4 py-2.5 cursor-pointer transition-colors ${
+                    isActive
+                      ? "bg-surface-secondary text-primary"
+                      : "text-secondary hover:bg-surface-secondary hover:text-primary"
+                  }`}
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    <Database size={14} className="text-blue-400 shrink-0" />
+                    <span className="text-sm font-medium truncate">
+                      {database}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    {isCurrent ? (
+                      <span className="text-[10px] uppercase font-bold text-blue-400 border border-blue-500/40 px-1.5 py-0.5 rounded tracking-wider select-none">
+                        {t("databaseSwitcher.current", {
+                          defaultValue: "Current",
+                        })}
+                      </span>
+                    ) : (
+                      isSelected && (
+                        <Check size={13} className="text-green-400" />
+                      )
+                    )}
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        {/* Footer hints */}
+        <div className="px-4 py-2 border-t border-default bg-base/50 flex justify-between text-[11px] text-muted select-none">
+          <span>
+            {t("databaseSwitcher.count", {
+              count: filteredDatabases.length,
+              defaultValue: "{{count}} databases",
+            })}
+          </span>
+          <div className="flex gap-4">
+            <span>{t("editor.quickNavigator.navigationHint")}</span>
+            <span>{t("editor.quickNavigator.escHint")}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/config/shortcuts.json
+++ b/src/config/shortcuts.json
@@ -210,6 +210,16 @@
     "overridable": true
   },
   {
+    "id": "database_switcher",
+    "category": "navigation",
+    "defaultMac": "⌘+K",
+    "defaultWin": "Ctrl+K",
+    "macMatch": { "metaKey": true, "key": "k" },
+    "winMatch": { "ctrlKey": true, "key": "k" },
+    "i18nKey": "settings.shortcuts.databaseSwitcher",
+    "overridable": true
+  },
+  {
     "id": "trigger_suggestions",
     "category": "editor",
     "defaultMac": "⌘+I",

--- a/src/hooks/useGlobalShortcuts.ts
+++ b/src/hooks/useGlobalShortcuts.ts
@@ -58,6 +58,12 @@ export function useGlobalShortcuts() {
 				return;
 			}
 
+			if (matchesShortcut(e, "database_switcher")) {
+				e.preventDefault();
+				window.dispatchEvent(new CustomEvent("tabularis:open-database-switcher"));
+				return;
+			}
+
 			if (matchesShortcut(e, "open_connections")) {
 				e.preventDefault();
 				navigate("/connections");

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -711,7 +711,8 @@
       "quickNavigator": "Schnellnavigation",
       "triggerSuggestions": "Vorschläge anzeigen",
       "formatSql": "SQL formatieren",
-      "refreshTable": "Tabelle aktualisieren"
+      "refreshTable": "Tabelle aktualisieren",
+      "databaseSwitcher": "Datenbank-Umschalter öffnen"
     },
     "aiActivity": "KI-Aktivität",
     "backup": {
@@ -2030,5 +2031,15 @@
     },
     "title": "Protokoll des Verbindungstests",
     "showLog": "Protokoll anzeigen"
+  },
+  "databaseSwitcher": {
+    "open": "Datenbank wechseln",
+    "placeholder": "Datenbanken durchsuchen...",
+    "loading": "Datenbanken werden geladen...",
+    "empty": "Keine Datenbanken gefunden",
+    "noResults": "Keine Datenbank entspricht \"{{query}}\"",
+    "current": "Aktuell",
+    "count_one": "{{count}} Datenbank",
+    "count_other": "{{count}} Datenbanken"
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -754,7 +754,8 @@
       "quickNavigator": "Quick Navigator",
       "triggerSuggestions": "Trigger suggestions",
       "formatSql": "Format SQL",
-      "refreshTable": "Refresh table"
+      "refreshTable": "Refresh table",
+      "databaseSwitcher": "Open database switcher"
     },
     "aiActivity": "AI Activity",
     "backup": {
@@ -2119,5 +2120,15 @@
     },
     "title": "Connection test log",
     "showLog": "Show log"
+  },
+  "databaseSwitcher": {
+    "open": "Switch database",
+    "placeholder": "Search databases...",
+    "loading": "Loading databases...",
+    "empty": "No databases found",
+    "noResults": "No databases match \"{{query}}\"",
+    "current": "Current",
+    "count_one": "{{count}} database",
+    "count_other": "{{count}} databases"
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -736,7 +736,8 @@
       "quickNavigator": "Navegador rápido",
       "triggerSuggestions": "Mostrar sugerencias",
       "formatSql": "Formatear SQL",
-      "refreshTable": "Actualizar tabla"
+      "refreshTable": "Actualizar tabla",
+      "databaseSwitcher": "Abrir el selector de bases de datos"
     },
     "aiActivity": "Actividad IA",
     "backup": {
@@ -1952,5 +1953,15 @@
     },
     "title": "Registro de la prueba de conexión",
     "showLog": "Mostrar registro"
+  },
+  "databaseSwitcher": {
+    "open": "Cambiar base de datos",
+    "placeholder": "Buscar bases de datos...",
+    "loading": "Cargando bases de datos...",
+    "empty": "No se encontraron bases de datos",
+    "noResults": "Ninguna base de datos coincide con \"{{query}}\"",
+    "current": "Actual",
+    "count_one": "{{count}} base de datos",
+    "count_other": "{{count}} bases de datos"
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -745,7 +745,8 @@
       "quickNavigator": "Navigateur rapide",
       "triggerSuggestions": "Afficher les suggestions",
       "formatSql": "Formater SQL",
-      "refreshTable": "Actualiser la table"
+      "refreshTable": "Actualiser la table",
+      "databaseSwitcher": "Ouvrir le sélecteur de bases de données"
     },
     "aiActivity": "Activité IA",
     "backup": {
@@ -2108,5 +2109,15 @@
     },
     "title": "Journal du test de connexion",
     "showLog": "Afficher le journal"
+  },
+  "databaseSwitcher": {
+    "open": "Changer de base de données",
+    "placeholder": "Rechercher des bases de données...",
+    "loading": "Chargement des bases de données...",
+    "empty": "Aucune base de données trouvée",
+    "noResults": "Aucune base de données ne correspond à « {{query}} »",
+    "current": "Actuelle",
+    "count_one": "{{count}} base de données",
+    "count_other": "{{count}} bases de données"
   }
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -736,7 +736,8 @@
       "quickNavigator": "Navigatore rapido",
       "triggerSuggestions": "Mostra suggerimenti",
       "formatSql": "Formatta SQL",
-      "refreshTable": "Aggiorna tabella"
+      "refreshTable": "Aggiorna tabella",
+      "databaseSwitcher": "Apri il selettore di database"
     },
     "aiActivity": "Attività AI",
     "backup": {
@@ -2032,5 +2033,15 @@
     },
     "title": "Log del test di connessione",
     "showLog": "Mostra log"
+  },
+  "databaseSwitcher": {
+    "open": "Cambia database",
+    "placeholder": "Cerca database...",
+    "loading": "Caricamento database...",
+    "empty": "Nessun database trovato",
+    "noResults": "Nessun database corrisponde a \"{{query}}\"",
+    "current": "Attuale",
+    "count_one": "{{count}} database",
+    "count_other": "{{count}} database"
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -725,7 +725,8 @@
       "quickNavigator": "クイックナビゲーター",
       "triggerSuggestions": "候補を表示",
       "formatSql": "SQLをフォーマット",
-      "refreshTable": "テーブルを更新"
+      "refreshTable": "テーブルを更新",
+      "databaseSwitcher": "データベース切り替えを開く"
     },
     "aiActivity": "AI アクティビティ",
     "backup": {
@@ -2048,5 +2049,15 @@
     },
     "title": "接続テストのログ",
     "showLog": "ログを表示"
+  },
+  "databaseSwitcher": {
+    "open": "データベースを切り替え",
+    "placeholder": "データベースを検索...",
+    "loading": "データベースを読み込み中...",
+    "empty": "データベースが見つかりません",
+    "noResults": "「{{query}}」に一致するデータベースはありません",
+    "current": "現在",
+    "count_one": "{{count}} 件のデータベース",
+    "count_other": "{{count}} 件のデータベース"
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -709,7 +709,8 @@
       "categories_notebook": "노트북",
       "pasteImportClipboard": "클립보드에서 가져오기",
       "quickNavigator": "빠른 탐색기",
-      "formatSql": "SQL 포맷"
+      "formatSql": "SQL 포맷",
+      "databaseSwitcher": "데이터베이스 전환기 열기"
     },
     "aiActivity": "AI 활동",
     "backup": {
@@ -2016,5 +2017,15 @@
     },
     "title": "연결 테스트 로그",
     "showLog": "로그 보기"
+  },
+  "databaseSwitcher": {
+    "open": "데이터베이스 전환",
+    "placeholder": "데이터베이스 검색...",
+    "loading": "데이터베이스 불러오는 중...",
+    "empty": "데이터베이스를 찾을 수 없습니다",
+    "noResults": "\"{{query}}\"와 일치하는 데이터베이스가 없습니다",
+    "current": "현재",
+    "count_one": "데이터베이스 {{count}}개",
+    "count_other": "데이터베이스 {{count}}개"
   }
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -747,7 +747,8 @@
       "quickNavigator": "Navegador Rápido",
       "triggerSuggestions": "Acionar sugestões",
       "formatSql": "Formatar SQL",
-      "refreshTable": "Atualizar tabela"
+      "refreshTable": "Atualizar tabela",
+      "databaseSwitcher": "Abrir o seletor de bancos de dados"
     },
     "aiActivity": "Atividade de IA",
     "backup": {
@@ -2105,5 +2106,15 @@
     },
     "title": "Log do teste de conexão",
     "showLog": "Mostrar log"
+  },
+  "databaseSwitcher": {
+    "open": "Trocar banco de dados",
+    "placeholder": "Pesquisar bancos de dados...",
+    "loading": "Carregando bancos de dados...",
+    "empty": "Nenhum banco de dados encontrado",
+    "noResults": "Nenhum banco de dados corresponde a \"{{query}}\"",
+    "current": "Atual",
+    "count_one": "{{count}} banco de dados",
+    "count_other": "{{count}} bancos de dados"
   }
 }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -704,7 +704,8 @@
       "quickNavigator": "Быстрый навигатор",
       "triggerSuggestions": "Показать подсказки",
       "formatSql": "Форматировать SQL",
-      "refreshTable": "Обновить таблицу"
+      "refreshTable": "Обновить таблицу",
+      "databaseSwitcher": "Открыть переключатель баз данных"
     },
     "aiActivity": "Активность AI",
     "backup": {
@@ -2060,5 +2061,15 @@
     },
     "title": "Журнал теста подключения",
     "showLog": "Показать журнал"
+  },
+  "databaseSwitcher": {
+    "open": "Сменить базу данных",
+    "placeholder": "Поиск баз данных...",
+    "loading": "Загрузка баз данных...",
+    "empty": "Базы данных не найдены",
+    "noResults": "Нет баз данных, соответствующих «{{query}}»",
+    "current": "Текущая",
+    "count_one": "{{count}} база данных",
+    "count_other": "{{count}} баз данных"
   }
 }

--- a/src/i18n/locales/tl.json
+++ b/src/i18n/locales/tl.json
@@ -741,7 +741,8 @@
       "categories_notebook": "Notebook",
       "pasteImportClipboard": "I-import mula sa Clipboard",
       "quickNavigator": "Quick Navigator",
-      "formatSql": "I-format ang SQL"
+      "formatSql": "I-format ang SQL",
+      "databaseSwitcher": "Buksan ang database switcher"
     },
     "aiActivity": "AI Activity",
     "backup": {
@@ -2059,5 +2060,15 @@
     },
     "title": "Log ng pagsubok ng koneksyon",
     "showLog": "Ipakita ang log"
+  },
+  "databaseSwitcher": {
+    "open": "Magpalit ng database",
+    "placeholder": "Maghanap ng mga database...",
+    "loading": "Nilo-load ang mga database...",
+    "empty": "Walang natagpuang database",
+    "noResults": "Walang database na tumutugma sa \"{{query}}\"",
+    "current": "Kasalukuyan",
+    "count_one": "{{count}} database",
+    "count_other": "{{count}} database"
   }
 }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -676,7 +676,8 @@
       "quickNavigator": "快速导航",
       "triggerSuggestions": "触发建议",
       "formatSql": "格式化 SQL",
-      "refreshTable": "刷新表格"
+      "refreshTable": "刷新表格",
+      "databaseSwitcher": "打开数据库切换器"
     },
     "aiActivity": "AI 活动",
     "backup": {
@@ -1970,5 +1971,15 @@
     },
     "title": "连接测试日志",
     "showLog": "显示日志"
+  },
+  "databaseSwitcher": {
+    "open": "切换数据库",
+    "placeholder": "搜索数据库...",
+    "loading": "正在加载数据库...",
+    "empty": "未找到数据库",
+    "noResults": "没有与“{{query}}”匹配的数据库",
+    "current": "当前",
+    "count_one": "{{count}} 个数据库",
+    "count_other": "{{count}} 个数据库"
   }
 }

--- a/tests/components/modals/DatabaseSwitcherModal.test.tsx
+++ b/tests/components/modals/DatabaseSwitcherModal.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { invoke } from "@tauri-apps/api/core";
+import { DatabaseSwitcherModal } from "../../../src/components/modals/DatabaseSwitcherModal";
+import type { DriverCapabilities } from "../../../src/types/plugins";
+
+const dbMocks = vi.hoisted(() => ({
+  setSelectedDatabases: vi.fn(),
+  setActiveTable: vi.fn(),
+  state: {
+    capabilities: null as DriverCapabilities | null,
+    selectedDatabases: [] as string[],
+    activeSchema: null as string | null,
+  },
+}));
+
+vi.mock("../../../src/hooks/useDatabase", () => ({
+  useDatabase: () => ({
+    activeConnectionId: "conn-1",
+    activeCapabilities: dbMocks.state.capabilities,
+    activeSchema: dbMocks.state.activeSchema,
+    selectedDatabases: dbMocks.state.selectedDatabases,
+    setSelectedDatabases: dbMocks.setSelectedDatabases,
+    setActiveTable: dbMocks.setActiveTable,
+  }),
+}));
+
+const multiDbCapabilities: DriverCapabilities = {
+  schemas: false,
+  views: true,
+  routines: true,
+  file_based: false,
+  folder_based: false,
+  identifier_quote: "`",
+  alter_primary_key: true,
+};
+
+describe("DatabaseSwitcherModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMocks.state.capabilities = multiDbCapabilities;
+    dbMocks.state.selectedDatabases = ["shop"];
+    dbMocks.state.activeSchema = "shop";
+    vi.mocked(invoke).mockResolvedValue(["shop", "analytics", "archive"]);
+  });
+
+  it("renders nothing for non multi-database drivers", () => {
+    dbMocks.state.capabilities = {
+      ...multiDbCapabilities,
+      single_database: true,
+    };
+    const { container } = render(
+      <DatabaseSwitcherModal isOpen={true} onClose={() => {}} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+    expect(invoke).not.toHaveBeenCalledWith(
+      "get_available_databases",
+      expect.anything(),
+    );
+  });
+
+  it("loads and lists databases sorted, marking the current one", async () => {
+    render(<DatabaseSwitcherModal isOpen={true} onClose={() => {}} />);
+    expect(invoke).toHaveBeenCalledWith("get_available_databases", {
+      connectionId: "conn-1",
+    });
+    await waitFor(() => {
+      expect(screen.getByText("analytics")).toBeInTheDocument();
+    });
+    const names = screen
+      .getAllByText(/^(shop|analytics|archive)$/)
+      .map((el) => el.textContent);
+    expect(names).toEqual(["analytics", "archive", "shop"]);
+    expect(screen.getByText("databaseSwitcher.current")).toBeInTheDocument();
+  });
+
+  it("filters databases as the user types", async () => {
+    render(<DatabaseSwitcherModal isOpen={true} onClose={() => {}} />);
+    await waitFor(() => {
+      expect(screen.getByText("analytics")).toBeInTheDocument();
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText("databaseSwitcher.placeholder"),
+      { target: { value: "arch" } },
+    );
+    expect(screen.getByText("archive")).toBeInTheDocument();
+    expect(screen.queryByText("analytics")).not.toBeInTheDocument();
+  });
+
+  it("adds an unselected database to the selection and focuses it", async () => {
+    const onClose = vi.fn();
+    render(<DatabaseSwitcherModal isOpen={true} onClose={onClose} />);
+    await waitFor(() => {
+      expect(screen.getByText("analytics")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("analytics"));
+    expect(dbMocks.setSelectedDatabases).toHaveBeenCalledWith([
+      "shop",
+      "analytics",
+    ]);
+    expect(dbMocks.setActiveTable).toHaveBeenCalledWith(null, "analytics");
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("focuses an already selected database without re-adding it", async () => {
+    dbMocks.state.selectedDatabases = ["shop", "analytics"];
+    render(<DatabaseSwitcherModal isOpen={true} onClose={() => {}} />);
+    await waitFor(() => {
+      expect(screen.getByText("analytics")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("analytics"));
+    expect(dbMocks.setSelectedDatabases).not.toHaveBeenCalled();
+    expect(dbMocks.setActiveTable).toHaveBeenCalledWith(null, "analytics");
+  });
+
+  it("shows the error state with a retry that refetches", async () => {
+    vi.mocked(invoke).mockRejectedValueOnce("Access denied for user 'x'");
+    render(<DatabaseSwitcherModal isOpen={true} onClose={() => {}} />);
+    await waitFor(() => {
+      expect(
+        screen.getByText("Access denied for user 'x'"),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("sidebar.retry"));
+    await waitFor(() => {
+      expect(screen.getByText("analytics")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Post-connect **database switcher** in the style of the existing Quick Navigator (`Ctrl/Cmd+P`), addressing the "database selection UX" gap: switching/adding a database no longer requires reopening the connection modal.

> Stacked on #570 (its tests rely on lucide mock entries added there). Retarget to `main` once #570 merges.

- **`Ctrl/Cmd+K`** (new rebindable `database_switcher` shortcut) opens a palette listing every database on the server (`get_available_databases`): fuzzy search, arrow-key navigation, Enter/click to switch.
- Distinct states: loading spinner, error with **Retry**, empty list, and no-match-for-query.
- Picking a database **adds it to the sidebar selection** if missing and makes it active — the sidebar auto-expands its node via the existing `activeSchema` mechanism. Current database is badged, selected ones get a check.
- **Capabilities respected end-to-end** via `isMultiDatabaseCapable`: for single-database, file/folder-based or schema-based drivers the shortcut is inert, no button is shown, and no backend call is made. No per-driver conditionals (`.rules/frontend.md`).
- Sidebar affordances: switch button in the multi-database header next to "Manage databases", and one in the single-database layout, which previously offered no way to change database at all.
- i18n keys translated in all 11 locales (including the shortcut label in Settings).

## Test plan
- `pnpm vitest run tests/components/modals/DatabaseSwitcherModal.test.tsx` — 6 tests: capability gating (no render, no fetch), sorted listing with current badge, fuzzy filtering, add+focus vs focus-only selection, error state with working retry.
- Full suite green (3418 tests), tsc + eslint clean.
- Manual: MySQL multi-db (add db via Ctrl+K, verify sidebar expansion), Postgres (shortcut inert), SQLite (inert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)