### PR TITLE
fix(inputs): suppress macOS WKWebView text hints on all technical fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,7 @@
 <!doctype html>
-<html lang="en">
+<!-- spellcheck="false" sets the inherited default for the whole document (WKWebView/macOS
+     text helpers). Natural-language prose fields opt back in with spellCheck={true}. -->
+<html lang="en" spellcheck="false">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/src/components/connections/GroupHeader.tsx
+++ b/src/components/connections/GroupHeader.tsx
@@ -69,7 +69,7 @@ export const GroupHeader = ({
       <FolderOpen size={16} className="text-amber-400" />
     )}
     {editingGroupId === group.id ? (
-      <input
+      <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
         type="text"
         value={editGroupName}
         onChange={(e) => setEditGroupName(e.target.value)}

--- a/src/components/layout/ExplorerSidebar.tsx
+++ b/src/components/layout/ExplorerSidebar.tsx
@@ -780,7 +780,7 @@ export const ExplorerSidebar = ({ sidebarWidth, startResize, onCollapse, sidebar
                       size={12}
                       className="absolute left-2 top-1/2 -translate-y-1/2 text-muted"
                     />
-                    <input
+                    <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                       type="text"
                       value={favoritesFilter}
                       onChange={(e) => setFavoritesFilter(e.target.value)}
@@ -1364,7 +1364,7 @@ export const ExplorerSidebar = ({ sidebarWidth, startResize, onCollapse, sidebar
                   <div className="px-3 pb-1.5">
                     <div className="relative flex items-center">
                       <Search size={11} className="absolute left-2 text-muted pointer-events-none" />
-                      <input
+                      <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                         type="text"
                         value={dbFilter}
                         onChange={(e) => setDbFilter(e.target.value)}
@@ -1541,7 +1541,7 @@ export const ExplorerSidebar = ({ sidebarWidth, startResize, onCollapse, sidebar
                       <div className="px-2 py-1">
                         <div className="relative flex items-center">
                           <Search size={11} className="absolute left-2 text-muted pointer-events-none" />
-                          <input
+                          <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                             type="text"
                             data-table-filter
                             value={tableFilter}
@@ -1726,7 +1726,7 @@ export const ExplorerSidebar = ({ sidebarWidth, startResize, onCollapse, sidebar
                         <div className="px-2 py-1">
                           <div className="relative flex items-center">
                             <Search size={11} className="absolute left-2 text-muted pointer-events-none" />
-                            <input
+                            <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                               type="text"
                               value={triggerFilterFlat}
                               onChange={(e) => setTriggerFilterFlat(e.target.value)}

--- a/src/components/layout/sidebar/NotebooksSection.tsx
+++ b/src/components/layout/sidebar/NotebooksSection.tsx
@@ -230,7 +230,7 @@ export function NotebooksSection({
             size={12}
             className="absolute left-2 top-1/2 -translate-y-1/2 text-muted"
           />
-          <input
+          <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
             type="text"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
@@ -280,7 +280,7 @@ export function NotebooksSection({
             title={nb.title}
           >
             {editingId === nb.id ? (
-              <input
+              <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                 type="text"
                 value={editingTitle}
                 autoFocus

--- a/src/components/layout/sidebar/QueryHistorySection.tsx
+++ b/src/components/layout/sidebar/QueryHistorySection.tsx
@@ -115,7 +115,7 @@ export function QueryHistorySection({
             size={12}
             className="absolute left-2 top-1/2 -translate-y-1/2 text-muted"
           />
-          <input
+          <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
             type="text"
             value={search}
             onChange={(e) => setSearch(e.target.value)}

--- a/src/components/layout/sidebar/SidebarDatabaseItem.tsx
+++ b/src/components/layout/sidebar/SidebarDatabaseItem.tsx
@@ -261,7 +261,7 @@ export const SidebarDatabaseItem = ({
                   <div className="px-2 py-1">
                     <div className="relative flex items-center">
                       <Search size={11} className="absolute left-2 text-muted pointer-events-none" />
-                      <input
+                      <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                         type="text"
                         data-table-filter
                         value={tableFilter}
@@ -382,7 +382,7 @@ export const SidebarDatabaseItem = ({
                     <div className="px-2 py-1">
                       <div className="relative flex items-center">
                         <Search size={11} className="absolute left-2 text-muted pointer-events-none" />
-                        <input
+                        <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                           type="text"
                           value={triggerFilter}
                           onChange={(e) => setTriggerFilter(e.target.value)}

--- a/src/components/layout/sidebar/SidebarSchemaItem.tsx
+++ b/src/components/layout/sidebar/SidebarSchemaItem.tsx
@@ -219,7 +219,7 @@ export const SidebarSchemaItem = ({
                   <div className="px-2 py-1">
                     <div className="relative flex items-center">
                       <Search size={11} className="absolute left-2 text-muted pointer-events-none" />
-                      <input
+                      <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                         type="text"
                         data-table-filter
                         value={tableFilter}
@@ -365,7 +365,7 @@ export const SidebarSchemaItem = ({
                     <div className="px-2 py-1">
                       <div className="relative flex items-center">
                         <Search size={11} className="absolute left-2 text-muted pointer-events-none" />
-                        <input
+                        <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                           type="text"
                           value={triggerFilter}
                           onChange={(e) => setTriggerFilter(e.target.value)}

--- a/src/components/modals/AiApprovalModal.tsx
+++ b/src/components/modals/AiApprovalModal.tsx
@@ -234,7 +234,8 @@ export function AiApprovalModal({
             <label className="text-xs uppercase font-bold text-muted mb-2 block">
               {t("aiApproval.reasonLabel")}
             </label>
-            <input
+            {/* Prose field: natural-language input, so spellcheck/autocorrect stay ON; only the WebKit autofill pill is disabled. */}
+            <input autoComplete="off" spellCheck={true}
               type="text"
               value={reason}
               onChange={(e) => setReason(e.target.value)}

--- a/src/components/modals/AiQueryModal.tsx
+++ b/src/components/modals/AiQueryModal.tsx
@@ -157,7 +157,8 @@ export const AiQueryModal = ({
             <label className="block text-sm font-medium text-secondary mb-2">
               Describe your query in natural language
             </label>
-            <textarea
+            {/* Prose field: natural-language input, so spellcheck/autocorrect stay ON; only the WebKit autofill pill is disabled. */}
+            <textarea autoComplete="off" spellCheck={true}
               value={prompt}
               onChange={(e) => setPrompt(e.target.value)}
               placeholder="e.g. Find all users who signed up last month and ordered a 'Premium' plan..."

--- a/src/components/modals/ClipboardImport/SchemaEditor.tsx
+++ b/src/components/modals/ClipboardImport/SchemaEditor.tsx
@@ -228,7 +228,7 @@ export function SchemaEditor({
                       {isAppend && !col.isNewColumn ? (
                         <span className="w-full text-sm text-primary font-mono truncate">{col.name}</span>
                       ) : (
-                        <input
+                        <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                           value={col.name}
                           onChange={(e) => onColumnChange(i, { name: e.target.value })}
                           className="w-full bg-transparent text-sm text-primary focus:outline-none border-b border-transparent focus:border-blue-500 font-mono"

--- a/src/components/modals/ClipboardImport/TableNameInput.tsx
+++ b/src/components/modals/ClipboardImport/TableNameInput.tsx
@@ -27,7 +27,7 @@ export function TableNameInput({
       </label>
       <div className="flex gap-2">
         <div className="relative flex-1">
-          <input
+          <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
             value={value}
             onChange={(e) => onChange(e.target.value)}
             placeholder={t('clipboardImport.tableNamePlaceholder')}

--- a/src/components/modals/CreateForeignKeyModal.tsx
+++ b/src/components/modals/CreateForeignKeyModal.tsx
@@ -198,7 +198,7 @@ export const CreateForeignKeyModal = ({
 
             <div>
                 <label className="block text-xs uppercase font-bold text-muted mb-1">{t('createFk.name')}</label>
-                <input
+                <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                     value={fkName}
                     onChange={(e) => { setFkName(e.target.value); setError(''); }}
                     autoFocus

--- a/src/components/modals/CreateIndexModal.tsx
+++ b/src/components/modals/CreateIndexModal.tsx
@@ -140,7 +140,7 @@ export const CreateIndexModal = ({
         <div className="p-6 flex flex-col gap-4 overflow-y-auto">
             <div>
                 <label className="block text-xs uppercase font-bold text-muted mb-1">{t('createIndex.name')}</label>
-                <input
+                <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                     value={indexName}
                     onChange={(e) => { setIndexName(e.target.value); setError(''); }}
                     className={`w-full bg-base border rounded-lg px-3 py-2 text-primary text-sm focus:border-blue-500 focus:outline-none font-mono ${!indexName.trim() && error ? 'border-red-500' : 'border-strong'}`}

--- a/src/components/modals/CreateTableModal.tsx
+++ b/src/components/modals/CreateTableModal.tsx
@@ -182,7 +182,7 @@ export const CreateTableModal = ({ isOpen, onClose, onSuccess, schema }: CreateT
             {/* Table Name */}
             <div>
                 <label className="block text-xs uppercase font-bold text-muted mb-1">{t('createTable.tableName')}</label>
-                <input
+                <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                     value={tableName}
                     onChange={(e) => { setTableName(e.target.value); setError(''); }}
                     className={`w-full bg-base border rounded-lg px-3 py-2 text-primary focus:border-blue-500 focus:outline-none transition-all font-mono ${!tableName.trim() && error ? 'border-red-500' : 'border-strong'}`}
@@ -220,7 +220,7 @@ export const CreateTableModal = ({ isOpen, onClose, onSuccess, schema }: CreateT
                                 <tr key={col.id} className="hover:bg-surface-secondary/30 group">
                                     <td className="p-2 w-8"></td>
                                     <td className="p-2">
-                                        <input
+                                        <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                                             value={col.name}
                                             onChange={(e) => updateColumn(col.id, 'name', e.target.value)}
                                             className={`w-full bg-transparent text-sm text-primary focus:outline-none border-b font-mono placeholder:text-muted ${!col.name.trim() ? 'border-red-500/50' : 'border-transparent focus:border-blue-500'}`}
@@ -249,7 +249,7 @@ export const CreateTableModal = ({ isOpen, onClose, onSuccess, schema }: CreateT
                                         />
                                     </td>
                                     <td className="p-2">
-                                        <input
+                                        <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                                             value={col.length}
                                             onChange={(e) => updateColumn(col.id, 'length', e.target.value)}
                                             className="w-full bg-transparent text-xs text-secondary focus:outline-none border-b border-transparent focus:border-blue-500 text-center disabled:opacity-30"
@@ -287,7 +287,7 @@ export const CreateTableModal = ({ isOpen, onClose, onSuccess, schema }: CreateT
                                         />
                                     </td>
                                     <td className="p-2">
-                                         <input
+                                         <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                                             value={col.isAutoInc ? '' : col.defaultValue}
                                             onChange={(e) => updateColumn(col.id, 'defaultValue', e.target.value)}
                                             disabled={col.isAutoInc}

--- a/src/components/modals/ImportFromAppModal.tsx
+++ b/src/components/modals/ImportFromAppModal.tsx
@@ -714,7 +714,7 @@ const BulkGroupSelector = ({
           </div>
           {value === GROUP_NEW && (
             <div className="mt-2 flex items-center gap-2">
-              <input
+              <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                 type="text"
                 value={newGroupName}
                 autoFocus
@@ -900,7 +900,7 @@ const PreviewRow = ({
           />
           {groupChoice === GROUP_NEW && (
             <>
-              <input
+              <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                 type="text"
                 value={newGroupName}
                 onChange={(e) => onNewGroupNameChange(e.target.value)}

--- a/src/components/modals/K8sConnectionsModal.tsx
+++ b/src/components/modals/K8sConnectionsModal.tsx
@@ -903,7 +903,7 @@ function EditForm({
     <div className="space-y-3">
       <div>
         <label className={LabelClass}>{t("k8sConnections.name")}</label>
-        <input
+        <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
           value={name}
           onChange={(event) => setName(event.target.value)}
           className={InputClass}
@@ -999,7 +999,7 @@ function EditForm({
 
       <div>
         <label className={LabelClass}>{t("k8sConnections.port")}</label>
-        <input
+        <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
           type="number"
           value={port ?? ""}
           onChange={(event) =>

--- a/src/components/modals/ModifyColumnModal.tsx
+++ b/src/components/modals/ModifyColumnModal.tsx
@@ -229,7 +229,7 @@ export const ModifyColumnModal = ({
             <label className="block text-xs uppercase font-bold text-muted mb-1">
               {t("modifyColumn.name")}
             </label>
-            <input
+            <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
               value={form.name}
               onChange={(e) => { setForm({ ...form, name: e.target.value }); setError(""); }}
               className={`w-full bg-base border rounded-lg px-3 py-2 text-primary text-sm focus:border-blue-500 focus:outline-none font-mono ${!form.name.trim() && error ? 'border-red-500' : 'border-strong'}`}
@@ -274,7 +274,7 @@ export const ModifyColumnModal = ({
               <label className="block text-xs uppercase font-bold text-muted mb-1">
                 {t("modifyColumn.length")}
               </label>
-              <input
+              <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                 value={form.length}
                 onChange={(e) => setForm({ ...form, length: e.target.value })}
                 disabled={
@@ -295,7 +295,7 @@ export const ModifyColumnModal = ({
               <label className="block text-xs uppercase font-bold text-muted mb-1">
                 {t("modifyColumn.default")}
               </label>
-              <input
+              <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                 value={form.isAutoInc ? "" : form.defaultValue}
                 onChange={(e) =>
                   setForm({ ...form, defaultValue: e.target.value })

--- a/src/components/modals/NewConnectionModal/TagSelector.tsx
+++ b/src/components/modals/NewConnectionModal/TagSelector.tsx
@@ -185,7 +185,7 @@ export function TagSelector({ selectedIds, onChange }: TagSelectorProps) {
             </button>
           ) : (
             <div className="flex items-center gap-2 flex-wrap w-full mt-1 p-2 rounded-lg border border-strong bg-base">
-              <input
+              <input autoCorrect="off" autoCapitalize="off" autoComplete="off"
                 type="text"
                 value={newName}
                 onChange={(e) => setNewName(e.target.value)}
@@ -235,7 +235,7 @@ export function TagSelector({ selectedIds, onChange }: TagSelectorProps) {
                 key={tag.id}
                 className="flex items-center gap-2 flex-wrap p-2 rounded-lg border border-strong bg-base"
               >
-                <input
+                <input autoCorrect="off" autoCapitalize="off" autoComplete="off"
                   type="text"
                   value={editName}
                   onChange={(e) => setEditName(e.target.value)}

--- a/src/components/modals/NewRowModal.tsx
+++ b/src/components/modals/NewRowModal.tsx
@@ -347,7 +347,7 @@ export const NewRowModal = ({
                           `}
                     />
                   ) : (
-                    <input
+                    <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                       disabled={col.is_generated}
                       value={String(formData[col.name] ?? "")}
                       onChange={(e) =>

--- a/src/components/modals/PluginSettingsModal.tsx
+++ b/src/components/modals/PluginSettingsModal.tsx
@@ -154,7 +154,7 @@ export const PluginSettingsModal = ({
     if (def.type === "number") {
       return (
         <div className="flex items-start gap-2">
-          <input
+          <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
             type="number"
             value={typeof value === "number" ? value : ""}
             onChange={(e) => handleDynamicChange(def.key, e.target.value === "" ? undefined : Number(e.target.value))}
@@ -167,7 +167,7 @@ export const PluginSettingsModal = ({
 
     return (
       <div className="flex items-start gap-2">
-        <input
+        <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
           type="text"
           value={typeof value === "string" ? value : ""}
           onChange={(e) => handleDynamicChange(def.key, e.target.value)}
@@ -210,7 +210,7 @@ export const PluginSettingsModal = ({
               {t("settings.plugins.pluginSettings.interpreterDesc")}
             </p>
             <div className="flex gap-2">
-              <input
+              <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                 type="text"
                 value={interpreter}
                 placeholder={t("settings.plugins.pluginSettings.interpreterPlaceholder")}

--- a/src/components/modals/QueryModal.tsx
+++ b/src/components/modals/QueryModal.tsx
@@ -75,7 +75,7 @@ export const QueryModal = ({ isOpen, onClose, onSave, initialName = '', initialS
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label className="block text-sm font-medium text-secondary mb-1">Name</label>
-            <input
+            <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}

--- a/src/components/modals/QueryParamsModal.tsx
+++ b/src/components/modals/QueryParamsModal.tsx
@@ -77,7 +77,7 @@ const QueryParamsForm = ({ parameters, initialValues, onSubmit, onClose, mode }:
                 <label className="text-xs font-medium text-secondary font-mono">
                   :{param}
                 </label>
-                <input
+                <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                   type="text"
                   value={values[param] || ""}
                   onChange={(e) => handleChange(param, e.target.value)}

--- a/src/components/modals/RunRoutineModal.tsx
+++ b/src/components/modals/RunRoutineModal.tsx
@@ -166,7 +166,7 @@ export const RunRoutineModal = ({
                     </div>
                   ) : (
                     <div className="flex items-center gap-3">
-                      <input
+                      <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                         type="text"
                         value={input.isNull ? "" : input.value}
                         disabled={input.isNull}

--- a/src/components/modals/SshAskpassModal.tsx
+++ b/src/components/modals/SshAskpassModal.tsx
@@ -85,7 +85,7 @@ export const SshAskpassModal = ({
           </p>
 
           {isSecret && (
-            <input
+            <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
               type="password"
               value={value}
               onChange={(e) => setValue(e.target.value)}

--- a/src/components/modals/TriggerEditorModal.tsx
+++ b/src/components/modals/TriggerEditorModal.tsx
@@ -270,7 +270,7 @@ export const TriggerEditorModal = ({
                 <label htmlFor="trigger-name" className="text-xs uppercase font-bold text-muted mb-1 block">
                   {t("triggers.triggerName")}
                 </label>
-                <input
+                <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                   id="trigger-name"
                   type="text"
                   value={name}
@@ -287,7 +287,7 @@ export const TriggerEditorModal = ({
                 <label htmlFor="trigger-table" className="text-xs uppercase font-bold text-muted mb-1 block">
                   {t("triggers.tableName")}
                 </label>
-                <input
+                <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                   id="trigger-table"
                   type="text"
                   value={tableName}

--- a/src/components/modals/ViewEditorModal.tsx
+++ b/src/components/modals/ViewEditorModal.tsx
@@ -212,7 +212,7 @@ export const ViewEditorModal = ({
             <label htmlFor="view-name" className="text-xs uppercase font-bold text-muted mb-1 block">
               {t("views.viewName")}
             </label>
-            <input
+            <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
               id="view-name"
               type="text"
               value={name}

--- a/src/components/modals/connection/ConnectionCatalogue.tsx
+++ b/src/components/modals/connection/ConnectionCatalogue.tsx
@@ -73,7 +73,7 @@ export function ConnectionCatalogue({
             size={15}
             className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted"
           />
-          <input
+          <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
             type="text"
             value={search}
             onChange={(e) => setSearch(e.target.value)}

--- a/src/components/notebook/MarkdownCell.tsx
+++ b/src/components/notebook/MarkdownCell.tsx
@@ -57,8 +57,9 @@ function MarkdownEditor({
     }
   }, [content]);
 
+  // Prose field: natural-language input, so spellcheck/autocorrect stay ON; only the WebKit autofill pill is disabled.
   return (
-    <textarea
+    <textarea autoComplete="off" spellCheck={true}
       ref={textareaRef}
       value={content}
       onChange={(e) => onContentChange(e.target.value)}

--- a/src/components/notebook/NotebookCellHeader.tsx
+++ b/src/components/notebook/NotebookCellHeader.tsx
@@ -169,7 +169,7 @@ export function NotebookCellHeader({
         <CellTypeBadge cellType={cellType} />
         <span className="text-[10px] text-muted">#{index + 1}</span>
         {isEditingName ? (
-          <input
+          <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
             type="text"
             value={nameInput}
             onChange={(e) => setNameInput(e.target.value)}

--- a/src/components/notebook/ParamsPanel.tsx
+++ b/src/components/notebook/ParamsPanel.tsx
@@ -30,7 +30,7 @@ function ParamRow({
         @{param.name}
       </span>
       <span className="text-[10px] text-muted">=</span>
-      <input
+      <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
         type="text"
         value={param.value}
         onChange={(e) => onValueChange(e.target.value)}
@@ -73,7 +73,7 @@ function AddParamForm({
   return (
     <div className="flex items-center gap-1.5">
       <span className="text-[10px] text-muted shrink-0">@</span>
-      <input
+      <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
         type="text"
         value={name}
         onChange={(e) => {
@@ -85,7 +85,7 @@ function AddParamForm({
         onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
       />
       <span className="text-[10px] text-muted">=</span>
-      <input
+      <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
         type="text"
         value={value}
         onChange={(e) => setValue(e.target.value)}

--- a/src/components/settings/AiTab.tsx
+++ b/src/components/settings/AiTab.tsx
@@ -382,7 +382,7 @@ export function AiTab() {
                   <div className="space-y-2">
                     <div className="flex gap-2">
                       <div className="relative flex-1 group">
-                        <input
+                        <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                           type={showKey ? "text" : "password"}
                           value={keyInput}
                           placeholder={t("settings.ai.enterKey", {
@@ -436,7 +436,7 @@ export function AiTab() {
                 <label className="block text-sm font-medium text-secondary">
                   {t("settings.ai.endpointUrl")}
                 </label>
-                <input
+                <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                   type="text"
                   value={settings.aiCustomOpenaiUrl || ""}
                   onChange={(e) =>
@@ -498,7 +498,7 @@ export function AiTab() {
                   <label className="text-sm text-secondary whitespace-nowrap">
                     {t("settings.ai.ollamaPort")}:
                   </label>
-                  <input
+                  <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                     type="number"
                     value={settings.aiOllamaPort || 11434}
                     onChange={(e) =>
@@ -636,7 +636,7 @@ export function AiTab() {
                 </button>
                 {isOpen && (
                   <div className="px-5 pb-5 pt-1 border-t border-default">
-                    <textarea
+                    <textarea autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                       value={prompt}
                       onChange={(e) => setPrompt(e.target.value)}
                       className="w-full h-36 bg-base border border-strong rounded-lg p-3 text-primary text-sm font-mono focus:outline-none focus:border-blue-500 transition-colors resize-y"

--- a/src/components/settings/BackupTab.tsx
+++ b/src/components/settings/BackupTab.tsx
@@ -172,7 +172,7 @@ export function BackupTab() {
               label={t("settings.backup.webdavUrl")}
               description={t("settings.backup.webdavUrlDesc")}
             >
-              <input
+              <input autoComplete="off"
                 type="url"
                 value={webdavUrl}
                 onChange={(e) => setWebdavUrl(e.target.value)}
@@ -191,7 +191,7 @@ export function BackupTab() {
               label={t("settings.backup.webdavUsername")}
               description={t("settings.backup.webdavUsernameDesc")}
             >
-              <input
+              <input autoComplete="off"
                 type="text"
                 value={webdavUsername}
                 onChange={(e) => setWebdavUsername(e.target.value)}

--- a/src/components/settings/FontPicker.tsx
+++ b/src/components/settings/FontPicker.tsx
@@ -74,7 +74,7 @@ export function FontPicker({
           )}
         </div>
         <div className="space-y-2">
-          <input
+          <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
             id={inputId}
             type="text"
             placeholder={t("settings.fonts.customPlaceholder")}

--- a/src/components/settings/MaskingOverridesEditor.tsx
+++ b/src/components/settings/MaskingOverridesEditor.tsx
@@ -56,7 +56,7 @@ export function MaskingOverridesEditor({
         description={t("settings.maskingIncludeDesc")}
         vertical
       >
-        <textarea
+        <textarea autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
           value={includeDraft ?? include.join("\n")}
           disabled={!maskingEnabled}
           onChange={(e) => setIncludeDraft(e.target.value)}
@@ -76,7 +76,7 @@ export function MaskingOverridesEditor({
         description={t("settings.maskingExcludeDesc")}
         vertical
       >
-        <textarea
+        <textarea autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
           value={excludeDraft ?? exclude.join("\n")}
           disabled={!maskingEnabled}
           onChange={(e) => setExcludeDraft(e.target.value)}

--- a/src/components/settings/PluginSettingsPage.tsx
+++ b/src/components/settings/PluginSettingsPage.tsx
@@ -235,7 +235,7 @@ function PluginSettingsForm({ pluginId, manifest }: PluginSettingsFormProps) {
     if (def.type === "number") {
       return (
         <div className="flex items-start gap-2">
-          <input
+          <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
             type="number"
             value={typeof value === "number" ? value : ""}
             onChange={(e) =>
@@ -255,7 +255,7 @@ function PluginSettingsForm({ pluginId, manifest }: PluginSettingsFormProps) {
 
     return (
       <div className="flex items-start gap-2">
-        <input
+        <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
           type="text"
           value={typeof value === "string" ? value : ""}
           onChange={(e) => handleDynamicChange(def.key, e.target.value)}
@@ -285,7 +285,7 @@ function PluginSettingsForm({ pluginId, manifest }: PluginSettingsFormProps) {
         >
           <div className="py-3">
             <div className="flex gap-2">
-              <input
+              <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                 type="text"
                 value={interpreter}
                 placeholder={t(

--- a/src/components/settings/PluginsTab.tsx
+++ b/src/components/settings/PluginsTab.tsx
@@ -921,7 +921,7 @@ export function PluginsTab({
                 size={12}
                 className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-muted"
               />
-              <input
+              <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                 type="text"
                 placeholder={t("settings.plugins.searchPlaceholder")}
                 value={searchQuery}

--- a/src/components/settings/PrivacyTab.tsx
+++ b/src/components/settings/PrivacyTab.tsx
@@ -50,7 +50,7 @@ export function PrivacyTab() {
           description={t("settings.maskingPatternsDesc")}
           vertical
         >
-          <textarea
+          <textarea autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
             value={patternsDraft ?? patterns.join("\n")}
             disabled={!maskingEnabled}
             onChange={(e) => setPatternsDraft(e.target.value)}

--- a/src/components/settings/SettingControls.tsx
+++ b/src/components/settings/SettingControls.tsx
@@ -217,7 +217,7 @@ export function SettingNumberInput({
 }: SettingNumberInputProps) {
   return (
     <div className="flex items-center gap-2">
-      <input
+      <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
         type="number"
         min={min}
         max={max}

--- a/src/components/settings/ai-activity/AiActivityEventsTab.tsx
+++ b/src/components/settings/ai-activity/AiActivityEventsTab.tsx
@@ -235,7 +235,7 @@ function FiltersBar({
             size={14}
             className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted"
           />
-          <input
+          <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
             type="text"
             placeholder={t("aiActivity.searchQuery")}
             value={filter.queryContains ?? ""}

--- a/src/components/settings/ai-activity/AiActivitySessionsTab.tsx
+++ b/src/components/settings/ai-activity/AiActivitySessionsTab.tsx
@@ -62,7 +62,7 @@ export function AiActivitySessionsTab() {
               size={14}
               className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted"
             />
-            <input
+            <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
               type="text"
               placeholder={t("aiActivity.searchSessions", {
                 defaultValue: "Search session, client, connection…",

--- a/src/components/ssh/SshConnectionsManager.tsx
+++ b/src/components/ssh/SshConnectionsManager.tsx
@@ -58,7 +58,7 @@ function SshInput({
     <div className="flex flex-col">
       <label className={LabelClass}>{label}</label>
       <div className="relative group">
-        <input
+        <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
           type={isPassword ? (showPassword ? "text" : "password") : type}
           value={value ?? ""}
           onChange={(e) => onChange(e.target.value)}

--- a/src/components/ui/DataGridRow.tsx
+++ b/src/components/ui/DataGridRow.tsx
@@ -571,7 +571,7 @@ export const MemoRow = React.memo(function MemoRow(rowCtx: MemoRowProps) {
                         <span className="invisible whitespace-nowrap">
                           {String(displayValue)}
                         </span>
-                        <textarea
+                        <textarea autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                           ref={(el) => {
                             (
                               editInputRef as React.MutableRefObject<HTMLElement | null>

--- a/src/components/ui/DateInput.tsx
+++ b/src/components/ui/DateInput.tsx
@@ -70,7 +70,7 @@ const Spinner = ({
     <div
       className={`flex items-center border border-strong rounded bg-base ${width}`}
     >
-      <input
+      <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
         ref={inputRef}
         type="number"
         min={min}

--- a/src/components/ui/FieldEditor.tsx
+++ b/src/components/ui/FieldEditor.tsx
@@ -177,7 +177,7 @@ export const FieldEditor = ({
       className={className}
     />
   ) : (
-    <textarea
+    <textarea autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
       value={String(value ?? "")}
       onChange={(e) => onChange(e.target.value)}
       placeholder={defaultPlaceholder}

--- a/src/components/ui/FilterRow.tsx
+++ b/src/components/ui/FilterRow.tsx
@@ -105,7 +105,7 @@ export const FilterRow = ({
       {noValue && <div className="flex-1" />}
       {isBetween && (
         <div className="flex items-center gap-1.5 flex-1 min-w-0">
-          <input
+          <input autoComplete="off"
             type="text"
             spellCheck={false}
             autoCorrect="off"
@@ -117,7 +117,7 @@ export const FilterRow = ({
             placeholder={t("toolbar.fromPlaceholder")}
           />
           <span className="text-[10px] text-muted shrink-0 font-mono uppercase tracking-wider">AND</span>
-          <input
+          <input autoComplete="off"
             type="text"
             spellCheck={false}
             autoCorrect="off"

--- a/src/components/ui/GeometryInput.tsx
+++ b/src/components/ui/GeometryInput.tsx
@@ -120,7 +120,7 @@ export const GeometryInput = ({
   if (!isGeometricType(dataType)) {
     // Fallback to regular input for non-geometric types
     return (
-      <input
+      <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
         ref={actualRef as React.RefObject<HTMLInputElement>}
         value={value}
         onChange={handleChange}
@@ -136,7 +136,7 @@ export const GeometryInput = ({
   return (
     <div className="relative w-full" ref={dropdownRef}>
       <div className="flex items-center gap-1">
-        <input
+        <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
           ref={actualRef as React.RefObject<HTMLInputElement>}
           value={value}
           onChange={handleChange}

--- a/src/components/ui/JsonInput.tsx
+++ b/src/components/ui/JsonInput.tsx
@@ -258,7 +258,7 @@ export const JsonInput: React.FC<JsonInputProps> = ({
         )}
 
         {mode === "raw" && (
-          <textarea
+          <textarea autoCorrect="off" autoCapitalize="off" autoComplete="off"
             data-testid="json-input-raw"
             value={text}
             onChange={handleRawChange}

--- a/src/components/ui/JsonTreeView.tsx
+++ b/src/components/ui/JsonTreeView.tsx
@@ -117,7 +117,7 @@ export const JsonTreeView = ({
         {!externalSearchProvided && (
           <div className="flex items-center gap-2 bg-base border border-strong rounded px-2 py-1.5 focus-within:border-blue-500 transition-colors flex-shrink-0">
             <Search size={14} className="text-muted shrink-0" />
-            <input
+            <input autoCorrect="off" autoCapitalize="off" autoComplete="off"
               type="text"
               role="searchbox"
               value={internalSearch}
@@ -166,7 +166,7 @@ export const JsonTreeView = ({
       {!externalSearchProvided && (
         <div className="flex items-center gap-2 bg-base border border-strong rounded px-2 py-1.5 focus-within:border-blue-500 transition-colors">
           <Search size={14} className="text-muted shrink-0" />
-          <input
+          <input autoCorrect="off" autoCapitalize="off" autoComplete="off"
             type="text"
             role="searchbox"
             value={internalSearch}

--- a/src/components/ui/MultiResultPanel.tsx
+++ b/src/components/ui/MultiResultPanel.tsx
@@ -152,7 +152,7 @@ function ResultTab({
       {/* Label */}
       <span className="truncate flex-1 flex items-center gap-1">
         {isEditing ? (
-          <input
+          <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
             ref={inputRef}
             value={editValue}
             onChange={(e) => setEditValue(e.target.value)}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -122,7 +122,7 @@ export const Select = ({
         <div className="p-2 border-b border-default bg-elevated">
           <div className="flex items-center gap-2 bg-base border border-strong rounded px-2 py-1.5 focus-within:border-blue-500 transition-colors">
             <Search size={14} className="text-muted shrink-0" />
-            <input
+            <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
               ref={searchInputRef}
               type="text"
               placeholder={searchPlaceholder}

--- a/src/components/ui/SpotlightPalette.tsx
+++ b/src/components/ui/SpotlightPalette.tsx
@@ -141,7 +141,7 @@ export const SpotlightPalette = ({
           >
             {ariaLabel}
           </span>
-          <input
+          <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
             role="combobox"
             aria-label={searchLabel}
             aria-controls={resultsId}

--- a/src/components/ui/StackedResultItem.tsx
+++ b/src/components/ui/StackedResultItem.tsx
@@ -133,7 +133,7 @@ export function StackedResultItem({
 
         {/* Editable label */}
         {isEditing ? (
-          <input
+          <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
             ref={inputRef}
             value={editValue}
             onChange={(e) => setEditValue(e.target.value)}

--- a/src/components/ui/TableNode.tsx
+++ b/src/components/ui/TableNode.tsx
@@ -134,7 +134,7 @@ export const TableNodeComponent = memo(({ data }: NodeProps<TableNode>) => {
                   {aggregation?.function && (
                     <>
                       <div className="text-[10px] text-secondary font-semibold mb-1 mt-2">AGGREGATION ALIAS</div>
-                      <input
+                      <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                         type="text"
                         placeholder="e.g., total_count"
                         value={aggregation?.alias || ''}
@@ -147,7 +147,7 @@ export const TableNodeComponent = memo(({ data }: NodeProps<TableNode>) => {
                         className="w-full bg-surface-secondary border border-strong rounded px-2 py-1 text-[10px] text-secondary placeholder-slate-500"
                       />
                       <div className="text-[10px] text-secondary font-semibold mb-1 mt-2">POSITION</div>
-                      <input
+                      <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                         type="number"
                         min="1"
                         placeholder="e.g., 1"
@@ -167,7 +167,7 @@ export const TableNodeComponent = memo(({ data }: NodeProps<TableNode>) => {
                   {!aggregation?.function && (
                     <>
                       <div className="text-[10px] text-secondary font-semibold mb-1 mt-2">COLUMN ALIAS</div>
-                      <input
+                      <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                         type="text"
                         placeholder="e.g., user_name"
                         value={columnAlias?.alias || ''}
@@ -177,7 +177,7 @@ export const TableNodeComponent = memo(({ data }: NodeProps<TableNode>) => {
                         className="w-full bg-surface-secondary border border-strong rounded px-2 py-1 text-[10px] text-secondary placeholder-slate-500"
                       />
                       <div className="text-[10px] text-secondary font-semibold mb-1 mt-2">POSITION</div>
-                      <input
+                      <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                         type="number"
                         min="1"
                         placeholder="e.g., 1"

--- a/src/components/ui/TableToolbar.tsx
+++ b/src/components/ui/TableToolbar.tsx
@@ -436,7 +436,7 @@ const TableToolbarInternal = ({
           <div className="flex items-center gap-2 flex-1 bg-base border border-default rounded px-2 py-1 focus-within:border-blue-500/50 transition-colors relative">
             <Filter size={14} className="text-muted shrink-0" />
             <span className="hidden @[440px]:inline text-xs text-blue-400 font-mono shrink-0">WHERE</span>
-            <input
+            <input autoComplete="off"
               ref={filterInputRef}
               type="text"
               spellCheck={false}
@@ -491,7 +491,7 @@ const TableToolbarInternal = ({
         <div className="relative flex items-center gap-1.5 flex-1 bg-base border border-default rounded px-2 py-1 focus-within:border-blue-500/50 transition-colors">
           <ArrowUpDown size={14} className="text-muted shrink-0" />
           <span className="hidden @[440px]:inline text-xs text-blue-400 font-mono shrink-0">ORDER BY</span>
-          <input
+          <input autoComplete="off"
             ref={sortInputRef}
             type="text"
             spellCheck={false}
@@ -533,7 +533,7 @@ const TableToolbarInternal = ({
         <div className="flex items-center gap-1.5 w-20 @[560px]:w-32 bg-base border border-default rounded px-2 py-1 focus-within:border-blue-500/50 transition-colors shrink-0">
           <ListFilter size={14} className="text-muted shrink-0" />
           <span className="hidden @[440px]:inline text-xs text-blue-400 font-mono shrink-0">LIMIT</span>
-          <input
+          <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
             type="number"
             value={limitInput}
             onChange={(e) => setLimitInput(e.target.value)}

--- a/src/components/ui/VisualQueryBuilder.tsx
+++ b/src/components/ui/VisualQueryBuilder.tsx
@@ -407,7 +407,7 @@ const VisualQueryBuilderContent = () => {
                       <option value="IN">IN</option>
                     </select>
                     <div className="flex-1 relative">
-                      <input
+                      <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                         type="text"
                         value={condition.value}
                         onChange={(e) => setWhereConditions(whereConditions.map(c => c.id === condition.id ? { ...c, value: e.target.value } : c))}
@@ -526,7 +526,7 @@ const VisualQueryBuilderContent = () => {
                 <Hash size={16} className="text-orange-400" />
                 LIMIT
               </div>
-              <input
+              <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                 type="number"
                 value={limit}
                 onChange={(e) => setLimit(e.target.value)}

--- a/src/components/users/UserManagementView.tsx
+++ b/src/components/users/UserManagementView.tsx
@@ -437,7 +437,7 @@ export function UserManagementView({ connectionId, isActive }: Props) {
               size={12}
               className="absolute left-2 top-1/2 -translate-y-1/2 text-muted"
             />
-            <input
+            <input autoCorrect="off" autoCapitalize="off" autoComplete="off"
               type="text"
               value={filter}
               onChange={(e) => setFilter(e.target.value)}
@@ -529,7 +529,7 @@ export function UserManagementView({ connectionId, isActive }: Props) {
               </button>
             </div>
             <div className="flex items-center gap-2 max-w-md">
-              <input
+              <input autoCorrect="off" autoCapitalize="off" autoComplete="off"
                 type="text"
                 value={newUser}
                 onChange={(e) => setNewUser(e.target.value)}
@@ -539,7 +539,7 @@ export function UserManagementView({ connectionId, isActive }: Props) {
                 className="flex-1 px-2 py-1.5 bg-base border border-strong rounded-md text-xs text-primary placeholder:text-muted focus:border-blue-500 focus:outline-none"
               />
               <span className="text-muted text-xs">@</span>
-              <input
+              <input autoCorrect="off" autoCapitalize="off" autoComplete="off"
                 type="text"
                 value={newHost}
                 onChange={(e) => setNewHost(e.target.value)}
@@ -548,7 +548,7 @@ export function UserManagementView({ connectionId, isActive }: Props) {
                 className="w-28 px-2 py-1.5 bg-base border border-strong rounded-md text-xs text-primary placeholder:text-muted focus:border-blue-500 focus:outline-none"
               />
             </div>
-            <input
+            <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
               type="password"
               value={newPassword}
               onChange={(e) => setNewPassword(e.target.value)}
@@ -565,7 +565,7 @@ export function UserManagementView({ connectionId, isActive }: Props) {
                 <label className="text-xs text-muted shrink-0">
                   {t("userManagement.scope")}
                 </label>
-                <input
+                <input autoCorrect="off" autoCapitalize="off" autoComplete="off"
                   type="text"
                   value={newScopeDb}
                   onChange={(e) => {
@@ -672,7 +672,7 @@ export function UserManagementView({ connectionId, isActive }: Props) {
 
             {changingPassword && (
               <div className="max-w-md flex items-center gap-2">
-                <input
+                <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                   type="password"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
@@ -710,7 +710,7 @@ export function UserManagementView({ connectionId, isActive }: Props) {
 
               {addingScope && (
                 <div className="flex items-center gap-2 flex-wrap max-w-xl p-2 rounded-lg border border-strong bg-elevated">
-                  <input
+                  <input autoCorrect="off" autoCapitalize="off" autoComplete="off"
                     type="text"
                     value={addDb}
                     onChange={(e) => setAddDb(e.target.value)}
@@ -721,7 +721,7 @@ export function UserManagementView({ connectionId, isActive }: Props) {
                     className="w-44 px-2 py-1.5 bg-base border border-strong rounded-md text-xs text-primary placeholder:text-muted focus:border-blue-500 focus:outline-none"
                   />
                   <span className="text-muted text-xs">.</span>
-                  <input
+                  <input autoCorrect="off" autoCapitalize="off" autoComplete="off"
                     type="text"
                     value={addTable}
                     onChange={(e) => setAddTable(e.target.value)}

--- a/src/pages/Connections.tsx
+++ b/src/pages/Connections.tsx
@@ -775,7 +775,7 @@ export const Connections = () => {
               onClick={(e) => e.stopPropagation()}
             >
               <FolderPlus size={12} className="text-amber-400 shrink-0" />
-              <input
+              <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                 type="text"
                 value={subgroupInputValue}
                 onChange={(e) => setSubgroupInputValue(e.target.value)}
@@ -1094,7 +1094,7 @@ export const Connections = () => {
                   size={14}
                   className="absolute left-3.5 top-1/2 -translate-y-1/2 text-muted pointer-events-none"
                 />
-                <input
+                <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                   type="text"
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
@@ -1114,7 +1114,7 @@ export const Connections = () => {
               {/* New Group button or input */}
               {isCreatingGroup ? (
                 <div className="flex items-center gap-2 shrink-0">
-                  <input
+                  <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                     type="text"
                     value={newGroupName}
                     onChange={(e) => setNewGroupName(e.target.value)}

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -3570,7 +3570,7 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
                 <FileCode size={12} className="text-accent-secondary shrink-0" />
               )}
               {editingTabId === tab.id ? (
-                <input
+                <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                   type="text"
                   draggable={false}
                   value={editingTabTitle}
@@ -4300,7 +4300,7 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
                           title={t("editor.jumpToPage")}
                         >
                           {isEditingPage ? (
-                            <input
+                            <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
                               autoFocus
                               type="text"
                               className="w-full bg-transparent text-center focus:outline-none text-white p-0 m-0 border-none h-full"


### PR DESCRIPTION
Closes #633

## Problem

On macOS, Tabularis renders in WKWebView and inherits Safari's text helpers: the floating form-autofill suggestion pill, inline predictive text, autocorrect, and spellcheck underlines. Prior fixes (#64, #431) opted out piecemeal, leaving ~100 text fields across ~60 files exposed — the hint dropdown appears in sidebar filters, quick navigator, modal inputs, cell editors, etc., and worsens over time as WebKit accumulates per-origin value history.

There is no webview-level toggle (`WKWebViewConfiguration` exposes none); suppression must happen in markup.

## Fix

- Added `autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}` to every technical text `<input>`/`<textarea>` missing them (102 fields, 57 files), following the existing `NewConnectionModal` convention — no new pattern introduced.
- `index.html`: `spellcheck="false"` on `<html>` as an inherited baseline so future fields default to no spellcheck.
- Monaco SQL editor untouched — v0.55 already sets all four attributes on its hidden input.

## Fields deliberately left with text assistance ON

Natural-language prose fields keep `spellCheck={true}` and default autocorrect; only the autofill pill is disabled (`autoComplete="off"`), since replaying a previous value is useless there too:

- `AiQueryModal` prompt — users describe queries in English sentences
- `AiApprovalModal` rejection reason — free-text explanation to the AI
- Notebook markdown cell editor — long-form prose

Each carve-out carries a code comment stating the rationale.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `vitest run` — 3723/3723 pass
- Manually verified in the built macOS app: text-hint dropdown no longer appears in affected fields