### PR TITLE
fix: support parameters in explain plan

### DIFF
--- a/src/components/modals/QueryParamsModal.tsx
+++ b/src/components/modals/QueryParamsModal.tsx
@@ -108,7 +108,7 @@ const QueryParamsForm = ({ parameters, initialValues, onSubmit, onClose, mode }:
                 <Save size={16} fill="currentColor" />
               )}
               {mode === "explain"
-                ? t("editor.explain")
+                ? t("editor.visualExplain.buttonShort")
                 : mode === "run"
                   ? t("editor.run")
                   : t("common.save")}

--- a/src/components/modals/QueryParamsModal.tsx
+++ b/src/components/modals/QueryParamsModal.tsx
@@ -9,7 +9,7 @@ interface QueryParamsModalProps {
   onSubmit: (values: Record<string, string>) => void;
   parameters: string[];
   initialValues: Record<string, string>;
-  mode?: "run" | "save";
+  mode?: "run" | "save" | "explain";
 }
 
 export const QueryParamsModal = ({
@@ -38,7 +38,7 @@ const QueryParamsForm = ({ parameters, initialValues, onSubmit, onClose, mode }:
   initialValues: Record<string, string>;
   onSubmit: (values: Record<string, string>) => void;
   onClose: () => void;
-  mode: "run" | "save";
+  mode: "run" | "save" | "explain";
 }) => {
   const { t } = useTranslation();
   const [values, setValues] = useState<Record<string, string>>(initialValues || {});
@@ -102,12 +102,16 @@ const QueryParamsForm = ({ parameters, initialValues, onSubmit, onClose, mode }:
               disabled={!isFormValid}
               className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {mode === "run" ? (
+              {mode === "run" || mode === "explain" ? (
                 <Play size={16} fill="currentColor" />
               ) : (
                 <Save size={16} fill="currentColor" />
               )}
-              {mode === "run" ? t("editor.run") : t("common.save")}
+              {mode === "explain"
+                ? t("editor.explain")
+                : mode === "run"
+                  ? t("editor.run")
+                  : t("common.save")}
             </button>
           </div>
         </form>

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -342,7 +342,7 @@ export const Editor = () => {
     parameters: string[];
     pendingPageNum: number;
     pendingTabId?: string;
-    mode: "run" | "save";
+    mode: "run" | "save" | "explain";
     pendingMultiQueries?: string[];
   }>({
     isOpen: false,
@@ -1790,10 +1790,41 @@ export const Editor = () => {
     }
   }, [activeTab, activeDialect, runQuery, runMultipleQueries, settings.runStatementUnderCursor]);
 
-  const openExplainForQuery = useCallback((query: string) => {
-    setVisualExplainQuery(query);
+  const openExplainForQuery = useCallback((query: string, tabId?: string) => {
+    let queryToExplain = query;
+    const params = extractQueryParams(queryToExplain, activeDialect);
+    const targetTabId = tabId ?? activeTabIdRef.current;
+
+    if (params.length > 0 && targetTabId) {
+      const targetTab = tabsRef.current.find((tab) => tab.id === targetTabId);
+      const storedParams = targetTab?.queryParams || {};
+      const missingParams = params.filter(
+        (param) =>
+          storedParams[param] === undefined || storedParams[param].trim() === "",
+      );
+
+      if (missingParams.length > 0) {
+        setQueryParamsModal({
+          isOpen: true,
+          sql: queryToExplain,
+          parameters: params,
+          pendingPageNum: 1,
+          pendingTabId: targetTabId,
+          mode: "explain",
+        });
+        return;
+      }
+
+      queryToExplain = interpolateQueryParams(
+        queryToExplain,
+        storedParams,
+        activeDialect,
+      );
+    }
+
+    setVisualExplainQuery(queryToExplain);
     setIsVisualExplainOpen(true);
-  }, []);
+  }, [activeDialect]);
 
   const handleExplainButton = useCallback(() => {
     if (!activeTab || !activeConnectionId) return;
@@ -2754,9 +2785,18 @@ export const Editor = () => {
         } else {
           runQuery(sql, pendingPageNum, pendingTabId, newParams);
         }
+      } else if (mode === "explain") {
+        setVisualExplainQuery(interpolateQueryParams(sql, newParams, activeDialect));
+        setIsVisualExplainOpen(true);
       }
     },
-    [queryParamsModal, updateTab, runQuery, runMultipleQueries],
+    [
+      activeDialect,
+      queryParamsModal,
+      updateTab,
+      runQuery,
+      runMultipleQueries,
+    ],
   );
 
   const handleEditParams = useCallback(() => {

--- a/tests/components/modals/QueryModal.test.tsx
+++ b/tests/components/modals/QueryModal.test.tsx
@@ -222,6 +222,10 @@ describe("QueryModal", () => {
     await waitFor(() => {
       expect(saveButton).toBeDisabled();
     });
+
+    await waitFor(() => {
+      expect(mockOnClose).toHaveBeenCalled();
+    });
   });
 
   it("resets state when reopening with different initial values", () => {


### PR DESCRIPTION
## Summary
- Reuse the existing query parameter modal when Visual Explain is opened for SQL with missing parameters.
- Reuse saved tab parameter values when they are already complete.
- Save submitted values back to the tab before opening the interpolated Explain query.

## Validation
- `pnpm.cmd typecheck`
- `pnpm.cmd lint`

Fixes #565
