### PR TITLE
fix: expand SQLite home paths

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2270,7 +2270,11 @@ pub async fn test_connection<R: Runtime>(
 
     // For file-based drivers, verify the database file exists before attempting connection
     if drv.manifest().capabilities.file_based {
-        let db_path = std::path::Path::new(resolved_params.database.primary());
+        let db_path = if resolved_params.driver == "sqlite" {
+            crate::sqlite_database::expand_sqlite_filename(resolved_params.database.primary())
+        } else {
+            PathBuf::from(resolved_params.database.primary())
+        };
         if !db_path.exists() {
             return Err(format!(
                 "Database file not found: {}",

--- a/src-tauri/src/pool_manager.rs
+++ b/src-tauri/src/pool_manager.rs
@@ -14,6 +14,7 @@ use rustls_platform_verifier::BuilderVerifierExt;
 use sha2::{Digest, Sha256};
 use sqlx::{sqlite::SqliteConnectOptions, ConnectOptions, Connection, Executor, MySql, Pool, Sqlite};
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
@@ -646,7 +647,27 @@ impl ServerCertVerifier for VerifyCaCertVerifier {
 }
 
 fn build_sqlite_connectoptions(params: &ConnectionParams) -> SqliteConnectOptions {
-    SqliteConnectOptions::new().filename(params.database.to_string())
+    SqliteConnectOptions::new().filename(expand_sqlite_filename(params.database.primary()))
+}
+
+fn expand_sqlite_filename(value: &str) -> PathBuf {
+    let home = directories::BaseDirs::new().map(|dirs| dirs.home_dir().to_path_buf());
+    expand_sqlite_filename_with_home(value, home.as_deref())
+}
+
+fn expand_sqlite_filename_with_home(value: &str, home: Option<&Path>) -> PathBuf {
+    let home_relative = if value == "~" {
+        Some("")
+    } else {
+        value
+            .strip_prefix("~/")
+            .or_else(|| value.strip_prefix("~\\"))
+    };
+
+    match (home_relative, home) {
+        (Some(relative), Some(home)) => home.join(relative),
+        _ => PathBuf::from(value),
+    }
 }
 
 /// Return the connection's startup script if it is set and not blank.
@@ -1112,5 +1133,37 @@ pub async fn close_all_pools() {
         for (_, pool) in pools.drain() {
             pool.close().await;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expands_sqlite_home_prefixes() {
+        let home = PathBuf::from("/home/dev");
+
+        assert_eq!(
+            expand_sqlite_filename_with_home("~/db.sqlite", Some(&home)),
+            home.join("db.sqlite")
+        );
+        assert_eq!(
+            expand_sqlite_filename_with_home("~\\db.sqlite", Some(&home)),
+            home.join("db.sqlite")
+        );
+        assert_eq!(expand_sqlite_filename_with_home("~", Some(&home)), home);
+    }
+
+    #[test]
+    fn leaves_non_home_sqlite_paths_unchanged() {
+        assert_eq!(
+            expand_sqlite_filename_with_home("relative/db.sqlite", None),
+            PathBuf::from("relative/db.sqlite")
+        );
+        assert_eq!(
+            expand_sqlite_filename_with_home("~user/db.sqlite", Some(Path::new("/home/dev"))),
+            PathBuf::from("~user/db.sqlite")
+        );
     }
 }

--- a/src-tauri/src/pool_manager.rs
+++ b/src-tauri/src/pool_manager.rs
@@ -1,4 +1,5 @@
 use crate::models::ConnectionParams;
+use crate::sqlite_database::expand_sqlite_filename;
 use deadpool_postgres::{Hook as PgHook, HookError as PgHookError, Manager as PgPoolManager, Pool as PgPool};
 use once_cell::sync::Lazy;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
@@ -14,7 +15,6 @@ use rustls_platform_verifier::BuilderVerifierExt;
 use sha2::{Digest, Sha256};
 use sqlx::{sqlite::SqliteConnectOptions, ConnectOptions, Connection, Executor, MySql, Pool, Sqlite};
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
@@ -650,26 +650,6 @@ fn build_sqlite_connectoptions(params: &ConnectionParams) -> SqliteConnectOption
     SqliteConnectOptions::new().filename(expand_sqlite_filename(params.database.primary()))
 }
 
-fn expand_sqlite_filename(value: &str) -> PathBuf {
-    let home = directories::BaseDirs::new().map(|dirs| dirs.home_dir().to_path_buf());
-    expand_sqlite_filename_with_home(value, home.as_deref())
-}
-
-fn expand_sqlite_filename_with_home(value: &str, home: Option<&Path>) -> PathBuf {
-    let home_relative = if value == "~" {
-        Some("")
-    } else {
-        value
-            .strip_prefix("~/")
-            .or_else(|| value.strip_prefix("~\\"))
-    };
-
-    match (home_relative, home) {
-        (Some(relative), Some(home)) => home.join(relative),
-        _ => PathBuf::from(value),
-    }
-}
-
 /// Return the connection's startup script if it is set and not blank.
 /// Whitespace-only scripts are treated as absent so the per-connection
 /// hook is skipped entirely rather than issuing an empty query.
@@ -1133,37 +1113,5 @@ pub async fn close_all_pools() {
         for (_, pool) in pools.drain() {
             pool.close().await;
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn expands_sqlite_home_prefixes() {
-        let home = PathBuf::from("/home/dev");
-
-        assert_eq!(
-            expand_sqlite_filename_with_home("~/db.sqlite", Some(&home)),
-            home.join("db.sqlite")
-        );
-        assert_eq!(
-            expand_sqlite_filename_with_home("~\\db.sqlite", Some(&home)),
-            home.join("db.sqlite")
-        );
-        assert_eq!(expand_sqlite_filename_with_home("~", Some(&home)), home);
-    }
-
-    #[test]
-    fn leaves_non_home_sqlite_paths_unchanged() {
-        assert_eq!(
-            expand_sqlite_filename_with_home("relative/db.sqlite", None),
-            PathBuf::from("relative/db.sqlite")
-        );
-        assert_eq!(
-            expand_sqlite_filename_with_home("~user/db.sqlite", Some(Path::new("/home/dev"))),
-            PathBuf::from("~user/db.sqlite")
-        );
     }
 }

--- a/src-tauri/src/pool_manager_tests.rs
+++ b/src-tauri/src/pool_manager_tests.rs
@@ -951,6 +951,42 @@ mod postgres_tls_connector_tests {
 }
 
 #[cfg(test)]
+mod sqlite_path_tests {
+    use crate::sqlite_database::expand_sqlite_filename_with_home;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn expands_sqlite_home_prefixes() {
+        let home = PathBuf::from("/home/dev");
+
+        assert_eq!(
+            expand_sqlite_filename_with_home("~/db.sqlite", Some(&home)),
+            home.join("db.sqlite")
+        );
+        assert_eq!(
+            expand_sqlite_filename_with_home("~\\db.sqlite", Some(&home)),
+            home.join("db.sqlite")
+        );
+    }
+
+    #[test]
+    fn leaves_non_home_sqlite_paths_unchanged() {
+        assert_eq!(
+            expand_sqlite_filename_with_home("relative/db.sqlite", None),
+            PathBuf::from("relative/db.sqlite")
+        );
+        assert_eq!(
+            expand_sqlite_filename_with_home("~", Some(Path::new("/home/dev"))),
+            PathBuf::from("~")
+        );
+        assert_eq!(
+            expand_sqlite_filename_with_home("~user/db.sqlite", Some(Path::new("/home/dev"))),
+            PathBuf::from("~user/db.sqlite")
+        );
+    }
+}
+
+#[cfg(test)]
 mod startup_script_tests {
     use crate::models::{ConnectionParams, DatabaseSelection};
     use crate::pool_manager::{close_pool_with_id, get_sqlite_pool_with_id};

--- a/src-tauri/src/sqlite_database.rs
+++ b/src-tauri/src/sqlite_database.rs
@@ -13,7 +13,7 @@ pub(crate) fn normalize_sqlite_path(raw_path: &str) -> Result<PathBuf, String> {
         return Err("Choose a file name for the SQLite database.".to_string());
     }
 
-    let mut path = PathBuf::from(trimmed);
+    let mut path = expand_sqlite_filename(trimmed);
     if path.file_name().is_none() {
         return Err("Choose a valid SQLite database file name.".to_string());
     }
@@ -34,6 +34,22 @@ pub(crate) fn normalize_sqlite_path(raw_path: &str) -> Result<PathBuf, String> {
     }
 
     Ok(path)
+}
+
+pub(crate) fn expand_sqlite_filename(value: &str) -> PathBuf {
+    let home = directories::BaseDirs::new().map(|dirs| dirs.home_dir().to_path_buf());
+    expand_sqlite_filename_with_home(value, home.as_deref())
+}
+
+pub(crate) fn expand_sqlite_filename_with_home(value: &str, home: Option<&Path>) -> PathBuf {
+    let home_relative = value
+        .strip_prefix("~/")
+        .or_else(|| value.strip_prefix("~\\"));
+
+    match (home_relative, home) {
+        (Some(relative), Some(home)) => home.join(relative),
+        _ => PathBuf::from(value),
+    }
 }
 
 fn connection_name(path: &Path) -> Result<String, String> {

--- a/src-tauri/src/sqlite_database_tests.rs
+++ b/src-tauri/src/sqlite_database_tests.rs
@@ -1,13 +1,30 @@
-use crate::sqlite_database::{create_sqlite_file, normalize_sqlite_path};
+use crate::sqlite_database::{
+    create_sqlite_file, expand_sqlite_filename_with_home, normalize_sqlite_path,
+};
 use sqlx::sqlite::SqliteConnectOptions;
 use sqlx::{Connection, SqliteConnection};
 use std::fs;
+use std::path::PathBuf;
 
 #[test]
 fn appends_db_extension_when_missing() {
     let path = normalize_sqlite_path("/tmp/customer-data").unwrap();
 
     assert_eq!(path.to_string_lossy(), "/tmp/customer-data.db");
+}
+
+#[test]
+fn normalizes_home_relative_sqlite_paths() {
+    let home = PathBuf::from("/home/dev");
+
+    assert_eq!(
+        expand_sqlite_filename_with_home("~/customer-data", Some(&home)),
+        home.join("customer-data")
+    );
+    assert_eq!(
+        expand_sqlite_filename_with_home("~\\customer-data", Some(&home)),
+        home.join("customer-data")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- expand SQLite `~/` and `~\` paths before file-based connection validation
- share SQLite path expansion between pool creation and new database creation
- move path expansion tests into the existing pool manager test module and cover create-new normalization

## Testing
- cargo test --manifest-path src-tauri/Cargo.toml pool_manager --lib --no-run
- cargo test --manifest-path src-tauri/Cargo.toml sqlite_database --lib --no-run
- pnpm.cmd typecheck
- pnpm.cmd lint

Refs #165