### PR TITLE
ci(release): stop bundling libwayland in the AppImage and reuse build.yml for releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,8 @@
 name: Build
 
-# Reusable build matrix used by nightly.yml (cron). Centralises the
-# signing/notarization config in one place so callers can't drift from it.
+# Reusable build matrix used by nightly.yml (cron) and release.yml (tags).
+# Centralises the signing/notarization config in one place so callers can't
+# drift from it.
 on:
   workflow_call:
     inputs:
@@ -33,6 +34,16 @@ on:
         required: false
         type: string
         default: ""
+      release_body:
+        description: "Body of the GitHub Release."
+        required: false
+        type: string
+        default: "See the assets to download this version and install."
+      experimental_appimage:
+        description: "Build the AppImage with the experimental sharun-based format (tauri PR #12491) instead of the official linuxdeploy bundler. Nightly-only until the PR stabilises."
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   publish-tauri:
@@ -122,9 +133,32 @@ jobs:
         with:
           workspaces: src-tauri
 
-      - name: Override tauri-cli with custom AppImage format (Linux)
-        if: matrix.platform == 'ubuntu-24.04'
+      - name: Override tauri-cli with custom AppImage format (Linux, experimental only)
+        if: matrix.platform == 'ubuntu-24.04' && inputs.experimental_appimage
         run: cargo install tauri-cli --git https://github.com/tauri-apps/tauri --branch feat/truly-portable-appimage --force
+
+      # The official tauri-cli AppImage bundler (linuxdeploy) bundles the build
+      # container's libwayland-*; on hosts with a newer Mesa the host libEGL
+      # binds to that stale bundled libwayland-client and WebKit aborts with
+      # EGL_BAD_PARAMETER (issue #423). libwayland must always come from the
+      # host — the AppImage excludelist prescribes exactly that:
+      # https://github.com/AppImageCommunity/pkg2appimage/pull/559
+      # tauri-bundler only downloads linuxdeploy-plugin-gtk.sh when it's
+      # missing from its tools cache, so pre-seed a patched copy that strips
+      # libwayland from the AppDir before the squashfs is packed (the updater
+      # signature is computed afterwards, so it stays valid).
+      - name: Patch AppImage bundling to strip bundled libwayland (Linux)
+        if: matrix.platform == 'ubuntu-24.04' && !inputs.experimental_appimage
+        run: |
+          mkdir -p ~/.cache/tauri
+          curl -fsSL https://raw.githubusercontent.com/tauri-apps/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh \
+            -o ~/.cache/tauri/linuxdeploy-plugin-gtk.sh
+          cat >> ~/.cache/tauri/linuxdeploy-plugin-gtk.sh <<'EOF'
+
+          # tabularis #423: libwayland must come from the host, never bundled.
+          find "$APPDIR" -name 'libwayland-*.so*' -delete
+          EOF
+          chmod +x ~/.cache/tauri/linuxdeploy-plugin-gtk.sh
 
       # Notarization needs the App Store Connect API key on disk. The .p8 is stored
       # base64-encoded in APPLE_API_KEY_CONTENT and decoded into a temp file (macOS only).
@@ -150,7 +184,7 @@ jobs:
       - uses: tauri-apps/tauri-action@73fb865345c54760d875b94642314f8c0c894afa # v0.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAURI_BUNDLER_NEW_APPIMAGE_FORMAT: "true"
+          TAURI_BUNDLER_NEW_APPIMAGE_FORMAT: ${{ inputs.experimental_appimage && 'true' || '' }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
           # macOS code signing (Developer ID Application certificate)
@@ -164,10 +198,11 @@ jobs:
         with:
           tagName: ${{ inputs.tag }}
           releaseName: ${{ inputs.release_name }}
-          releaseBody: "See the assets to download this version and install."
+          releaseBody: ${{ inputs.release_body }}
           releaseDraft: ${{ inputs.draft }}
           prerelease: ${{ inputs.prerelease }}
-          tauriScript: ${{ matrix.platform == 'ubuntu-24.04' && 'cargo tauri' || 'pnpm tauri' }}
+          # The experimental AppImage format needs the cargo-installed CLI override.
+          tauriScript: ${{ inputs.experimental_appimage && matrix.platform == 'ubuntu-24.04' && 'cargo tauri' || 'pnpm tauri' }}
           args: ${{ matrix.args }}
 
       - name: Upload portable executable (Windows only)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -126,3 +126,6 @@ jobs:
       prerelease: true
       draft: false
       updater_version: ${{ needs.gate.outputs.updater_version }}
+      # Nightlies double as the daily canary for the sharun-based AppImage
+      # format (tauri PR #12491); releases stay on the official bundler.
+      experimental_appimage: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
-env:
-  GH_TOKEN: ${{ SECRETS.GITHUB_TOKEN }}
+
+# Thin dispatcher over the reusable build matrix in build.yml — the single
+# place that defines platforms, signing and AppImage handling for every
+# channel (release + nightly), so the two can't drift apart again (the
+# v0.13.3 AppImage regression, issue #423, came from exactly that drift).
 on:
   push:
     tags:
@@ -15,39 +18,13 @@ on:
         required: false
 
 jobs:
-  publish-tauri:
-    permissions:
-      contents: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: "macos-latest" # for Arm64
-            args: "--target aarch64-apple-darwin"
-          - platform: "macos-15-intel" # for Intel
-            args: "--target x86_64-apple-darwin"
-          - platform: "ubuntu-24.04"
-            args: ""
-            # Build inside an ubuntu:22.04 container (glibc 2.35) rather than
-            # on the bare ubuntu-24.04 runner (glibc 2.39), so the produced
-            # .deb/.AppImage keep running on older LTS distros. Pinned to the
-            # container image, not the runner, so it's unaffected by GitHub's
-            # eventual deprecation of the ubuntu-22.04 *runner* image.
-            container: "ubuntu:22.04"
-          - platform: "windows-latest"
-            args: ""
-
-    runs-on: ${{ matrix.platform }}
-    container: ${{ matrix.container }}
+  meta:
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.meta.outputs.ref }}
+      tag: ${{ steps.meta.outputs.tag }}
+      prerelease: ${{ steps.meta.outputs.prerelease }}
     steps:
-      # libatomic1 is required by the standalone pnpm binary (@pnpm/exe), which
-      # pnpm/action-setup bootstraps here because it runs before setup-node and
-      # finds no Node in the container.
-      - name: Install container prerequisites (ubuntu container only)
-        if: matrix.container
-        run: |
-          apt-get update
-          apt-get install -y git ca-certificates curl libatomic1
       - name: Resolve build ref + tag
         id: meta
         shell: bash
@@ -72,98 +49,20 @@ jobs:
             fi
           fi
 
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ steps.meta.outputs.ref }}
+  publish-tauri:
+    needs: meta
+    permissions:
+      contents: write
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
+    with:
+      ref: ${{ needs.meta.outputs.ref }}
+      tag: ${{ needs.meta.outputs.tag }}
+      release_name: "v__VERSION__"
+      release_body: |
+        See the assets below to download this version and install.
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version-file: .node-version
-          cache: "pnpm"
-
-      - name: install Rust stable
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-        with:
-          # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin' || matrix.platform == 'macos-13' && 'x86_64-apple-darwin' || '' }}
-
-      - name: install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-24.04'
-        run: |
-          apt-get update
-          apt-get install -y \
-            build-essential \
-            curl \
-            wget \
-            file \
-            libssl-dev \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            libfuse2 \
-            libsoup-3.0-dev \
-            libwebkit2gtk-4.1-dev \
-            patchelf \
-            xdg-utils \
-            gstreamer1.0-plugins-base \
-            gstreamer1.0-plugins-bad \
-            fonts-noto-color-emoji \
-            pkg-config \
-            unzip
-
-      - name: install frontend dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Cache Rust dependencies
-        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          workspaces: src-tauri
-
-      # Notarization needs the App Store Connect API key on disk. The .p8 is stored
-      # base64-encoded in APPLE_API_KEY_CONTENT and decoded into a temp file (macOS only).
-      - name: Prepare Apple API key (macOS only)
-        if: startsWith(matrix.platform, 'macos')
-        shell: bash
-        run: |
-          echo "${{ secrets.APPLE_API_KEY_CONTENT }}" | base64 --decode > "$RUNNER_TEMP/apple_api_key.p8"
-          echo "APPLE_API_KEY_PATH=$RUNNER_TEMP/apple_api_key.p8" >> "$GITHUB_ENV"
-
-      - uses: tauri-apps/tauri-action@73fb865345c54760d875b94642314f8c0c894afa # v0.6.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
-          # macOS code signing (Developer ID Application certificate)
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          # macOS notarization (App Store Connect API key)
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-          APPLE_API_KEY_PATH: ${{ env.APPLE_API_KEY_PATH }}
-        with:
-          tagName: ${{ steps.meta.outputs.tag }}
-          releaseName: "v__VERSION__"
-          releaseBody: |
-            See the assets below to download this version and install.
-
-            ---
-            **Stay in touch:** [Website](https://tabularis.dev) · [Discord](https://discord.com/invite/K2hmhfHRSt) · [X](https://x.com/tabularisdb) · [Bluesky](https://bsky.app/profile/tabularis.bsky.social) · [Mastodon](https://mastodon.social/@tabularis) · [GitHub](https://github.com/TabularisDB/tabularis)
-          releaseDraft: true
-          prerelease: ${{ steps.meta.outputs.prerelease == 'true' }}
-          tauriScript: pnpm tauri
-          args: ${{ matrix.args }}
-
-      - name: Upload portable executable (Windows only)
-        if: matrix.platform == 'windows-latest'
-        shell: pwsh
-        run: |
-          $version = "${{ steps.meta.outputs.tag }}".TrimStart('v')
-          $src = "src-tauri\target\release\tabularis.exe"
-          $portable = "tabularis_${version}_x64-portable.exe"
-          Copy-Item $src $portable
-          gh release upload "${{ steps.meta.outputs.tag }}" $portable --clobber
+        ---
+        **Stay in touch:** [Website](https://tabularis.dev) · [Discord](https://discord.com/invite/K2hmhfHRSt) · [X](https://x.com/tabularisdb) · [Bluesky](https://bsky.app/profile/tabularis.bsky.social) · [Mastodon](https://mastodon.social/@tabularis) · [GitHub](https://github.com/TabularisDB/tabularis)
+      draft: true
+      prerelease: ${{ needs.meta.outputs.prerelease == 'true' }}


### PR DESCRIPTION
Fixes #423.

## Root cause

The AppImage bundles the build container's `libwayland-client/cursor/egl/server` (Ubuntu 22.04, libwayland ~1.20). On distros with a recent Mesa (Solus, up to date Arch) the host libEGL binds to that stale bundled `libwayland-client` instead of the system one, protocol marshalling doesn't match, and WebKitWebProcess aborts with `EGL_BAD_PARAMETER`, leaving a black window. This is a known class of AppImage breakage: the upstream excludelist added `libwayland-client.so.0` for exactly this reason (AppImageCommunity/pkg2appimage#559, referencing mesa#11316). The linuxdeploy binary pinned by tauri-cli predates that entry, and upstream has stated the linuxdeploy based bundler won't be worked on anymore (tauri-apps/tauri#8604), so waiting for a fix there is not an option.

The regression window matches the CI history: v0.13.2 was built with the custom `feat/truly-portable-appimage` tauri-cli and worked, then `fe592726` switched releases back to the official tauri-cli 2.11.4 and v0.13.3/v0.13.4 broke. Nightlies kept the custom CLI in `build.yml`, which is why they still work on Solus today. HelixNotes, mentioned in the issue as a working reference, actually ships the same four libwayland libs; theirs happen to be new enough (glibc 2.38 base) to still be compatible with current Mesa, so it is the same time bomb on a longer fuse rather than a different approach.

## What changed

**`.github/workflows/build.yml`**: the stable path (official tauri-cli) now pre-seeds a patched `linuxdeploy-plugin-gtk.sh` into the tauri tools cache. tauri-bundler only downloads that file when it is missing, so the patched copy is picked up and removes `libwayland-*.so*` from the AppDir at the end of the plugin run, before the squashfs is packed. The updater signature is computed afterwards and stays valid. The custom CLI override, `TAURI_BUNDLER_NEW_APPIMAGE_FORMAT` and the `cargo tauri` script are now gated behind a new `experimental_appimage` input (default false). Also added a `release_body` input so callers can set the release notes.

**`.github/workflows/release.yml`**: rewritten as a thin dispatcher: a `meta` job resolving ref/tag/prerelease (same logic as before, tag push or `pr_number`/`tag_name` dispatch) plus a `workflow_call` to `build.yml`. The duplicated matrix, signing and notarization config is gone, which is what allowed the two channels to drift apart and cause this regression in the first place. As a side effect releases inherit the correct Rust target condition for `macos-15-intel` (the old copy still referenced `macos-13`).

**`.github/workflows/nightly.yml`**: passes `experimental_appimage: true`, so nightlies keep building the sharun based format from tauri-apps/tauri#12491 unchanged and keep serving as its daily canary until that PR stabilises.

## Verification

- Local build with the patched plugin pre-seeded in an isolated `XDG_CACHE_HOME`: the produced AppImage contains 0 `libwayland-*` files (the published v0.18.0 contains 4), the rest of the bundle is unchanged, and the app starts cleanly with host libwayland (GTK/WebKit up, no EGL errors).
- Workflow YAML parsed and expressions checked; the heredoc in the patch step dedents correctly.
- CI-fidelity check: a prerelease will be dispatched from this PR (`pr_number` + `v0.18.1-appimage-test.1`) so the Solus reporters in #423 can test the artifact built in the ubuntu:22.04 container before this merges.

CI YAML only, no code symbols touched (GitNexus impact analysis n/a).
