### PR TITLE
fix(editor): keep Add Row available for empty tables

### DIFF
--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { reconstructTableQuery } from "../utils/editor";
+import { shouldShowStatementSuccess } from "../utils/resultPresentation";
 import { formatRowsForCopy, copyTextToClipboard } from "../utils/clipboard";
 import { serializePkKey, buildPkMap } from "../utils/dataGrid";
 import {
@@ -4205,14 +4206,11 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
               </div>
             ) : activeTab.error ? (
               <ErrorDisplay error={activeTab.error} t={t} />
-            ) : activeTab.result &&
-              activeTab.result.columns.length === 0 &&
-              !(
-                activeTab.pendingInsertions &&
-                Object.keys(activeTab.pendingInsertions).length > 0
-              ) ? (
+            ) : shouldShowStatementSuccess(activeTab) ? (
               // Non-SELECT statement (INSERT/UPDATE/DELETE/DDL): no result set,
               // so surface an explicit success message instead of an empty grid.
+              // Table tabs stay in data mode even when an empty result omits
+              // columns, keeping the Add Row action available.
               <div className="flex-1 min-h-0 flex flex-col items-center justify-center gap-2 text-center px-4">
                 <CheckCircle2 size={32} className="text-green-500" />
                 <p className="text-sm font-medium text-primary">

--- a/src/utils/resultPresentation.ts
+++ b/src/utils/resultPresentation.ts
@@ -1,0 +1,22 @@
+import type { QueryResult, Tab } from "../types/editor";
+
+type ResultPresentationTab = Pick<
+  Tab,
+  "type" | "result" | "pendingInsertions"
+>;
+
+/**
+ * Distinguishes command results from an empty table browse result.
+ * Table tabs must keep rendering their data controls so users can add the
+ * first row even when a driver returns no column metadata for an empty table.
+ */
+export function shouldShowStatementSuccess(
+  tab: ResultPresentationTab,
+): tab is ResultPresentationTab & { result: QueryResult } {
+  return (
+    tab.type !== "table" &&
+    tab.result !== null &&
+    tab.result.columns.length === 0 &&
+    Object.keys(tab.pendingInsertions ?? {}).length === 0
+  );
+}

--- a/tests/utils/resultPresentation.test.ts
+++ b/tests/utils/resultPresentation.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { Tab } from "../../src/types/editor";
+import { shouldShowStatementSuccess } from "../../src/utils/resultPresentation";
+
+function resultTab(overrides: Partial<Tab> = {}): Tab {
+  return {
+    id: "tab-1",
+    title: "Result",
+    type: "console",
+    query: "",
+    result: {
+      columns: [],
+      rows: [],
+      affected_rows: 0,
+    },
+    error: "",
+    executionTime: null,
+    page: 1,
+    activeTable: null,
+    pkColumns: null,
+    connectionId: "connection-1",
+    ...overrides,
+  };
+}
+
+describe("resultPresentation", () => {
+  describe("shouldShowStatementSuccess", () => {
+    it("shows success for a command without a result set", () => {
+      expect(shouldShowStatementSuccess(resultTab())).toBe(true);
+    });
+
+    it("keeps an empty table tab in data mode so the first row can be added", () => {
+      expect(
+        shouldShowStatementSuccess(
+          resultTab({ type: "table", activeTable: "users" }),
+        ),
+      ).toBe(false);
+    });
+
+    it("keeps rendering pending insertions", () => {
+      expect(
+        shouldShowStatementSuccess(
+          resultTab({
+            pendingInsertions: {
+              temporary: {
+                tempId: "temporary",
+                data: {},
+                displayIndex: 0,
+              },
+            },
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    it("does not show success before a result exists", () => {
+      expect(shouldShowStatementSuccess(resultTab({ result: null }))).toBe(
+        false,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- keep table tabs in data mode when an empty result omits column metadata
- preserve the data manipulation toolbar and **Add Row** action for empty tables and filtered zero-row results
- continue showing the success state for commands that do not return a result set
- add regression coverage for table, command, pending-insertion, and missing-result states

## Testing

- `pnpm typecheck`
- `pnpm exec eslint src/pages/Editor.tsx src/utils/resultPresentation.ts`
- `pnpm test --run` (223 files, 3757 tests passed)

Closes #641
