### PR TITLE
fix(connection-catalogue): clean up engine card layout and naming

### DIFF
--- a/src/components/modals/connection/EngineCard.tsx
+++ b/src/components/modals/connection/EngineCard.tsx
@@ -5,7 +5,9 @@ import { useTranslation } from "react-i18next";
 
 import type { PluginManifest } from "../../../types/plugins";
 import type { CatalogueDriver, EngineGroup } from "../../../utils/connectionCatalogue";
+import { labelForParadigm } from "../../../utils/connectionCatalogue";
 import { getDriverIcon } from "../../../utils/driverUI";
+import { RegistryDriverIcon } from "./RegistryDriverIcon";
 
 interface EngineCardProps {
   group: EngineGroup;
@@ -32,7 +34,7 @@ function accentFor(group: EngineGroup, rep: CatalogueDriver): string {
 function renderIcon(rep: CatalogueDriver) {
   const icon = rep.icon ?? "";
   if (/^https?:\/\//.test(icon) || icon.startsWith("data:")) {
-    return <img src={icon} alt="" className="h-6 w-6 rounded object-contain" />;
+    return <RegistryDriverIcon src={icon} size={24} fallback={<Database size={20} />} />;
   }
   if (rep.isBuiltin) {
     return getDriverIcon({ icon, color: rep.color ?? undefined } as PluginManifest, 22);
@@ -63,11 +65,10 @@ export function EngineCard({ group, onSelect }: EngineCardProps) {
       onClick={() => onSelect(group)}
       style={{ "--accent": accent } as CSSProperties}
       className={clsx(
-        "group relative flex cursor-pointer items-center gap-3 overflow-hidden rounded-xl border p-3 text-left",
+        "group relative flex cursor-pointer flex-col gap-2 overflow-hidden rounded-xl border p-3 text-left",
         "border-default bg-surface-secondary transition-all duration-150",
         "hover:-translate-y-px hover:border-[var(--accent)] hover:bg-surface hover:shadow-md hover:shadow-black/5",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/50",
-        unsupported && "opacity-60",
       )}
     >
       {/* accent rail */}
@@ -77,21 +78,28 @@ export function EngineCard({ group, onSelect }: EngineCardProps) {
         style={{ backgroundColor: accent }}
       />
 
-      {/* icon tile */}
-      <span
-        className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg"
-        style={{ backgroundColor: `${accent}1f`, color: accent }}
-      >
-        {renderIcon(rep)}
-      </span>
+      {/* header row: icon · name · status */}
+      <span className="flex w-full items-center gap-2.5">
+        {/* icon tile — dimmed instead of the whole card so the text stays readable */}
+        <span
+          className={clsx(
+            "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg",
+            unsupported && "opacity-50 grayscale",
+          )}
+          style={{ backgroundColor: `${accent}1f`, color: accent }}
+        >
+          {renderIcon(rep)}
+        </span>
 
-      {/* body */}
-      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span className="flex items-center gap-1.5">
-          <span className="truncate font-semibold text-primary capitalize">{group.displayName}</span>
+        {/* name wraps (up to 2 lines) instead of truncating; icon stays glued to the last word */}
+        <span
+          className="line-clamp-2 min-w-0 flex-1 font-semibold leading-snug text-primary [overflow-wrap:anywhere]"
+          title={group.displayName}
+        >
+          {group.displayName}
           {group.verified && (
             <span
-              className="inline-flex shrink-0 items-center text-blue-400"
+              className="ml-1.5 inline-flex translate-y-px items-center align-baseline text-blue-400"
               title={t("connectionCatalogue.verified", { defaultValue: "Verified" })}
             >
               <ShieldCheck size={13} aria-hidden />
@@ -99,42 +107,44 @@ export function EngineCard({ group, onSelect }: EngineCardProps) {
             </span>
           )}
         </span>
-        <span className="flex items-center gap-1 text-[11px] text-muted">
-          <span className="capitalize">{group.primaryParadigm}</span>
-          {group.secondaryParadigms.length > 0 && (
-            <span className="text-muted/70">· +{group.secondaryParadigms.length}</span>
-          )}
-          {driverCount > 1 && (
-            <span className="text-muted/70">
-              · {t("connectionCatalogue.driverCount", { count: driverCount, defaultValue: "{{count}} drivers" })}
-            </span>
-          )}
-        </span>
-      </span>
 
-      {/* trailing status */}
-      <span className="flex shrink-0 flex-col items-end gap-1">
+        {/* trailing status */}
         {group.installed ? (
-          <span className="flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-semibold text-emerald-400">
+          <span className="flex shrink-0 items-center gap-1 whitespace-nowrap rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-semibold text-emerald-400">
             <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
             {t("connectionCatalogue.installed", { defaultValue: "Installed" })}
           </span>
         ) : unsupported ? (
           <span
-            className="flex items-center gap-1 rounded-full border border-amber-500/30 px-2 py-0.5 text-[10px] font-medium text-amber-400"
+            className="flex shrink-0 items-center gap-1 whitespace-nowrap rounded-full border border-amber-500/30 px-2 py-0.5 text-[10px] font-medium text-amber-400"
             title={t("connectionCatalogue.unavailableOnPlatform", { defaultValue: "Unavailable on your platform" })}
           >
             <MonitorOff size={10} aria-hidden />
-            {t("connectionCatalogue.unavailableOnPlatform", { defaultValue: "Unavailable on your platform" })}
+            {t("connectionCatalogue.unavailable", { defaultValue: "Unavailable" })}
           </span>
         ) : (
-          <span className="rounded-full border border-default px-2 py-0.5 text-[10px] font-medium text-muted opacity-0 transition-opacity group-hover:opacity-100">
+          <span className="shrink-0 whitespace-nowrap rounded-full border border-default px-2 py-0.5 text-[10px] font-medium text-muted transition-colors group-hover:border-[var(--accent)] group-hover:text-primary">
             {t("connectionCatalogue.install", { defaultValue: "Install" })}
           </span>
         )}
+      </span>
+
+      {/* meta row, full card width: paradigm (+n) · drivers · downloads */}
+      <span className="block w-full truncate text-[11px] text-muted">
+        {labelForParadigm(group.primaryParadigm)}
+        {group.secondaryParadigms.length > 0 && (
+          <span className="text-muted/70"> +{group.secondaryParadigms.length}</span>
+        )}
+        {driverCount > 1 && (
+          <span className="text-muted/70">
+            {" · "}
+            {t("connectionCatalogue.driverCount", { count: driverCount, defaultValue: "{{count}} drivers" })}
+          </span>
+        )}
         {group.downloads != null && (
-          <span className="flex items-center gap-0.5 text-[10px] text-muted">
-            <Download size={10} />
+          <span className="text-muted/70">
+            {" · "}
+            <Download size={10} className="inline -translate-y-px" aria-hidden />
             {formatCount(group.downloads)}
           </span>
         )}

--- a/src/components/modals/connection/InstallGate.tsx
+++ b/src/components/modals/connection/InstallGate.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { CatalogueDriver } from "../../../utils/connectionCatalogue";
+import { RegistryDriverIcon } from "./RegistryDriverIcon";
 
 export type InstallStatus = "idle" | "installing" | "error";
 
@@ -31,7 +32,7 @@ function accentFor(driver: CatalogueDriver): string {
 function renderIcon(driver: CatalogueDriver) {
   const icon = driver.icon ?? "";
   if (/^https?:\/\//.test(icon) || icon.startsWith("data:")) {
-    return <img src={icon} alt="" className="h-8 w-8 rounded object-contain" />;
+    return <RegistryDriverIcon src={icon} size={32} fallback={<Database size={26} />} />;
   }
   return <Database size={26} />;
 }

--- a/src/components/modals/connection/RegistryDriverIcon.tsx
+++ b/src/components/modals/connection/RegistryDriverIcon.tsx
@@ -1,0 +1,29 @@
+import { useState } from "react";
+import type { ReactNode } from "react";
+
+interface RegistryDriverIconProps {
+  /** Icon URL served by the registry (http(s) or data URI). */
+  src: string;
+  /** Rendered square size of the image in px. */
+  size: number;
+  /** Shown instead of the image when the URL fails to load. */
+  fallback: ReactNode;
+}
+
+/**
+ * Remote driver icon that swaps to the generic fallback when the registry
+ * URL is broken or unreachable, instead of leaving an invisible broken <img>.
+ */
+export function RegistryDriverIcon({ src, size, fallback }: RegistryDriverIconProps) {
+  const [failed, setFailed] = useState(false);
+  if (failed) return <>{fallback}</>;
+  return (
+    <img
+      src={src}
+      alt=""
+      style={{ width: size, height: size }}
+      className="rounded object-contain"
+      onError={() => setFailed(true)}
+    />
+  );
+}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -2038,6 +2038,7 @@
     "driverCount_other": "{{count}} Treiber",
     "connectTo": "Mit {{name}} verbinden",
     "unavailableOnPlatform": "Auf deiner Plattform nicht verfügbar",
+    "unavailable": "Nicht verfügbar",
     "backToCatalogue": "Zurück zum Katalog",
     "pickDriver": "Mehrere Treiber verbinden sich mit {{name}}. Wähle einen:",
     "latestVersion": "Neueste v{{version}}",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2127,6 +2127,7 @@
     "driverCount_other": "{{count}} drivers",
     "connectTo": "Connect to {{name}}",
     "unavailableOnPlatform": "Unavailable on your platform",
+    "unavailable": "Unavailable",
     "backToCatalogue": "Back to catalogue",
     "pickDriver": "Multiple drivers connect to {{name}}. Pick one:",
     "latestVersion": "Latest v{{version}}",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1960,6 +1960,7 @@
     "driverCount_other": "{{count}} controladores",
     "connectTo": "Conectar a {{name}}",
     "unavailableOnPlatform": "No disponible en tu plataforma",
+    "unavailable": "No disponible",
     "backToCatalogue": "Volver al catálogo",
     "pickDriver": "Varios controladores se conectan a {{name}}. Elige uno:",
     "latestVersion": "Última v{{version}}",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -2116,6 +2116,7 @@
     "driverCount_other": "{{count}} pilotes",
     "connectTo": "Se connecter à {{name}}",
     "unavailableOnPlatform": "Indisponible sur votre plateforme",
+    "unavailable": "Indisponible",
     "backToCatalogue": "Retour au catalogue",
     "pickDriver": "Plusieurs pilotes se connectent à {{name}}. Choisissez-en un :",
     "latestVersion": "Dernière v{{version}}",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -2040,6 +2040,7 @@
     "driverCount_other": "{{count}} driver",
     "connectTo": "Connetti a {{name}}",
     "unavailableOnPlatform": "Non disponibile sulla tua piattaforma",
+    "unavailable": "Non disponibile",
     "backToCatalogue": "Torna al catalogo",
     "pickDriver": "Più driver si connettono a {{name}}. Scegline uno:",
     "latestVersion": "Ultima v{{version}}",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2056,6 +2056,7 @@
     "driverCount_other": "{{count}} 個のドライバー",
     "connectTo": "{{name}} に接続",
     "unavailableOnPlatform": "お使いのプラットフォームでは利用できません",
+    "unavailable": "利用不可",
     "backToCatalogue": "カタログに戻る",
     "pickDriver": "複数のドライバーが {{name}} に接続します。1つ選択してください：",
     "latestVersion": "最新 v{{version}}",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -2089,6 +2089,7 @@
     "driverCount_other": "{{count}} drivers",
     "connectTo": "Conectar a {{name}}",
     "unavailableOnPlatform": "Indisponível na sua plataforma",
+    "unavailable": "Indisponível",
     "backToCatalogue": "Voltar ao catálogo",
     "pickDriver": "Vários drivers se conectam a {{name}}. Escolha um:",
     "latestVersion": "Mais recente v{{version}}",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1978,6 +1978,7 @@
     "driverCount_other": "{{count}} 个驱动程序",
     "connectTo": "连接到 {{name}}",
     "unavailableOnPlatform": "在您的平台上不可用",
+    "unavailable": "不可用",
     "backToCatalogue": "返回目录",
     "pickDriver": "多个驱动程序可连接到 {{name}}。请选择一个：",
     "latestVersion": "最新 v{{version}}",

--- a/src/utils/connectionCatalogue.ts
+++ b/src/utils/connectionCatalogue.ts
@@ -118,6 +118,39 @@ export interface EngineSelection {
   driver?: CatalogueDriver;
 }
 
+/** Proper-noun spellings for engines whose names simple title-casing gets wrong. */
+const ENGINE_DISPLAY_NAMES: Record<string, string> = {
+  csv: 'CSV',
+  postgres: 'PostgreSQL',
+  postgresql: 'PostgreSQL',
+  mysql: 'MySQL',
+  sqlite: 'SQLite',
+  mariadb: 'MariaDB',
+  mongodb: 'MongoDB',
+  'mongodb-atlas': 'MongoDB Atlas',
+  mssql: 'SQL Server',
+  sqlserver: 'SQL Server',
+  clickhouse: 'ClickHouse',
+  cockroachdb: 'CockroachDB',
+  duckdb: 'DuckDB',
+  dynamodb: 'DynamoDB',
+  couchdb: 'CouchDB',
+};
+
+/**
+ * Human-readable name for an engine slug: known proper noun when we have one,
+ * otherwise title-cased words ("vector-db" → "Vector Db").
+ */
+export function engineDisplayName(engine: string): string {
+  const known = ENGINE_DISPLAY_NAMES[engine.toLowerCase()];
+  if (known) return known;
+  return engine
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
 export function groupByEngine(drivers: CatalogueDriver[]): EngineGroup[] {
   const map = new Map<string, CatalogueDriver[]>();
   for (const d of drivers) {
@@ -138,7 +171,9 @@ export function groupByEngine(drivers: CatalogueDriver[]): EngineGroup[] {
     );
     groups.push({
       engine,
-      displayName: representative.name,
+      // The card represents the engine, not whichever plugin happens to be
+      // first in the group — driver names show up in the driver picker.
+      displayName: engineDisplayName(engine),
       primaryParadigm,
       secondaryParadigms: [...allParadigms],
       drivers: list,
@@ -175,7 +210,7 @@ export function paradigmFacets(groups: EngineGroup[]): ParadigmFacet[] {
     .sort((a, b) => b.count - a.count || a.key.localeCompare(b.key));
 }
 
-function labelForParadigm(key: string): string {
+export function labelForParadigm(key: string): string {
   if (key === 'sql') return 'SQL';
   if (key === 'nosql') return 'NoSQL';
   return key.charAt(0).toUpperCase() + key.slice(1);

--- a/tests/components/connection/EngineCard.test.tsx
+++ b/tests/components/connection/EngineCard.test.tsx
@@ -31,7 +31,9 @@ describe('EngineCard', () => {
 
   it('marks a group with no platform build as unavailable', () => {
     render(<EngineCard group={{ ...group, installed: false, platformSupported: false }} onSelect={vi.fn()} />);
-    expect(screen.getByText(/connectionCatalogue\.unavailableOnPlatform/i)).toBeInTheDocument();
+    // Badge shows the short label; the full sentence lives in the tooltip.
+    expect(screen.getByText(/connectionCatalogue\.unavailable$/i)).toBeInTheDocument();
+    expect(screen.getByTitle(/connectionCatalogue\.unavailableOnPlatform/i)).toBeInTheDocument();
     expect(screen.queryByText(/connectionCatalogue\.install$/i)).not.toBeInTheDocument();
   });
 

--- a/tests/utils/connectionCatalogue.test.ts
+++ b/tests/utils/connectionCatalogue.test.ts
@@ -3,6 +3,7 @@ import {
   toCatalogueDriver,
   builtinToCatalogueDriver,
   localPluginToCatalogueDriver,
+  engineDisplayName,
   groupByEngine,
   paradigmFacets,
   filterCatalogue,
@@ -141,6 +142,27 @@ describe('connectionCatalogue', () => {
       const d = toCatalogueDriver(registryPlugin({ id: 'weird', engine: 'weird', paradigms: [] }));
       const groups = groupByEngine([d]);
       expect(groups[0].primaryParadigm).toBe('other');
+    });
+
+    it('titles the group after the engine, not the first driver name', () => {
+      const d = toCatalogueDriver(
+        registryPlugin({ id: 'mongodb-atlas-driver', name: 'mongodb-atlas', engine: 'mongodb' }),
+      );
+      expect(groupByEngine([d])[0].displayName).toBe('MongoDB');
+    });
+  });
+
+  describe('engineDisplayName', () => {
+    it('uses the proper-noun spelling for known engines', () => {
+      expect(engineDisplayName('postgres')).toBe('PostgreSQL');
+      expect(engineDisplayName('mongodb-atlas')).toBe('MongoDB Atlas');
+      expect(engineDisplayName('MSSQL')).toBe('SQL Server');
+    });
+
+    it('title-cases unknown slugs word by word', () => {
+      expect(engineDisplayName('qdrant')).toBe('Qdrant');
+      expect(engineDisplayName('vector-db')).toBe('Vector Db');
+      expect(engineDisplayName('time_series')).toBe('Time Series');
     });
   });
 


### PR DESCRIPTION
The engine cards in the connection catalogue had a handful of visual problems that showed up as soon as the registry had real content in it:

- Card titles came straight from the plugin name on the registry, so you got things like "Mongodb-Atlas" instead of the database name
- The "Unavailable on your platform" badge was so long it squeezed the title down to a few characters, and the whole card was dimmed on top of that
- The meta line wrapped and got clipped mid-word ("2 drive:")
- A registry icon URL that failed to load left an empty tile
- Paradigm labels went through CSS capitalize, so "sql" rendered as "Sql"

### What changed

Cards are now titled after the engine, not whichever plugin happens to be first in the group. `engineDisplayName()` maps known engines to their proper spelling (PostgreSQL, MongoDB Atlas, SQL Server, CSV, ...) and title-cases anything it doesn't know. Individual driver names still show where they belong: in the driver picker and the install screen.

The card layout is reworked into two rows: icon, name and status badge on top, then a full-width meta line (paradigm, driver count, downloads) that ellipsizes instead of clipping. Names wrap to a second line rather than truncating, and the verified shield stays glued to the last word of the name instead of dropping to its own line.

For unsupported platforms the badge now just says "Unavailable" with the full sentence in a tooltip, and only the icon gets dimmed so the text stays readable. The "Install" hint is always visible instead of only appearing on hover.

New `RegistryDriverIcon` component swaps in the generic database icon when a registry icon URL fails to load. Used by both `EngineCard` and `InstallGate`.

### Notes

- New i18n key `connectionCatalogue.unavailable`, translated in all eight locales
- Tests added for `engineDisplayName` and the engine-based group title
- ClickHouse, DuckDB etc. still land in the "Other" section because their registry manifests don't declare `paradigms`; that needs fixing on the Tabularium side, not here