### PR TITLE
Register DynamoDB plugin

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -380,7 +380,7 @@
       "id": "dynamodb",
       "name": "DynamoDB",
       "description": "Tabularis driver plugin for AWS DynamoDB",
-      "author": "erwin-lovecraft <https://github.com/erwin-lovecraft>",
+      "author": "fuleinist <https://github.com/fuleinist>",
       "homepage": "https://github.com/TabularisDB/tabularis-dynamodb-plugin",
       "latest_version": "0.1.1",
       "releases": [

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -375,6 +375,36 @@
           }
         }
       ]
+    },
+    {
+      "id": "dynamodb",
+      "name": "DynamoDB",
+      "description": "Tabularis driver plugin for AWS DynamoDB",
+      "author": "erwin-lovecraft <https://github.com/erwin-lovecraft>",
+      "homepage": "https://github.com/TabularisDB/tabularis-dynamodb-plugin",
+      "latest_version": "0.1.1",
+      "releases": [
+        {
+          "version": "0.1.0",
+          "min_tabularis_version": "0.15.0",
+          "assets": {
+            "linux-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.0/dynamodb-plugin-linux-x64.zip",
+            "darwin-arm64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.0/dynamodb-plugin-darwin-arm64.zip",
+            "win-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.0/dynamodb-plugin-win-x64.zip"
+          }
+        },
+        {
+          "version": "0.1.1",
+          "min_tabularis_version": "0.15.0",
+          "assets": {
+            "linux-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.1/dynamodb-plugin-linux-x64.zip",
+            "linux-arm64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.1/dynamodb-plugin-linux-arm64.zip",
+            "darwin-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.1/dynamodb-plugin-darwin-x64.zip",
+            "darwin-arm64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.1/dynamodb-plugin-darwin-arm64.zip",
+            "win-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.1/dynamodb-plugin-win-x64.zip"
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## What

Register `tabularis-dynamodb-plugin` (https://github.com/TabularisDB/tabularis-dynamodb-plugin) in the official plugin registry.

## Details

- **ID:** `dynamodb`
- **Name:** DynamoDB
- **Description:** Tabularis driver plugin for AWS DynamoDB
- **Author:** erwin-lovecraft
- **Homepage:** https://github.com/TabularisDB/tabularis-dynamodb-plugin
- **Latest version:** 0.1.1

Registered releases:
- `v0.1.0` — linux-x64, darwin-arm64, win-x64
- `v0.1.1` — linux-x64, linux-arm64, darwin-x64, darwin-arm64, win-x64

`min_tabularis_version`: `0.15.0` (matches the most recent plugin registrations such as elasticsearch)

## Verification

- JSON validates
- Asset URLs follow the `https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v<ver>/dynamodb-plugin-<platform>.zip` pattern and match the actual release assets on the upstream repo