### PR TITLE
ci: cache Rust dependencies in the test job (#640)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev build-essential curl wget file libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libfuse2
 
+      - name: Cache Rust dependencies
+        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: src-tauri
+
       - name: Install dependencies
         run: pnpm install
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Lint
         run: pnpm run lint
-        
+
       - name: Build
         run: pnpm run build
 


### PR DESCRIPTION
Closes #640

## Summary

`ci.yml`'s `test` job had no Rust build caching, so every push/PR run recompiled the entire `Cargo.lock` dependency graph from scratch before running a single test — ~6.5 of the job's ~10.3 median minutes, of which only ~19s was the actual test run. Full analysis (a month of CI history, step-by-step timing breakdown) is on #640.

## What changed

Adds the exact same `swatinem/rust-cache` step (same pinned SHA, same `workspaces: src-tauri` config) already in use in `build.yml`'s release job — no new tooling, just applying an already-vetted pattern to a job that was missing it.

@debba [confirmed this approach](https://github.com/TabularisDB/tabularis/issues/640#issuecomment-5294056851) on the issue before this PR was opened.

## Verification

- YAML syntax validated
- Diffed against `build.yml`'s existing usage to confirm identical action reference and configuration — no drift
- **Measured directly on this PR's own CI runs** — run 1 populated the cache (necessarily a miss, nothing to restore yet), run 2 hit it:

  | Step | Run 1 (cache miss) | Run 2 (cache hit) | Delta |
  |---|---|---|---|
  | Cache Rust dependencies | 2s | 34s (restoring ~1.14 GB) | — |
  | **Test** (`pnpm test:rust && pnpm test:coverage`) | **8m28s** | **3m37s** | **−4m51s** |
  | **Total job** | **~11m45s** | **~6m29s** | **−5m16s (~45% faster)** |

  Confirmed via the cache action's own log: `Cache hit for: v0-rust-test-Linux-x64-...`, `Cache restored successfully`, `full match: true`. The `Test` step's drop matches #640's own analysis almost exactly — that step's ~6.5 minutes of Rust time was ~19s of actual test execution and the rest cold compile, and cold compile is what the cache now skips on a hit.
- Run 1: https://github.com/TabularisDB/tabularis/actions/runs/31816668408
- Run 2 (cache hit): https://github.com/TabularisDB/tabularis/actions/runs/31817948418

