### PR TITLE
fix(editor): keep query results when switching between connections

### DIFF
--- a/src/contexts/EditorProvider.tsx
+++ b/src/contexts/EditorProvider.tsx
@@ -58,6 +58,14 @@ export const EditorProvider = ({ children }: { children: ReactNode }) => {
       return;
     }
 
+    // This connection's tabs are already live in memory. Storage copies are
+    // saved result-stripped, so reloading them here would wipe the query
+    // results of every tab whenever the user switches connections (#292).
+    if (tabsRef.current.some((t) => t.connectionId === activeConnectionId)) {
+      setIsLoading(false);
+      return;
+    }
+
     const loadPreferences = async () => {
       setIsLoading(true);
       try {

--- a/tests/contexts/EditorProvider.test.tsx
+++ b/tests/contexts/EditorProvider.test.tsx
@@ -506,3 +506,112 @@ describe("EditorProvider", () => {
     expect(resultConn2.current.tabs).toHaveLength(0);
   });
 });
+
+describe("EditorProvider connection switching (#292)", () => {
+  const storage: Record<
+    string,
+    { tabs: Record<string, unknown>[]; active_tab_id: string | null } | null
+  > = {};
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    for (const key of Object.keys(storage)) delete storage[key];
+    vi.mocked(invoke).mockImplementation(
+      (cmd: string, args?: { connectionId?: string }) => {
+        if (cmd === "load_editor_preferences") {
+          return Promise.resolve(
+            args?.connectionId ? (storage[args.connectionId] ?? null) : null,
+          );
+        }
+        if (cmd === "save_editor_preferences") {
+          return Promise.resolve(undefined);
+        }
+        return Promise.resolve(null);
+      },
+    );
+  });
+
+  it("keeps query results when switching away and back to a connection", async () => {
+    storage["conn-1"] = {
+      tabs: [
+        {
+          id: "tab-1",
+          title: "Console",
+          type: "console",
+          query: "select * from users",
+          page: 1,
+          activeTable: null,
+          pkColumns: null,
+          connectionId: "conn-1",
+        },
+      ],
+      active_tab_id: "tab-1",
+    };
+
+    const conn = { current: "conn-1" };
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        DatabaseContext.Provider,
+        {
+          value: {
+            activeConnectionId: conn.current,
+            activeDriver: "mysql",
+            activeTable: null,
+            activeConnectionName: "Test Connection",
+            activeDatabaseName: "testdb",
+            tables: [],
+            isLoadingTables: false,
+            connect: vi.fn(),
+            disconnect: vi.fn(),
+            setActiveTable: vi.fn(),
+            refreshTables: vi.fn(),
+          },
+        },
+        React.createElement(EditorProvider, null, children),
+      );
+
+    const { result, rerender } = renderHook(() => useEditor(), { wrapper });
+
+    // Storage load brings in conn-1's tab (result-stripped, as persisted).
+    await waitFor(() => expect(result.current.tabs).toHaveLength(1));
+    expect(result.current.tabs[0].id).toBe("tab-1");
+
+    // Running the query fills in the live result.
+    const liveResult = {
+      columns: ["id"],
+      rows: [[1]],
+      affected_rows: 0,
+    };
+    act(() => {
+      result.current.updateTab("tab-1", { result: liveResult });
+    });
+    expect(result.current.tabs[0].result).toBe(liveResult);
+
+    // Switch to another connection; its initial tab gets created.
+    conn.current = "conn-2";
+    rerender();
+    await waitFor(() =>
+      expect(
+        result.current.tabs.some((t) => t.connectionId === "conn-2"),
+      ).toBe(true),
+    );
+
+    // Switching back must not reload conn-1's result-stripped storage copy.
+    conn.current = "conn-1";
+    rerender();
+
+    const tab1 = result.current.tabs.find((t) => t.id === "tab-1");
+    expect(tab1?.query).toBe("select * from users");
+    expect(tab1?.result).toBe(liveResult);
+
+    // The storage loader never ran for conn-1 a second time.
+    const conn1Loads = vi
+      .mocked(invoke)
+      .mock.calls.filter(
+        ([cmd, args]) =>
+          cmd === "load_editor_preferences" &&
+          (args as { connectionId?: string })?.connectionId === "conn-1",
+      );
+    expect(conn1Loads).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #292

With two connections open, switching to another connection and back wiped the first connection's query results: the tab kept its SQL, but the result grid came back empty.

**Root cause** (as suspected in the issue): the tab-loading effect in `EditorProvider` re-runs on *every* `activeConnectionId` change and replaces the connection's live tabs with the storage copies — and tabs are persisted result-stripped (`cleanTabForStorage` removes `result`, `error`, `executionTime`, etc.). So switching back to an already-loaded connection clobbered live tabs holding results with result-less storage copies.

## Fix

Skip the storage reload when the connection's tabs are already live in memory (`EditorProvider.tsx`). During a session the in-memory tab state is the source of truth — the continuous save effect (`tabs`/`activeTabIds` change → `saveTabsToStorage`) already keeps storage in sync for the next app start, so nothing is lost by not reloading.

This implements the issue's first suggested approach (guard on existing tabs). The merge-instead-of-reload alternative was unnecessary: the only reason to read storage is to restore tabs that aren't in memory, which by definition only happens on the first visit to a connection.

Side benefit: switching back to a loaded connection no longer flashes the loading state or re-runs the storage round-trip at all.

## What doesn't change

- First visit to a connection (including app start) still loads tabs from storage, including the legacy notebook-tab migration.
- Closing all of a connection's tabs and revisiting still loads from storage (in-memory guard finds no tabs) and creates the initial tab.
- Cross-connection notebook open (`pendingNotebookRef`) is unaffected: with the target connection already loaded, the deferred open resolves immediately instead of waiting out a redundant load.

## Test plan

- New regression test in `tests/contexts/EditorProvider.test.tsx` simulating the issue's exact repro: load conn-1's tab from storage → set a live result → switch to conn-2 (initial tab created) → switch back. Asserts the tab keeps its query *and* its result, and that `load_editor_preferences` ran only once for conn-1. **Verified it fails without the fix and passes with it.**
- `pnpm vitest run`: full suite passes (3431 tests)
- `tsc -b`: clean
- `eslint` on changed source: clean
- Manually verified with the `demo/` Docker stack (MySQL + PostgreSQL connections): results survive switching away and back; tabs still restore correctly from storage after an app restart.
