### PR TITLE
fix(mysql): delete rows with binary primary keys

### DIFF
--- a/src-tauri/src/drivers/mysql/mod.rs
+++ b/src-tauri/src/drivers/mysql/mod.rs
@@ -218,7 +218,16 @@ fn push_pk_value(
             }
         }
         serde_json::Value::String(s) => {
-            if let Some(n) = parse_unsafe_bigint_string(s) {
+            if let Some(bytes) = crate::drivers::common::decode_blob_wire_format(
+                s,
+                crate::drivers::common::DEFAULT_MAX_BLOB_SIZE,
+            ) {
+                if text.enabled {
+                    qb.push(mysql_bytes_literal(&bytes));
+                } else {
+                    qb.push_bind(bytes);
+                }
+            } else if let Some(n) = parse_unsafe_bigint_string(s) {
                 if text.enabled {
                     qb.push(n.to_string());
                 } else {

--- a/src-tauri/src/drivers/mysql/tests.rs
+++ b/src-tauri/src/drivers/mysql/tests.rs
@@ -267,6 +267,29 @@ mod push_pk_condition_tests {
     }
 
     #[test]
+    fn binary_wire_value_binds_with_equality() {
+        let wire_value = crate::drivers::common::encode_blob(&[
+            0x55, 0x0e, 0x84, 0x00, 0xe2, 0x9b, 0x41, 0xd4, 0xa7, 0x16, 0x44, 0x66, 0x55, 0x44,
+            0x00, 0x00,
+        ]);
+        assert_eq!(render(serde_json::json!(wire_value)), "`col` = ?");
+    }
+
+    #[test]
+    fn binary_wire_value_inlines_hex_literal_in_text_protocol() {
+        let wire_value = crate::drivers::common::encode_blob(&[0x00, 0x7f, 0xff]);
+        let mut qb = sqlx::QueryBuilder::<sqlx::MySql>::new("");
+        push_pk_condition(
+            &mut qb,
+            "col",
+            &serde_json::json!(wire_value),
+            TextProto::protocol_only(true),
+        )
+        .unwrap();
+        assert_eq!(qb.sql(), "`col` = x'007fff'");
+    }
+
+    #[test]
     fn bool_binds_with_equality() {
         assert_eq!(render(serde_json::json!(true)), "`col` = ?");
     }

--- a/src-tauri/tests/integration_tests.rs
+++ b/src-tauri/tests/integration_tests.rs
@@ -468,6 +468,81 @@ async fn test_mysql_affected_rows_reported_correctly() {
 }
 
 #[tokio::test]
+#[ignore]
+async fn test_mysql_delete_record_with_binary_primary_key() {
+    let params = get_mysql_params();
+    if !wait_for_mysql(&params).await {
+        eprintln!("SKIPPING: MySQL not reachable on 33060");
+        return;
+    }
+
+    let _ = mysql::execute_query(
+        &params,
+        "DROP TABLE IF EXISTS test_binary_pk_delete",
+        None,
+        1,
+        None,
+    )
+    .await;
+    mysql::execute_query(
+        &params,
+        "CREATE TABLE test_binary_pk_delete (id BINARY(16) PRIMARY KEY, description VARCHAR(100))",
+        None,
+        1,
+        None,
+    )
+    .await
+    .expect("table creation should succeed");
+    mysql::execute_query(
+        &params,
+        "INSERT INTO test_binary_pk_delete VALUES (UUID_TO_BIN('550e8400-e29b-41d4-a716-446655440000'), 'issue 646')",
+        None,
+        1,
+        None,
+    )
+    .await
+    .expect("row insertion should succeed");
+
+    let selected = mysql::execute_query(
+        &params,
+        "SELECT id, description FROM test_binary_pk_delete",
+        None,
+        1,
+        None,
+    )
+    .await
+    .expect("row selection should succeed");
+    let binary_id = selected.rows[0][0].clone();
+    assert!(binary_id.as_str().is_some_and(|value| value.starts_with("BLOB:")));
+
+    let pk_map = std::collections::HashMap::from([("id".to_string(), binary_id)]);
+    let affected = mysql::delete_record(&params, "test_binary_pk_delete", &pk_map)
+        .await
+        .expect("binary primary-key deletion should succeed");
+    assert_eq!(affected, 1);
+
+    let remaining = mysql::execute_query(
+        &params,
+        "SELECT COUNT(*) FROM test_binary_pk_delete",
+        None,
+        1,
+        None,
+    )
+    .await
+    .expect("row count should succeed");
+    assert_eq!(remaining.rows[0][0].as_i64(), Some(0));
+
+    let _ = mysql::execute_query(
+        &params,
+        "DROP TABLE test_binary_pk_delete",
+        None,
+        1,
+        None,
+    )
+    .await;
+}
+
+#[tokio::test]
 #[ignore] // Run via pg-integration.yml CI or --include-ignored
 async fn test_postgres_affected_rows_reported_correctly() {
     let params = get_postgres_params();


### PR DESCRIPTION
## Summary

- decode Tabularis BLOB wire values before using them in MySQL primary-key predicates
- bind binary primary keys as raw bytes for prepared statements
- render binary primary keys as hexadecimal literals for text-protocol connections
- add unit coverage for both protocol paths and a Docker-backed MySQL regression test

## Root cause

MySQL `BINARY` values are returned to the frontend using Tabularis' `BLOB:<size>:<mime>:<base64>` wire format. Row deletion passed that representation back into the primary-key predicate as a regular string, so it did not match the original binary value.

## Testing

- `cargo test --manifest-path src-tauri/Cargo.toml drivers::mysql::tests::push_pk_condition_tests --lib`
- `cargo test --manifest-path src-tauri/Cargo.toml --test integration_tests test_mysql_delete_record_with_binary_primary_key -- --ignored --exact` against MySQL 8.4 in Docker
- manual reproduction and verification through Tabularis using a `BINARY(16)` primary key

Fixes #646
