### PR TITLE
docs(plugins): .tabularium is the canonical manifest, not manifest.json

### DIFF
--- a/.claude/skills/tabularis-plugin-driver/references/manifest-checklist.md
+++ b/.claude/skills/tabularis-plugin-driver/references/manifest-checklist.md
@@ -1,17 +1,24 @@
 # Manifest Checklist
 
-Use this checklist when authoring `manifest.json` for a Tabularis database plugin.
+Use this checklist when authoring `.tabularium` for a Tabularis database plugin. `.tabularium` at the plugin root is the canonical manifest; `manifest.json` survives only as a host-side legacy fallback and is not a first-class source for the registry.
 
 ## Required Core Fields
 
-- `id`
-- `name`
-- `version`
-- `description`
+- `name` — lowercase slug matching `^[a-z][a-z0-9-]*$`; this is the registry slug, pinned at first submit
+- `version` — semver, **no leading `v`**; must equal the release tag stripped of any `v` prefix
 - `capabilities`
+
+Optional but constrained:
+
+- `description` — optional, max **280 chars**
+- `tags` — max 16, each ≤ 30 chars
+- `category`, `license` — each ≤ 40 chars
+
+There is no `id` field in the registry schema — the host's legacy `id` is ignored on submit; the registry keys everything off `name`.
 
 For driver plugins, also include:
 
+- `kind: "driver"` (plus `engine`, `paradigms`)
 - `default_port`
 - `executable`
 - `data_types`
@@ -19,10 +26,17 @@ For driver plugins, also include:
 ## Recommended Modern Fields
 
 - `default_username`
-- `color`
+- `color` (host/extension field, not part of the registry core schema)
 - `icon`
 - `settings`
 - `ui_extensions`
+
+## Publishing
+
+- Upload `.tabularium` as a standalone release asset too — GitHub silently renames it to `default.tabularium`; the registry accepts both names.
+- The registry hard-rejects submissions whose manifest fails schema validation (HTTP 422) — there is no silent fallback.
+- Installs are verified client-side via sha256 + JWS signature from the registry's integrity envelope.
+- Field reference: https://docs.tabularium.wiki/manifest/
 
 ## Capability Guidance
 

--- a/packages/create-plugin/README.md
+++ b/packages/create-plugin/README.md
@@ -81,15 +81,18 @@ npx @tabularis/create-plugin migrate ./my-driver
 
 This writes `.tabularium` from your `manifest.json`, removes the old file, and
 updates the `manifest.json` references in `release.yml`, `justfile`, and
-`README.md`. It keeps a `id` that differs from `name` (the host uses it as the
-plugin identity) and refuses to run if the manifest has no semver `version`,
-which the registry requires.
+`README.md`. A legacy `id` that differs from `name` is kept for the host's
+benefit only — the registry has no `id` field and keys everything off `name`
+(the pinned lowercase slug). The command refuses to run if the manifest has no
+semver `version`, which the registry requires — without a leading `v`, and it
+must equal the release tag stripped of any `v` prefix.
 
 By default the release workflow is left as-is (only its `manifest.json`
 reference is renamed so the build keeps working). The hosted Tabularium registry
 resolves the manifest from the **release assets**, so it needs `.tabularium`
-published as a standalone asset. Add `--ci` to regenerate `release.yml` from the
-registry-ready template:
+published as a standalone asset (GitHub renames the dotfile to
+`default.tabularium` on upload — the registry accepts either name). Add `--ci`
+to regenerate `release.yml` from the registry-ready template:
 
 ```bash
 npx @tabularis/create-plugin migrate ./my-driver --ci
@@ -139,6 +142,7 @@ my-driver/ui/
 ## Related
 
 - **[Plugin guide](https://github.com/TabularisDB/tabularis/blob/main/plugins/PLUGIN_GUIDE.md)** — authoritative reference for JSON-RPC methods, capabilities, slots.
+- **[Manifest reference](https://docs.tabularium.wiki/manifest/)** — every `.tabularium` field with constraints; invalid manifests are rejected at submit (HTTP 422).
 - **[`@tabularis/plugin-api`](https://www.npmjs.com/package/@tabularis/plugin-api)** — TypeScript types + hooks for UI extensions.
 - **[Tabularis repo](https://github.com/TabularisDB/tabularis)** — the host app.
 

--- a/plugins/PLUGIN_GUIDE.md
+++ b/plugins/PLUGIN_GUIDE.md
@@ -44,7 +44,7 @@ plugins/
 
 ### The `.tabularium` manifest
 
-One manifest tells Tabularis everything about your plugin — and, when you publish, tells the Tabularium registry how to list it. Its canonical name is **`.tabularium`**; the host still reads a legacy `manifest.json` as a fallback. In a `.tabularium`, `name` is the lowercase slug that identifies the plugin (legacy manifests may keep a separate `id` and a display `name`).
+One manifest tells Tabularis everything about your plugin — and, when you publish, tells the Tabularium registry how to list it. Its canonical name is **`.tabularium`**; the host still reads a legacy `manifest.json` as a fallback. In a `.tabularium`, `name` is the lowercase slug that identifies the plugin (legacy manifests may keep a separate `id` and a display `name`). When publishing, the registry resolves the manifest from your **release assets** — upload `.tabularium` as a standalone asset (GitHub silently renames the dotfile to `default.tabularium`; the registry accepts both names).
 
 > **JSON Schema available:** point `$schema` at the registry's live merged schema (as below) for IDE autocompletion and validation, or at the local [`plugins/manifest.schema.json`](./manifest.schema.json) for legacy `manifest.json` files.
 
@@ -86,10 +86,10 @@ One manifest tells Tabularis everything about your plugin — and, when you publ
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `name` | string | Lowercase slug identifying the plugin (e.g., `"duckdb"`). Must match the folder name. |
-| `id` | string | Legacy identifier from `manifest.json`-era plugins. Optional — when absent, identity falls back to `name`. Omit in new `.tabularium` manifests. |
-| `version` | string | Plugin version (semver). |
-| `description` | string | Short description shown in the plugins list. |
+| `name` | string | Lowercase slug identifying the plugin (e.g., `"duckdb"`). Must match the folder name and the registry pattern `^[a-z][a-z0-9-]*$`; it becomes the registry slug and is pinned at first submit. |
+| `id` | string | Legacy identifier from `manifest.json`-era plugins. Optional — when absent, identity falls back to `name`. Omit in new `.tabularium` manifests; the registry ignores it. |
+| `version` | string | Plugin version (semver, **no leading `v`**). Must equal the release tag with any `v` prefix stripped — the registry rejects tag/manifest mismatches. |
+| `description` | string | Short description shown in the plugins list. Optional for the registry; max **280 chars**. |
 | `default_port` | number \| null | Default TCP port. Use `null` for file-based databases. |
 | `executable` | string | Relative path to the executable inside the plugin folder. |
 | `capabilities` | object | Feature flags (see below). |
@@ -1357,8 +1357,9 @@ To make your plugin available in the official registry:
 
 1. Build release binaries for all supported platforms.
 2. Package each platform binary with your `.tabularium` into a `.zip` file (the scaffolded release workflow does this).
-3. Create a GitHub Release with the ZIP files attached.
-4. Submit your plugin at [registry.tabularis.dev/submit](https://registry.tabularis.dev/submit) — ownership is verified via OAuth against your linked repository, and CI can pre-validate the manifest via `POST /api/manifest/validate`. The registry's [plugin development page](https://registry.tabularis.dev/docs/plugin-development) documents every `.tabularium` field.
+3. Create a GitHub Release with the ZIP files attached — **plus `.tabularium` as a standalone asset** (GitHub renames it to `default.tabularium`; the registry accepts both). The registry resolves the manifest from release assets, and the tag stripped of `v` must equal the manifest `version`.
+4. Submit your plugin at [registry.tabularis.dev/submit](https://registry.tabularis.dev/submit) — ownership is verified via OAuth against your linked repository, and CI can pre-validate the manifest via `POST /api/manifest/validate`. A manifest that fails validation is rejected with **HTTP 422** — there is no silent fallback. The registry's [plugin development page](https://registry.tabularis.dev/docs/plugin-development) documents every `.tabularium` field; the full author docs live at [docs.tabularium.wiki](https://docs.tabularium.wiki/manifest/).
+5. Installs are verified client-side: Tabularis checks the registry's JWS signature and the download's SHA-256 before anything runs.
 
 The legacy path — a pull request adding an entry to `plugins/registry.json` (format in [README.md](./README.md)) — still works during the transition; new plugins should submit to the registry directly.
 

--- a/plugins/PLUGIN_GUIDE.md
+++ b/plugins/PLUGIN_GUIDE.md
@@ -24,35 +24,34 @@ An external plugin in Tabularis is a separate executable (binary or script) that
    - **Linux:** `~/.local/share/tabularis/plugins/`
    - **macOS:** `~/Library/Application Support/tabularis/plugins/`
    - **Windows:** `%APPDATA%\tabularis\plugins\`
-2. It reads the `manifest.json` for each plugin to discover its capabilities and data types.
+2. It reads each plugin's `.tabularium` manifest (or a legacy `manifest.json`) to discover its capabilities and data types.
 3. The plugin is registered as a driver and appears in the "Database Type" list.
 4. When the user opens a connection using the plugin's driver, Tabularis spawns the executable and begins sending JSON-RPC messages.
 5. The same process instance is reused for all operations in that session.
 
 ---
 
-## 2. Directory Structure & `manifest.json`
+## 2. Directory Structure & the Manifest (`.tabularium`)
 
 A Tabularis plugin is distributed as a `.zip` file. When extracted into the plugins folder, it must have the following structure:
 
 ```text
 plugins/
 └── duckdb/
-    ├── manifest.json
+    ├── .tabularium  (or legacy manifest.json)
     └── duckdb-plugin  (or duckdb-plugin.exe on Windows)
 ```
 
-### The `manifest.json`
+### The `.tabularium` manifest
 
-The manifest tells Tabularis everything about your plugin.
+One manifest tells Tabularis everything about your plugin — and, when you publish, tells the Tabularium registry how to list it. Its canonical name is **`.tabularium`**; the host still reads a legacy `manifest.json` as a fallback. In a `.tabularium`, `name` is the lowercase slug that identifies the plugin (legacy manifests may keep a separate `id` and a display `name`).
 
-> **JSON Schema available:** [`plugins/manifest.schema.json`](./manifest.schema.json) — add `"$schema": "./manifest.schema.json"` to your manifest for IDE autocompletion and validation.
+> **JSON Schema available:** point `$schema` at the registry's live merged schema (as below) for IDE autocompletion and validation, or at the local [`plugins/manifest.schema.json`](./manifest.schema.json) for legacy `manifest.json` files.
 
 ```json
 {
-  "$schema": "https://tabularis.dev/schemas/plugin-manifest.json",
-  "id": "duckdb",
-  "name": "DuckDB",
+  "$schema": "https://registry.tabularis.dev/manifest.schema.json?kind=driver",
+  "name": "duckdb",
   "version": "1.0.0",
   "description": "DuckDB file-based analytical database",
   "default_port": null,
@@ -87,8 +86,8 @@ The manifest tells Tabularis everything about your plugin.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `id` | string | Unique driver identifier (lowercase, no spaces). Must match the folder name. |
-| `name` | string | Display name shown in the UI (e.g., `"DuckDB"`). |
+| `name` | string | Lowercase slug identifying the plugin (e.g., `"duckdb"`). Must match the folder name. |
+| `id` | string | Legacy identifier from `manifest.json`-era plugins. Optional — when absent, identity falls back to `name`. Omit in new `.tabularium` manifests. |
 | `version` | string | Plugin version (semver). |
 | `description` | string | Short description shown in the plugins list. |
 | `default_port` | number \| null | Default TCP port. Use `null` for file-based databases. |
@@ -175,7 +174,7 @@ Since `map_inferred_type()` is a synchronous trait method that cannot issue an R
 
 Plugins can declare custom configuration fields that Tabularis renders in the **Settings → gear icon** modal for that plugin. Users fill in the values, Tabularis persists them in `config.json`, and passes them to the plugin at startup via an `initialize` RPC call.
 
-### Declaring settings in `manifest.json`
+### Declaring settings in the manifest
 
 Add an optional `settings` array at the top level of your manifest:
 
@@ -290,7 +289,7 @@ Plugins can inject custom React components into the host UI through a **slot-bas
 
 ### Declaring UI Extensions
 
-Add an optional `ui_extensions` array to your `manifest.json`:
+Add an optional `ui_extensions` array to your manifest:
 
 ```json
 {
@@ -482,7 +481,7 @@ Plugins can ship locale files at `locales/{lang}.json` inside their plugin folde
 
 ```
 my-plugin/
-├── manifest.json
+├── .tabularium
 ├── my-plugin-binary
 ├── locales/
 │   ├── en.json
@@ -1344,7 +1343,7 @@ You should see a valid JSON-RPC response on stdout.
    - **Linux:** `~/.local/share/tabularis/plugins/myplugin/`
    - **macOS:** `~/Library/Application Support/tabularis/plugins/myplugin/`
    - **Windows:** `%APPDATA%\tabularis\plugins\myplugin\`
-2. Place your `manifest.json` and the compiled executable in that directory.
+2. Place your `.tabularium` (or legacy `manifest.json`) and the compiled executable in that directory.
 3. On Linux/macOS, make the executable runnable: `chmod +x myplugin`
 4. Restart Tabularis (or install via Settings to hot-reload without restart).
 5. Open **Settings → Installed Plugins** — your driver should appear.
@@ -1357,11 +1356,11 @@ You should see a valid JSON-RPC response on stdout.
 To make your plugin available in the official registry:
 
 1. Build release binaries for all supported platforms.
-2. Package each platform binary with `manifest.json` into a `.zip` file.
-3. Create a GitHub Release (or host on another URL) with the ZIP files.
-4. Open a pull request to this repository adding your plugin entry to `plugins/registry.json`.
+2. Package each platform binary with your `.tabularium` into a `.zip` file (the scaffolded release workflow does this).
+3. Create a GitHub Release with the ZIP files attached.
+4. Submit your plugin at [registry.tabularis.dev/submit](https://registry.tabularis.dev/submit) — ownership is verified via OAuth against your linked repository, and CI can pre-validate the manifest via `POST /api/manifest/validate`. The registry's [plugin development page](https://registry.tabularis.dev/docs/plugin-development) documents every `.tabularium` field.
 
-See [README.md](./README.md) for the full `registry.json` format.
+The legacy path — a pull request adding an entry to `plugins/registry.json` (format in [README.md](./README.md)) — still works during the transition; new plugins should submit to the registry directly.
 
 > **Note:** `min_tabularis_version` is specified per-release inside the `releases[]` array,
 > not at the root plugin level. This allows older Tabularis installs to install an older

--- a/plugins/PLUGIN_TUTORIAL.md
+++ b/plugins/PLUGIN_TUTORIAL.md
@@ -36,7 +36,7 @@ What the flags mean:
 |------|-----|
 | `--db-type=api` | Google Sheets is a REST API, not a network DB. Sets `no_connection_required: true` in the manifest. |
 | `--dir <path>` | Scaffold somewhere outside this tutorial's reading order. |
-| `google-sheets` | The plugin id. Used for the crate name, binary name, manifest `id`, and the install directory. |
+| `google-sheets` | The plugin id. Used for the crate name, binary name, manifest `name` (the registry slug), and the install directory. |
 
 Expected output:
 
@@ -96,6 +96,7 @@ Edit `.tabularium`. The scaffold gives you this:
 {
   "$schema": "https://registry.tabularis.dev/manifest.schema.json?kind=driver",
   "name": "google-sheets",
+  "version": "0.1.0",
   "kind": "driver",
   "engine": "google-sheets",
   "paradigms": ["relational"],
@@ -595,7 +596,8 @@ That's it.
 
 Ruthlessly cut for the 20-minute budget:
 
-- **Release packaging** — the scaffold ships `.github/workflows/release.yml` with a 5-platform matrix. Tag `v0.1.0`, push, collect artifacts. Not reading-order critical.
+- **Release packaging** — the scaffold ships `.github/workflows/release.yml` with a 5-platform matrix. Tag `v0.1.0`, push, collect artifacts. The tag stripped of `v` must equal the manifest `version`, and `.tabularium` must be uploaded as a standalone release asset (GitHub renames it to `default.tabularium` — the registry accepts both). Not reading-order critical.
+- **Publishing to the registry** — submit at [registry.tabularis.dev/submit](https://registry.tabularis.dev/submit); an invalid manifest is rejected with HTTP 422. Full walkthrough: [docs.tabularium.wiki/publishing](https://docs.tabularium.wiki/publishing/).
 - **CRUD via the row editor UI** — covered in the implementation but not explained. Enable by filling in `handlers/crud.rs` (done in step 5) and setting `capabilities.readonly: false` (we did). Once you can edit rows, look at the `row-editor-sidebar.field.after` slot for per-field UI extensions.
 - **DDL generation for the SQL preview** — `get_create_table_sql` is the only one you can implement meaningfully for Sheets. The rest are explicit `-32601` with a clear message.
 - **Typed UI via `@tabularis/plugin-api`** — the scaffold's `--with-ui` mode sets this up with a hello-world button in `data-grid.toolbar.actions`. Worth trying when your second plugin doesn't need two slots.

--- a/plugins/PLUGIN_TUTORIAL.md
+++ b/plugins/PLUGIN_TUTORIAL.md
@@ -55,7 +55,7 @@ What you got:
 ```
 google-sheets/
 ├── Cargo.toml
-├── manifest.json          ← plugin metadata (id, capabilities, UI extensions…)
+├── .tabularium            ← plugin manifest (identity, capabilities, UI extensions…)
 ├── justfile               ← build / install / test recipes
 ├── README.md
 ├── rust-toolchain.toml
@@ -90,13 +90,15 @@ Should print `Finished` in a few seconds. If it doesn't, stop and open an issue 
 
 ## 2. Declare the driver (3 minutes)
 
-Edit `manifest.json`. The scaffold gives you this:
+Edit `.tabularium`. The scaffold gives you this:
 
 ```json
 {
-  "$schema": "https://tabularis.dev/schemas/plugin-manifest.json",
-  "id": "google-sheets",
-  "name": "Google Sheets",
+  "$schema": "https://registry.tabularis.dev/manifest.schema.json?kind=driver",
+  "name": "google-sheets",
+  "kind": "driver",
+  "engine": "google-sheets",
+  "paradigms": ["relational"],
   "capabilities": {
     "schemas": false, "views": false, "routines": false,
     "file_based": false, "folder_based": false,
@@ -155,7 +157,7 @@ Replace the default with the three types Sheets actually uses:
 ]
 ```
 
-**Checkpoint:** `cargo check` still passes — `manifest.json` isn't touched by rustc.
+**Checkpoint:** `cargo check` still passes — `.tabularium` isn't touched by rustc.
 
 ---
 
@@ -561,7 +563,7 @@ pnpm --dir ui build
 PLUGIN_DIR="$HOME/.local/share/tabularis/plugins/google-sheets"
 mkdir -p "$PLUGIN_DIR/ui/dist"
 cp target/release/google-sheets-plugin "$PLUGIN_DIR/"
-cp manifest.json "$PLUGIN_DIR/"
+cp .tabularium "$PLUGIN_DIR/"
 cp ui/dist/*.js "$PLUGIN_DIR/ui/dist/"
 chmod +x "$PLUGIN_DIR/google-sheets-plugin"
 ```

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -35,7 +35,7 @@ Built-in drivers (MySQL, PostgreSQL, SQLite) are compiled into the binary. All a
 
 ### How It Works
 
-1. At startup, Tabularis scans the user's plugins directory for subdirectories containing a `manifest.json`.
+1. At startup, Tabularis scans the user's plugins directory for subdirectories containing a `.tabularium` manifest (or a legacy `manifest.json`).
 2. For each valid plugin, it creates an RPC bridge to the plugin executable and registers it as a driver.
 3. When the user connects to a database using a plugin driver, Tabularis spawns the executable and routes all requests through JSON-RPC.
 4. Plugins can be installed, updated, and uninstalled from **Settings → Available Plugins** without restarting the app.
@@ -53,7 +53,7 @@ Each plugin lives in its own subdirectory:
 ```
 plugins/
 └── duckdb/
-    ├── manifest.json
+    ├── .tabularium  (or legacy manifest.json)
     └── duckdb-plugin-executable
 ```
 
@@ -105,7 +105,7 @@ The registry file is fetched from this repository by the app to display availabl
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `id` | string | Unique driver identifier, must match the `id` in `manifest.json` |
+| `id` | string | Unique driver identifier, must match the plugin's manifest identity (`name` in a `.tabularium`, `id` in a legacy `manifest.json`) |
 | `name` | string | Display name shown in the UI |
 | `description` | string | Short description shown in the plugins list |
 | `author` | string | Author name and URL in the format `"Name <https://url>"` |
@@ -132,10 +132,10 @@ Omit a platform key if your plugin does not support that platform. The app will 
 
 To add your plugin to the official registry:
 
-1. Build and release your plugin as a `.zip` file for each supported platform. The ZIP must extract to a directory containing `manifest.json` and the executable.
+1. Build and release your plugin as a `.zip` file for each supported platform. The ZIP must extract to a directory containing the `.tabularium` manifest and the executable.
 2. Host the release assets (e.g., GitHub Releases).
 3. Open a pull request adding your plugin entry to `registry.json`.
-4. Ensure your `manifest.json` matches the format described in [PLUGIN_GUIDE.md](./PLUGIN_GUIDE.md).
+4. Ensure your manifest matches the format described in [PLUGIN_GUIDE.md](./PLUGIN_GUIDE.md) — or skip the PR entirely and submit at [registry.tabularis.dev/submit](https://registry.tabularis.dev/submit), the preferred path for new plugins.
 
 ---
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -2,7 +2,7 @@
 
 This directory contains the official plugin registry and documentation for the Tabularis external plugin system.
 
-> 📚 The canonical, browsable plugin documentation lives on the website: [tabularis.dev/wiki/plugins](https://tabularis.dev/wiki/plugins) (protocol reference) and [tabularis.dev/wiki/building-plugins](https://tabularis.dev/wiki/building-plugins) (walkthrough). The files here are the in-repo working copies.
+> 📚 The canonical, browsable plugin documentation lives on the website: [tabularis.dev/wiki/plugins](https://tabularis.dev/wiki/plugins) (protocol reference) and [tabularis.dev/wiki/building-plugins](https://tabularis.dev/wiki/building-plugins) (walkthrough). Registry and manifest docs live at [docs.tabularium.wiki](https://docs.tabularium.wiki) (`/manifest/`, `/publishing/`, `/consuming/`). The files here are the in-repo working copies.
 
 ## Quick start — build a plugin
 
@@ -133,9 +133,9 @@ Omit a platform key if your plugin does not support that platform. The app will 
 To add your plugin to the official registry:
 
 1. Build and release your plugin as a `.zip` file for each supported platform. The ZIP must extract to a directory containing the `.tabularium` manifest and the executable.
-2. Host the release assets (e.g., GitHub Releases).
-3. Open a pull request adding your plugin entry to `registry.json`.
-4. Ensure your manifest matches the format described in [PLUGIN_GUIDE.md](./PLUGIN_GUIDE.md) — or skip the PR entirely and submit at [registry.tabularis.dev/submit](https://registry.tabularis.dev/submit), the preferred path for new plugins.
+2. Host the release assets (e.g., GitHub Releases) and upload `.tabularium` as a **standalone release asset** too — GitHub renames the dotfile to `default.tabularium`; the registry accepts both.
+3. Submit at [registry.tabularis.dev/submit](https://registry.tabularis.dev/submit). Manifest validation is enforced: a manifest that fails the schema is rejected with **HTTP 422**. Format reference: [PLUGIN_GUIDE.md](./PLUGIN_GUIDE.md) and [docs.tabularium.wiki/manifest](https://docs.tabularium.wiki/manifest/).
+4. Legacy path: a pull request adding your plugin entry to `registry.json` still works during the transition, but new plugins should use the hosted registry.
 
 ---
 

--- a/plugins/manifest.schema.json
+++ b/plugins/manifest.schema.json
@@ -5,7 +5,6 @@
   "description": "Schema for the manifest.json file required by every Tabularis database driver plugin.",
   "type": "object",
   "required": [
-    "id",
     "name",
     "version",
     "executable",
@@ -17,7 +16,7 @@
     "id": {
       "type": "string",
       "pattern": "^[a-z0-9-]+$",
-      "description": "Unique driver identifier (lowercase letters, digits, hyphens). Must match the plugin folder name."
+      "description": "Legacy driver identifier (lowercase letters, digits, hyphens). Optional — when absent, identity falls back to name. Omit in new .tabularium manifests."
     },
     "name": {
       "type": "string",

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -60,7 +60,7 @@ pub struct AppConfig {
     /// GitHub-hosted file when unset.
     #[serde(default)]
     pub legacy_registry_url: Option<String>,
-    /// Base URL of the Tabularium plugin registry (https://tabularium.wiki).
+    /// Base URL of the Tabularium plugin registry (e.g. https://registry.tabularis.dev).
     /// Defaults to the built-in instance when unset.
     pub tabularium_registry_url: Option<String>,
     /// Update channel: "stable" (default) or "nightly". None ⇒ stable.

--- a/src-tauri/src/plugins/deep_link.rs
+++ b/src-tauri/src/plugins/deep_link.rs
@@ -207,12 +207,12 @@ mod tests {
     fn parses_query_based_install_url() {
         // Format emitted by the Tabularium frontend's "Open in App" button.
         let req = parse_install_url(
-            "tabularis://install?registry=https%3A%2F%2Fregistry.spitzli.dev&slug=firestore-tabularis&version=0.2.0",
+            "tabularis://install?registry=https%3A%2F%2Fregistry.tabularis.dev&slug=firestore-tabularis&version=0.2.0",
         )
         .expect("valid URL");
         assert_eq!(req.slug, "firestore-tabularis");
         assert_eq!(req.version.as_deref(), Some("0.2.0"));
-        assert_eq!(req.registry.as_deref(), Some("https://registry.spitzli.dev"));
+        assert_eq!(req.registry.as_deref(), Some("https://registry.tabularis.dev"));
     }
 
     #[test]

--- a/src-tauri/src/plugins/installer.rs
+++ b/src-tauri/src/plugins/installer.rs
@@ -150,7 +150,7 @@ pub async fn download_and_install(
 
     // Verify SHA-256 if the registry advertised one. The Tabularium
     // registry signs releases with a sha256 in the integrity envelope
-    // (see https://tabularium.wiki/docs/#/consuming) — refusing to install
+    // (see https://docs.tabularium.wiki/consuming/) — refusing to install
     // on mismatch is what protects users from a tampered upstream asset.
     // The legacy GitHub-hosted registry doesn't publish hashes, so this
     // check is opt-in per call.

--- a/src/types/plugins.ts
+++ b/src/types/plugins.ts
@@ -140,7 +140,7 @@ export interface RegistryPluginWithStatus {
   tags?: string[];
   category?: string | null;
   downloads?: number | null;
-  /** Base URL of the registry that served this plugin (e.g. https://registry.spitzli.dev). */
+  /** Base URL of the registry that served this plugin (e.g. https://registry.tabularis.dev). */
   registry_base_url?: string | null;
   /** Concrete database the driver connects to (registry manifest extensions.engine). */
   engine?: string | null;


### PR DESCRIPTION
Companion to the website-side fix (tabularis.dev/wiki/plugins already stopped presenting `manifest.json` as canonical). The host has treated `.tabularium` as the canonical on-disk manifest for a while (`installer.rs` `MANIFEST_FILE = ".tabularium"`, `manifest.json` legacy fallback in `compat.rs`, `ConfigManifest.id: Option<String>` with identity falling back to `name`) — the docs in `plugins/` still described the old world.

## Changes

- **PLUGIN_GUIDE.md** — § 2 reframed around `.tabularium`: directory trees, example manifest (slug `name`, no `id`, registry `$schema` with `?kind=driver`, matching what `@tabularis/create-plugin` scaffolds since #594), manifest-fields table (`name` = slug; `id` documented as optional legacy), lifecycle wording, install-locally step, and § 8 publishing now points at `registry.tabularis.dev/submit` with the `registry.json` PR labeled as the legacy path.
- **PLUGIN_TUTORIAL.md** — scaffold excerpts updated to the actual scaffold output (`.tabularium`, registry `$schema`, `kind`/`engine`/`paradigms`).
- **README.md** — startup scan, directory tree, registry-field note and publishing steps updated the same way.
- **manifest.schema.json** — `id` removed from `required` (kept as optional property, documented as legacy), matching the host's actual behavior. The copy served at `tabularis.dev/schemas/plugin-manifest.json` updates automatically on the next website build.

Docs + one schema-required-list change; no code touched.
