### PR TITLE
chore(plugins): bump DynamoDB plugin to v0.1.3

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -382,15 +382,28 @@
       "description": "Tabularis driver plugin for AWS DynamoDB",
       "author": "fuleinist <https://github.com/fuleinist>",
       "homepage": "https://github.com/TabularisDB/tabularis-dynamodb-plugin",
-      "latest_version": "0.1.1",
+      "latest_version": "0.1.3",
       "releases": [
         {
-          "version": "0.1.0",
+          "version": "0.1.3",
           "min_tabularis_version": "0.15.0",
           "assets": {
-            "linux-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.0/dynamodb-plugin-linux-x64.zip",
-            "darwin-arm64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.0/dynamodb-plugin-darwin-arm64.zip",
-            "win-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.0/dynamodb-plugin-win-x64.zip"
+            "linux-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.3/dynamodb-plugin-linux-x64.zip",
+            "linux-arm64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.3/dynamodb-plugin-linux-arm64.zip",
+            "darwin-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.3/dynamodb-plugin-darwin-x64.zip",
+            "darwin-arm64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.3/dynamodb-plugin-darwin-arm64.zip",
+            "win-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.3/dynamodb-plugin-win-x64.zip"
+          }
+        },
+        {
+          "version": "0.1.2",
+          "min_tabularis_version": "0.15.0",
+          "assets": {
+            "linux-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.2/dynamodb-plugin-linux-x64.zip",
+            "linux-arm64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.2/dynamodb-plugin-linux-arm64.zip",
+            "darwin-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.2/dynamodb-plugin-darwin-x64.zip",
+            "darwin-arm64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.2/dynamodb-plugin-darwin-arm64.zip",
+            "win-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.2/dynamodb-plugin-win-x64.zip"
           }
         },
         {
@@ -402,6 +415,15 @@
             "darwin-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.1/dynamodb-plugin-darwin-x64.zip",
             "darwin-arm64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.1/dynamodb-plugin-darwin-arm64.zip",
             "win-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.1/dynamodb-plugin-win-x64.zip"
+          }
+        },
+        {
+          "version": "0.1.0",
+          "min_tabularis_version": "0.15.0",
+          "assets": {
+            "linux-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.0/dynamodb-plugin-linux-x64.zip",
+            "darwin-arm64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.0/dynamodb-plugin-darwin-arm64.zip",
+            "win-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.0/dynamodb-plugin-win-x64.zip"
           }
         }
       ]


### PR DESCRIPTION
Bump DynamoDB plugin to v0.1.3 in the plugin registry.

## v0.1.3 (2026-08-02)

### Fixed

- **Parallelized `get_tables` DescribeTable calls** — `get_tables` no longer issues DescribeTable calls serially. On AWS accounts with hundreds of tables the serial loop took over a minute (~300ms per table), exceeding the GUI's connection timeout and failing the initial connection. Describes now run with bounded concurrency (16 in flight) and results are re-sorted alphabetically to preserve ListTables ordering. (#57)
- **Fixed pagination contract** — `execute_query` responses now include a complete `pagination` object with the `page`, `page_size`, `total_rows` and `has_more` fields the Tabularis app's `Pagination` struct requires. Previously only `next_token` was sent, and the app rejected every query response with "missing field `page`". (#58)

### Changed

- Added `futures` 0.3 dependency for bounded-concurrency stream parallelism.

### v0.1.2 (2026-08-01)

- Dependency bumps: base64 0.22→0.23, aws-sdk minor versions, GitHub Actions (checkout, setup-node, upload-artifact, download-artifact, action-gh-release).
- Tabularium driver-kind manifest compliance (added `kind`, `engine`, `paradigms`; fixed boolean category).

All cross-platform release assets verified published on GitHub.