### PR TITLE
feat: add inline hex preview and editing for BLOBs

### DIFF
--- a/src-tauri/src/drivers/common/blob.rs
+++ b/src-tauri/src/drivers/common/blob.rs
@@ -2,7 +2,7 @@
 /// All blobs are serialised as "BLOB:<size>:<mime_type>:<base64_data>".
 /// For blobs larger than this threshold only the first N bytes are included;
 /// smaller blobs are encoded in full.
-pub const MAX_BLOB_PREVIEW_SIZE: usize = 4096;
+pub const MAX_BLOB_PREVIEW_SIZE: usize = 10_240;
 
 /// Default maximum size in bytes for a BLOB file that can be uploaded/loaded into memory.
 /// Files larger than this limit will be rejected to prevent memory exhaustion.

--- a/src-tauri/src/drivers/common/tests.rs
+++ b/src-tauri/src/drivers/common/tests.rs
@@ -27,7 +27,10 @@ fn test_decode_blob_wire_format_not_wire_format() {
 fn test_decode_blob_wire_format_truncated_preview() {
     // Even if the wire format contains only a truncated preview, the decoded
     // bytes should equal the preview portion (first MAX_BLOB_PREVIEW_SIZE bytes)
-    let data: Vec<u8> = (0u8..=255u8).cycle().take(8192).collect();
+    let data: Vec<u8> = (0u8..=255u8)
+        .cycle()
+        .take(MAX_BLOB_PREVIEW_SIZE * 2)
+        .collect();
     let wire = encode_blob(&data);
     let decoded = decode_blob_wire_format(&wire, DEFAULT_MAX_BLOB_SIZE)
         .expect("should decode truncated wire format");

--- a/src/components/ui/BlobHexInput.tsx
+++ b/src/components/ui/BlobHexInput.tsx
@@ -1,0 +1,56 @@
+import { useMemo, useState } from "react";
+import {
+  blobHexToWireFormat,
+  blobValueToEditableHex,
+  extractBlobMetadata,
+} from "../../utils/blob";
+
+interface BlobHexInputProps {
+  value: unknown;
+  onChange: (value: string) => void;
+  className?: string;
+}
+
+export const BlobHexInput = ({
+  value,
+  onChange,
+  className = "",
+}: BlobHexInputProps) => {
+  const initialHex = blobValueToEditableHex(value) ?? "";
+  const mimeType = extractBlobMetadata(value)?.mimeType;
+  const [hexValue, setHexValue] = useState(initialHex);
+  const wireValue = useMemo(
+    () => blobHexToWireFormat(hexValue, mimeType),
+    [hexValue, mimeType],
+  );
+  const isValid = wireValue !== null;
+
+  const commit = () => {
+    if (!wireValue) {
+      setHexValue(initialHex);
+      return;
+    }
+    if (wireValue !== value) {
+      onChange(wireValue);
+    }
+  };
+
+  return (
+    <textarea
+      value={hexValue}
+      onChange={(event) => setHexValue(event.target.value)}
+      onBlur={commit}
+      onKeyDown={(event) => {
+        if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+          event.currentTarget.blur();
+        }
+      }}
+      placeholder="00 FF"
+      spellCheck={false}
+      aria-invalid={!isValid}
+      className={`w-full min-h-24 px-3 py-2 bg-base border rounded-lg text-primary font-mono text-sm resize-y focus:outline-none ${
+        isValid ? "border-strong focus:border-blue-500" : "border-red-500"
+      } ${className}`}
+    />
+  );
+};

--- a/src/components/ui/FieldEditor.tsx
+++ b/src/components/ui/FieldEditor.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Sparkles, Ban, Eraser, FileDigit } from "lucide-react";
 import { GeometryInput } from "./GeometryInput";
 import { BlobInput } from "./BlobInput";
+import { BlobHexInput } from "./BlobHexInput";
 import { DateInput } from "./DateInput";
 import { JsonInput } from "./JsonInput";
 import { TextInput } from "./TextInput";
@@ -14,7 +15,11 @@ import {
   parseSetValues,
 } from "../../utils/columnTypes";
 import { EnumSetInput } from "./EnumSetInput";
-import { isBlobColumn } from "../../utils/blob";
+import {
+  blobValueToEditableHex,
+  isBlobColumn,
+  isBlobWireFormat,
+} from "../../utils/blob";
 import {
   isJsonColumn,
   isJsonContent,
@@ -75,7 +80,10 @@ export const FieldEditor = ({
 }: FieldEditorProps) => {
   const { t } = useTranslation();
   const isGeometric = type && isGeometricType(type);
-  const isBlob = type && isBlobColumn(type, characterMaximumLength);
+  const isBlob =
+    type &&
+    (isBlobColumn(type, characterMaximumLength) || isBlobWireFormat(value));
+  const editableBlobHex = isBlob ? blobValueToEditableHex(value) : null;
   const isJsonByType = !!(type && (isJsonColumn(type) || isHstoreColumn(type)));
   const detectedJson =
     !isBlob &&
@@ -121,17 +129,25 @@ export const FieldEditor = ({
 
   const inputElement = isBlob ? (
     <div className={`${className}`}>
-      <BlobInput
-        value={value}
-        dataType={type}
-        onChange={(newValue) => onChange(newValue)}
-        placeholder={defaultPlaceholder}
-        connectionId={connectionId}
-        tableName={tableName}
-        pkMap={pkMap}
-        colName={name}
-        schema={schema}
-      />
+      {editableBlobHex !== null ? (
+        <BlobHexInput
+          key={String(value)}
+          value={value}
+          onChange={(newValue) => onChange(newValue)}
+        />
+      ) : (
+        <BlobInput
+          value={value}
+          dataType={type}
+          onChange={(newValue) => onChange(newValue)}
+          placeholder={defaultPlaceholder}
+          connectionId={connectionId}
+          tableName={tableName}
+          pkMap={pkMap}
+          colName={name}
+          schema={schema}
+        />
+      )}
     </div>
   ) : isGeometric ? (
     <div className={`bg-base border border-strong rounded-lg p-3 ${className}`}>

--- a/src/utils/blob.ts
+++ b/src/utils/blob.ts
@@ -155,8 +155,15 @@ export function extractBlobMetadata(value: unknown): BlobMetadata | null {
     if (secondColon !== -1 && thirdColon !== -1) {
       const size = parseInt(stringValue.substring(firstColon, secondColon), 10);
       const mimeType = stringValue.substring(secondColon + 1, thirdColon);
-      const base64Length = stringValue.length - thirdColon - 1;
-      const isTruncated = size > (base64Length * 3) / 4;
+      const base64Start = thirdColon + 1;
+      const base64Length = stringValue.length - base64Start;
+      const padding = stringValue.endsWith("==")
+        ? 2
+        : stringValue.endsWith("=")
+          ? 1
+          : 0;
+      const decodedByteLength = Math.floor((base64Length * 3) / 4) - padding;
+      const isTruncated = size > decodedByteLength;
 
       return {
         mimeType,
@@ -325,9 +332,90 @@ export function blobPayloadToBytes(payload: string, isBase64: boolean): Uint8Arr
   return new TextEncoder().encode(payload);
 }
 
+const BLOB_INLINE_HEX_LIMIT_BYTES = 10 * 1024;
+const BLOB_HEX_PREVIEW_BYTES = 64;
+
+function bytesToHex(bytes: Uint8Array, separator = ""): string {
+  return Array.from(bytes, (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join(separator);
+}
+
+export function blobValueToEditableHex(value: unknown): string | null {
+  const metadata = extractBlobMetadata(value);
+  if (
+    !metadata ||
+    !metadata.isBase64 ||
+    metadata.isTruncated ||
+    metadata.size > BLOB_INLINE_HEX_LIMIT_BYTES
+  ) {
+    return null;
+  }
+
+  try {
+    const payload = extractBase64Payload(value);
+    const bytes = blobPayloadToBytes(payload, true);
+    return bytesToHex(bytes, " ").toUpperCase();
+  } catch {
+    return null;
+  }
+}
+
+export function blobHexToWireFormat(
+  hexValue: string,
+  mimeType = "application/octet-stream",
+): string | null {
+  let normalized = hexValue.trim();
+  if (normalized.startsWith("0x") || normalized.startsWith("0X")) {
+    normalized = normalized.slice(2);
+  }
+  normalized = normalized.replace(/\s/g, "");
+
+  if (normalized.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(normalized)) {
+    return null;
+  }
+
+  const bytes = new Uint8Array(normalized.length / 2);
+  for (let index = 0; index < normalized.length; index += 2) {
+    bytes[index / 2] = Number.parseInt(normalized.slice(index, index + 2), 16);
+  }
+
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return `BLOB:${bytes.length}:${mimeType}:${btoa(binary)}`;
+}
+
+function formatBlobHexPreview(
+  value: unknown,
+  metadata: BlobMetadata,
+): string | null {
+  if (
+    metadata.mimeType !== "application/octet-stream" ||
+    !metadata.isBase64 ||
+    metadata.isTruncated ||
+    metadata.size > BLOB_INLINE_HEX_LIMIT_BYTES
+  ) {
+    return null;
+  }
+
+  try {
+    const payload = extractBase64Payload(value);
+    const bytes = blobPayloadToBytes(payload, true);
+    const preview = bytes.slice(0, BLOB_HEX_PREVIEW_BYTES);
+    const hex = bytesToHex(preview);
+    const suffix = bytes.length > BLOB_HEX_PREVIEW_BYTES ? "…" : "";
+    return `0x${hex}${suffix}`;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Formats a BLOB value for display in the DataGrid.
- * Shows MIME type and size instead of raw data.
+ * Small generic binary values use a compact hex preview. Recognized file types
+ * and blobs that require fetching retain their MIME type and size metadata.
  */
 export function formatBlobValue(value: unknown, dataType: string): string {
   if (!isBlobType(dataType)) {
@@ -340,5 +428,8 @@ export function formatBlobValue(value: unknown, dataType: string): string {
     return "NULL";
   }
 
-  return `${metadata.mimeType} (${metadata.formattedSize})`;
+  return (
+    formatBlobHexPreview(value, metadata) ??
+    `${metadata.mimeType} (${metadata.formattedSize})`
+  );
 }

--- a/tests/components/ui/FieldEditor.test.tsx
+++ b/tests/components/ui/FieldEditor.test.tsx
@@ -21,6 +21,10 @@ vi.mock("../../../src/components/ui/GeometryInput", () => ({
   ),
 }));
 
+vi.mock("../../../src/components/ui/BlobInput", () => ({
+  BlobInput: () => <div data-testid="blob-download-input" />,
+}));
+
 // Mock geometry utilities
 vi.mock("../../../src/utils/geometry", () => ({
   isGeometricType: (type: string) => type === "geometry" || type === "point",
@@ -97,6 +101,66 @@ describe("FieldEditor", () => {
 
     const textarea = screen.getByRole("textbox");
     expect(textarea).toHaveValue("");
+  });
+
+  it("should edit a small generic BINARY value as hex", () => {
+    const onChange = vi.fn();
+    const wire = `BLOB:4:application/octet-stream:${btoa("test")}`;
+    render(
+      <FieldEditor
+        name="payload"
+        type="BINARY"
+        characterMaximumLength={16}
+        value={wire}
+        onChange={onChange}
+      />
+    );
+
+    const input = screen.getByPlaceholderText("00 FF");
+    expect(input).toHaveValue("74 65 73 74");
+
+    fireEvent.change(input, { target: { value: "0A FF" } });
+    fireEvent.blur(input);
+
+    expect(onChange).toHaveBeenCalledWith(
+      "BLOB:2:application/octet-stream:Cv8=",
+    );
+  });
+
+  it("should keep a generic BLOB over 10 KiB in the download editor", () => {
+    const onChange = vi.fn();
+    const wire = `BLOB:10241:application/octet-stream:${btoa("preview")}`;
+    render(
+      <FieldEditor
+        name="payload"
+        type="BLOB"
+        value={wire}
+        onChange={onChange}
+      />
+    );
+
+    expect(screen.queryByPlaceholderText("00 FF")).not.toBeInTheDocument();
+    expect(screen.getByTestId("blob-download-input")).toBeInTheDocument();
+  });
+
+  it("should edit a recognized file type as hex and preserve its MIME type", () => {
+    const onChange = vi.fn();
+    const wire = `BLOB:4:application/pdf:${btoa("test")}`;
+    render(
+      <FieldEditor
+        name="payload"
+        type="BLOB"
+        value={wire}
+        onChange={onChange}
+      />
+    );
+
+    const input = screen.getByPlaceholderText("00 FF");
+    expect(input).toHaveValue("74 65 73 74");
+    fireEvent.change(input, { target: { value: "00" } });
+    fireEvent.blur(input);
+
+    expect(onChange).toHaveBeenCalledWith("BLOB:1:application/pdf:AA==");
   });
 
   it("should display custom placeholder", () => {

--- a/tests/utils/blob.test.ts
+++ b/tests/utils/blob.test.ts
@@ -8,6 +8,8 @@ import {
   parseBlobFileRef,
   extractBase64Payload,
   blobPayloadToBytes,
+  blobHexToWireFormat,
+  blobValueToEditableHex,
 } from "../../src/utils/blob";
 
 describe("blob utilities", () => {
@@ -106,6 +108,22 @@ describe("blob utilities", () => {
       expect(metadata?.isTruncated).toBe(false);
     });
 
+    it("should account for base64 padding at the preview boundary", () => {
+      const bytes = Array.from({ length: 10_240 }, (_, index) => index % 256);
+      const preview = btoa(String.fromCharCode(...bytes));
+
+      expect(
+        extractBlobMetadata(
+          makeBlobWire(10_240, "application/octet-stream", preview),
+        )?.isTruncated,
+      ).toBe(false);
+      expect(
+        extractBlobMetadata(
+          makeBlobWire(10_241, "application/octet-stream", preview),
+        )?.isTruncated,
+      ).toBe(true);
+    });
+
     it("should handle null values", () => {
       expect(extractBlobMetadata(null)).toBeNull();
       expect(extractBlobMetadata(undefined)).toBeNull();
@@ -142,22 +160,115 @@ describe("blob utilities", () => {
       expect(formatBlobValue(123, "INTEGER")).toBe("123");
     });
 
-    it("should work with different BLOB type names", () => {
+    it("should format small generic binary values as compact hex", () => {
       const b64 = btoa("test");
       const wire = `BLOB:4:application/octet-stream:${b64}`;
 
-      expect(formatBlobValue(wire, "BLOB")).toContain(
-        "application/octet-stream",
+      expect(formatBlobValue(wire, "BLOB")).toBe("0x74657374");
+      expect(formatBlobValue(wire, "TINYBLOB")).toBe("0x74657374");
+      expect(formatBlobValue(wire, "MEDIUMBLOB")).toBe("0x74657374");
+      expect(formatBlobValue(wire, "LONGBLOB")).toBe("0x74657374");
+    });
+
+    it("should show all 16 bytes of a binary identifier", () => {
+      const bytes = Array.from({ length: 16 }, (_, index) => index);
+      const b64 = btoa(String.fromCharCode(...bytes));
+      const wire = `BLOB:16:application/octet-stream:${b64}`;
+
+      expect(formatBlobValue(wire, "BINARY(16)")).toBe(
+        "0x000102030405060708090a0b0c0d0e0f",
       );
-      expect(formatBlobValue(wire, "TINYBLOB")).toContain(
-        "application/octet-stream",
+    });
+
+    it("should show all 64 preview bytes without an ellipsis", () => {
+      const bytes = Array.from({ length: 64 }, (_, index) => index);
+      const b64 = btoa(String.fromCharCode(...bytes));
+      const wire = `BLOB:64:application/octet-stream:${b64}`;
+
+      const formatted = formatBlobValue(wire, "BLOB");
+      expect(formatted).toHaveLength(130);
+      expect(formatted.endsWith("…")).toBe(false);
+    });
+
+    it("should truncate the grid preview after 64 bytes", () => {
+      const bytes = Array.from({ length: 65 }, (_, index) => index);
+      const b64 = btoa(String.fromCharCode(...bytes));
+      const wire = `BLOB:65:application/octet-stream:${b64}`;
+
+      const formatted = formatBlobValue(wire, "BLOB");
+      const expectedHex = bytes
+        .slice(0, 64)
+        .map((byte) => byte.toString(16).padStart(2, "0"))
+        .join("");
+      expect(formatted).toBe(`0x${expectedHex}…`);
+    });
+
+    it("should keep a 10 KiB generic binary value in hex preview mode", () => {
+      const bytes = Array.from({ length: 10_240 }, (_, index) => index % 256);
+      const b64 = btoa(String.fromCharCode(...bytes));
+      const wire = `BLOB:10240:application/octet-stream:${b64}`;
+
+      expect(formatBlobValue(wire, "BLOB")).toMatch(/^0x[0-9a-f]{128}…$/);
+    });
+
+    it("should keep download metadata above the 10 KiB inline limit", () => {
+      const preview = String.fromCharCode(
+        ...Array.from({ length: 64 }, (_, index) => index),
       );
-      expect(formatBlobValue(wire, "MEDIUMBLOB")).toContain(
-        "application/octet-stream",
+      const wire = `BLOB:10241:application/octet-stream:${btoa(preview)}`;
+
+      expect(formatBlobValue(wire, "BLOB")).toBe(
+        "application/octet-stream (10.00 KB)",
       );
-      expect(formatBlobValue(wire, "LONGBLOB")).toContain(
-        "application/octet-stream",
+    });
+
+    it("should retain MIME metadata for recognized file types", () => {
+      const b64 = btoa("%PDF-1.7");
+      const wire = `BLOB:8:application/pdf:${b64}`;
+
+      expect(formatBlobValue(wire, "BLOB")).toBe("application/pdf (8 B)");
+    });
+  });
+
+  describe("inline hex editing", () => {
+    it("should convert a complete generic BLOB to editable uppercase hex", () => {
+      const wire = `BLOB:4:application/octet-stream:${btoa("test")}`;
+
+      expect(blobValueToEditableHex(wire)).toBe("74 65 73 74");
+    });
+
+    it("should edit recognized BLOBs while preserving their bytes", () => {
+      expect(
+        blobValueToEditableHex(`BLOB:4:application/pdf:${btoa("test")}`),
+      ).toBe("74 65 73 74");
+    });
+
+    it("should reject truncated BLOBs for inline editing", () => {
+      expect(
+        blobValueToEditableHex(
+          `BLOB:10241:application/octet-stream:${btoa("preview")}`,
+        ),
+      ).toBeNull();
+    });
+
+    it("should encode edited hex in the existing BLOB wire format", () => {
+      const wire = blobHexToWireFormat("0x00 A5 ff");
+
+      expect(wire).toBe("BLOB:3:application/octet-stream:AKX/");
+      expect(blobHexToWireFormat("00 A5 ff", "application/pdf")).toBe(
+        "BLOB:3:application/pdf:AKX/",
       );
+    });
+
+    it("should support an empty binary value", () => {
+      expect(blobHexToWireFormat("")).toBe(
+        "BLOB:0:application/octet-stream:",
+      );
+    });
+
+    it("should reject odd-length and non-hex input", () => {
+      expect(blobHexToWireFormat("ABC")).toBeNull();
+      expect(blobHexToWireFormat("GG")).toBeNull();
     });
   });
 

--- a/tests/utils/dataGrid.test.ts
+++ b/tests/utils/dataGrid.test.ts
@@ -113,6 +113,24 @@ describe('dataGrid utils', () => {
         expect(formatCellValue(true, 'NULL', 'BOOLEAN')).toBe('true');
       });
 
+      it('should display a BINARY(16) wire value as complete hex', () => {
+        const bytes = Array.from({ length: 16 }, (_, index) => index);
+        const wire = `BLOB:16:application/octet-stream:${btoa(String.fromCharCode(...bytes))}`;
+
+        expect(formatCellValue(wire, 'NULL', 'BINARY', 16)).toBe(
+          '0x000102030405060708090a0b0c0d0e0f',
+        );
+      });
+
+      it('should retain download metadata for generic binary values over 10 KiB', () => {
+        const preview = btoa('binary preview');
+        const wire = `BLOB:10241:application/octet-stream:${preview}`;
+
+        expect(formatCellValue(wire, 'NULL', 'BLOB')).toBe(
+          'application/octet-stream (10.00 KB)',
+        );
+      });
+
       it('should handle case-insensitive geometric types', () => {
         const wkt = 'LINESTRING(0 0, 1 1)';
         expect(formatCellValue(wkt, 'NULL', 'linestring')).toBe(wkt);


### PR DESCRIPTION
## Summary

Add hexadecimal presentation and editing for BLOB values while preserving Tabularis' existing Tauri and JSON-RPC contracts.

- Display small generic binary values as compact hexadecimal strings in the data grid.
- Open complete BLOB values up to 10 KiB in a dedicated hexadecimal sidebar editor.
- Keep truncated BLOBs above 10 KiB in the existing file/download editor.
- Preserve the original MIME type when an edited value is serialized back to the BLOB wire format.

## Technical details

### Grid presentation

`formatBlobValue` now decodes complete `application/octet-stream` payloads up to 10 KiB and renders a compact `0x...` preview:

- at most 64 bytes are rendered in the grid;
- longer values receive an ellipsis;
- recognized file MIME types continue to show MIME type and size metadata in the grid;
- truncated or oversized generic BLOBs continue to show MIME type and size metadata.

This also makes fixed-size binary identifiers such as `BINARY(16)` readable without exposing Base64 transport data.

### Sidebar hex editor

A new `BlobHexInput` component provides monospaced hexadecimal editing for every complete BLOB payload up to 10 KiB, including recognized MIME types.

- bytes are displayed as uppercase, space-separated hex pairs;
- whitespace and an optional `0x` prefix are accepted;
- odd-length and non-hexadecimal input is rejected;
- invalid edits are reverted on blur;
- valid edits commit on blur or `Cmd/Ctrl+Enter`;
- empty binary values are supported;
- the original MIME type is retained after editing.

`FieldEditor` routes complete BLOB wire values to this editor even when the database column is a small fixed-width binary type that would not otherwise be classified as a file-oriented BLOB. Truncated values and file references continue to use `BlobInput`.

### Preview boundary and transport compatibility

The backend BLOB preview boundary is increased from 4 KiB to 10 KiB so values within the editable range arrive in full. The public representation remains unchanged:

```text
BLOB:<size>:<mime-type>:<base64-payload>
```

No Tauri command signature, query result shape, driver RPC method, or persistence contract changes.

Base64 truncation detection now subtracts `=` padding when calculating decoded payload length. This correctly distinguishes a complete 10,240-byte payload from a 10,241-byte value containing a 10,240-byte preview and prevents truncated data from entering the hex editor.

## Behavior matrix

| Value | Grid | Sidebar |
| --- | --- | --- |
| Generic binary, complete, <= 64 B | Full compact hex | Hex editor |
| Generic binary, complete, 65 B–10 KiB | First 64 bytes + ellipsis | Hex editor |
| Recognized MIME, complete, <= 10 KiB | MIME type and size | Hex editor |
| Any BLOB > 10 KiB / truncated | MIME type and size | Existing download/file editor |
| BLOB file reference | Existing metadata | Existing download/file editor |

## Validation

- `pnpm test` — 223 files, 3,776 tests passed
- `pnpm exec tsc -b --pretty false`
- ESLint on changed frontend source files
- `cargo test --manifest-path src-tauri/Cargo.toml drivers::common::tests --lib` — 79 tests passed
- `git diff --check`
- GitNexus change analysis — LOW risk, no affected execution processes

A MySQL Docker lab was also exercised at 10,239, 10,240, and 10,241-byte boundaries.

