### PR TITLE
fix(nightly): scope the prerelease counter to the version base

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -85,12 +85,23 @@ jobs:
           #
           # The prerelease identifier MUST be a SINGLE NUMERIC value: Tauri's MSI
           # (WiX) and NSIS bundlers reject non-numeric or multi-part prerelease
-          # identifiers (tauri-apps/tauri#8038, #5286). github.run_number is
-          # monotonic and small, so `0.15.1-<run>` orders correctly across
-          # nightlies and stays bundler-safe. The human-readable date/sha lives
-          # in the tag (nightly-YYYYMMDD-sha) and the release name, not here.
+          # identifiers (tauri-apps/tauri#8038, #5286). The human-readable
+          # date/sha lives in the tag (nightly-YYYYMMDD-sha) and the release
+          # name, not here.
           next=$(node -e "const v=require('./src-tauri/tauri.conf.json').version.split('-')[0].split('.').map(Number); v[2]++; console.log(v.join('.'))")
-          updater_version="${next}-${{ github.run_number }}"
+
+          # Counter is scoped to the base: it increments while the base stays
+          # put and restarts at 1 as soon as a stable release moves it (0.17.1-3
+          # -> stable 0.18.0 -> 0.18.1-1). SemVer only compares prerelease
+          # identifiers between versions sharing a base, so restarting is safe;
+          # what matters is that it never goes backwards *within* one base.
+          # Hence max-of-existing + 1, read from the release names this same
+          # workflow writes ("Nightly (v<base>-<n>)").
+          next_re=${next//./\\.}
+          last_n=$(gh release list --limit 200 --json name --jq '.[].name' \
+            | sed -n "s/^Nightly (v${next_re}-\([0-9]\{1,\}\))$/\1/p" \
+            | sort -n | tail -1)
+          updater_version="${next}-$(( ${last_n:-0} + 1 ))"
 
           {
             echo "should_build=true"


### PR DESCRIPTION
## Problem

The number after the dash in a nightly version is `github.run_number`, not a nightly counter. It is monotonic per workflow and never resets, so:

* it keeps climbing straight through stable releases. We shipped `v0.17.0` and the next nightly was `0.17.1-18`, not `0.17.1-1`.
* it advances even on runs where the gate decides no build is due (no new green commit), which leaves gaps in the sequence.

## Change

Derive the counter from the nightly releases we have already published: take the highest suffix for the current base and add one.

```bash
next_re=${next//./\\.}
last_n=$(gh release list --limit 200 --json name --jq '.[].name' \
  | sed -n "s/^Nightly (v${next_re}-\([0-9]\{1,\}\))$/\1/p" \
  | sort -n | tail -1)
updater_version="${next}-$(( ${last_n:-0} + 1 ))"
```

Result:

| Situation | Before | After |
|---|---|---|
| Base unchanged | `0.17.1-18` -> `0.17.1-23` (gaps) | `0.17.1-18` -> `0.17.1-19` |
| `v0.18.0` ships | `0.18.1-24` | `0.18.1-1` |
| `v0.18.2` ships | `0.18.3-31` | `0.18.3-1` |

## Notes

* It is max+1, not a count. If a nightly gets deleted by hand the counter does not go backwards, so the updater never re-offers a version someone already has.
* Restarting on a base change is safe: SemVer only compares prerelease identifiers between versions that share a base, and `0.18.1-1` is still greater than `0.18.0`.
* The identifier stays a single numeric value, which the MSI/WiX and NSIS bundlers require (tauri-apps/tauri#8038, #5286).
* The counter is read from the release name that this same workflow writes via `release_name: "Nightly (v__VERSION__)"`. Changing that format means updating the regex too, and there is a comment in the workflow saying so.

## Testing

Ran the parsing locally against a sample release list. Base `0.17.1` with existing `-7`, `-9`, `-18` gives `19`; base `0.18.1` with no matching release gives `1`. The first nightly after this merges will be `0.17.1-19`, so the switch away from run numbers does not cause a version regression.
