### PR TITLE
Allow plugin installations to be cancelled

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -614,6 +614,7 @@ pub fn run() {
             // Plugin Registry
             plugins::commands::fetch_plugin_registry,
             plugins::commands::install_plugin,
+            plugins::commands::cancel_plugin_install,
             plugins::commands::uninstall_plugin,
             plugins::commands::get_installed_plugins,
             plugins::commands::disable_plugin,

--- a/src-tauri/src/plugins/commands.rs
+++ b/src-tauri/src/plugins/commands.rs
@@ -1,12 +1,10 @@
 use std::fs;
-use std::time::Duration;
 
 use crate::drivers::driver_trait::PluginManifest;
 use crate::plugins::installer::{self, InstalledPluginInfo};
 use crate::plugins::manager::ConfigManifest;
 use crate::plugins::registry::{self, RegistryPlugin, RegistryPluginWithStatus, RegistryReleaseWithStatus};
 use tauri::AppHandle;
-use tokio::time::sleep;
 
 /// Resolves which Tabularium registry to talk to. Operators pin a
 /// URL via `tabularium_registry_url` in `config.json`; otherwise the
@@ -157,11 +155,9 @@ pub async fn install_plugin(
     plugin_id: String,
     version: Option<String>,
 ) -> Result<(), String> {
-    // Updating an installed plugin must stop the existing process first,
-    // otherwise the OS may keep files locked while we replace the directory.
-    crate::drivers::registry::unregister_driver(&plugin_id).await;
-    crate::drivers::registry::unregister_manifest(&plugin_id).await;
-    sleep(Duration::from_millis(500)).await;
+    let install_guard = crate::plugins::install_cancellation::begin(&plugin_id)?;
+    let cancellation = install_guard.cancellation();
+    cancellation.check()?;
 
     let config = crate::config::load_config_internal(&app);
     let platform = registry::get_current_platform();
@@ -206,11 +202,13 @@ pub async fn install_plugin(
     // happens inside download_and_install, while the bundle is still in its
     // temp dir — a mismatching archive is discarded without ever touching an
     // existing installation.
+    cancellation.check()?;
     installer::download_and_install(
         &plugin_id,
         &download_url,
         expected_sha256.as_deref(),
         Some(&target_version),
+        cancellation,
     )
     .await?;
 
@@ -225,6 +223,11 @@ pub async fn install_plugin(
         .map_err(|e| format!("Plugin installed but failed to load: {}", e))?;
 
     Ok(())
+}
+
+#[tauri::command]
+pub fn cancel_plugin_install(plugin_id: String) -> bool {
+    crate::plugins::install_cancellation::cancel(&plugin_id)
 }
 
 #[tauri::command]

--- a/src-tauri/src/plugins/install_cancellation.rs
+++ b/src-tauri/src/plugins/install_cancellation.rs
@@ -1,0 +1,116 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use once_cell::sync::Lazy;
+use tokio::sync::Notify;
+
+pub const INSTALL_CANCELLED_ERROR: &str = "PLUGIN_INSTALL_CANCELLED";
+
+struct CancellationInner {
+    cancelled: AtomicBool,
+    notify: Notify,
+}
+
+#[derive(Clone)]
+pub struct InstallCancellation {
+    inner: Arc<CancellationInner>,
+}
+
+impl InstallCancellation {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(CancellationInner {
+                cancelled: AtomicBool::new(false),
+                notify: Notify::new(),
+            }),
+        }
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.inner.cancelled.load(Ordering::Acquire)
+    }
+
+    pub fn check(&self) -> Result<(), String> {
+        if self.is_cancelled() {
+            Err(INSTALL_CANCELLED_ERROR.to_string())
+        } else {
+            Ok(())
+        }
+    }
+
+    pub async fn cancelled(&self) {
+        if self.is_cancelled() {
+            return;
+        }
+
+        let notified = self.inner.notify.notified();
+        if self.is_cancelled() {
+            return;
+        }
+        notified.await;
+    }
+
+    fn cancel(&self) {
+        if !self.inner.cancelled.swap(true, Ordering::AcqRel) {
+            self.inner.notify.notify_waiters();
+        }
+    }
+}
+
+static ACTIVE_INSTALLS: Lazy<Mutex<HashMap<String, InstallCancellation>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+pub struct InstallGuard {
+    plugin_id: String,
+    cancellation: InstallCancellation,
+}
+
+impl InstallGuard {
+    pub fn cancellation(&self) -> &InstallCancellation {
+        &self.cancellation
+    }
+}
+
+impl Drop for InstallGuard {
+    fn drop(&mut self) {
+        let mut installs = ACTIVE_INSTALLS
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        installs.remove(&self.plugin_id);
+    }
+}
+
+pub fn begin(plugin_id: &str) -> Result<InstallGuard, String> {
+    let mut installs = ACTIVE_INSTALLS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if installs.contains_key(plugin_id) {
+        return Err(format!(
+            "An installation is already running for plugin '{}'",
+            plugin_id
+        ));
+    }
+
+    let cancellation = InstallCancellation::new();
+    installs.insert(plugin_id.to_string(), cancellation.clone());
+    Ok(InstallGuard {
+        plugin_id: plugin_id.to_string(),
+        cancellation,
+    })
+}
+
+pub fn cancel(plugin_id: &str) -> bool {
+    let cancellation = ACTIVE_INSTALLS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(plugin_id)
+        .cloned();
+
+    if let Some(cancellation) = cancellation {
+        cancellation.cancel();
+        true
+    } else {
+        false
+    }
+}

--- a/src-tauri/src/plugins/installer.rs
+++ b/src-tauri/src/plugins/installer.rs
@@ -1,10 +1,14 @@
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use tokio::time::sleep;
+
+use super::install_cancellation::{InstallCancellation, INSTALL_CANCELLED_ERROR};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct InstalledPluginInfo {
@@ -158,7 +162,9 @@ pub async fn download_and_install(
     download_url: &str,
     expected_sha256: Option<&str>,
     expected_version: Option<&str>,
+    cancellation: &InstallCancellation,
 ) -> Result<(), String> {
+    cancellation.check()?;
     let plugins_dir = get_plugins_dir()?;
     let tmp_dir = plugins_dir.join(format!(".tmp-{}", plugin_id));
     let final_dir = plugins_dir.join(plugin_id);
@@ -171,9 +177,13 @@ pub async fn download_and_install(
 
     // Download ZIP to memory
     log::info!("Downloading plugin '{}' from: {}", plugin_id, download_url);
-    let response = reqwest::get(download_url)
-        .await
-        .map_err(|e| format!("Failed to download plugin: {}", e))?;
+    let response = tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => return Err(INSTALL_CANCELLED_ERROR.to_string()),
+        result = reqwest::get(download_url) => {
+            result.map_err(|e| format!("Failed to download plugin: {}", e))?
+        }
+    };
 
     let status = response.status();
     let content_type = response
@@ -204,10 +214,13 @@ pub async fn download_and_install(
         ));
     }
 
-    let bytes = response
-        .bytes()
-        .await
-        .map_err(|e| format!("Failed to read plugin download: {}", e))?;
+    let bytes = tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => return Err(INSTALL_CANCELLED_ERROR.to_string()),
+        result = response.bytes() => {
+            result.map_err(|e| format!("Failed to read plugin download: {}", e))?
+        }
+    };
 
     log::info!(
         "Plugin '{}' downloaded {} bytes (content-type: {})",
@@ -241,6 +254,8 @@ pub async fn download_and_install(
         log::info!("Plugin '{}' SHA-256 verified ({})", plugin_id, actual);
     }
 
+    cancellation.check()?;
+
     // Extract to temp dir
     fs::create_dir_all(&tmp_dir).map_err(|e| format!("Failed to create temp directory: {}", e))?;
 
@@ -262,6 +277,12 @@ pub async fn download_and_install(
     })?;
 
     for i in 0..archive.len() {
+        if cancellation.is_cancelled() {
+            drop(archive);
+            fs::remove_dir_all(&tmp_dir).ok();
+            return Err(INSTALL_CANCELLED_ERROR.to_string());
+        }
+
         let mut file = archive
             .by_index(i)
             .map_err(|e| format!("Failed to read ZIP entry: {}", e))?;
@@ -282,8 +303,22 @@ pub async fn download_and_install(
                 }
             }
             let mut buf = Vec::new();
-            file.read_to_end(&mut buf)
-                .map_err(|e| format!("Failed to read ZIP file content: {}", e))?;
+            let mut chunk = [0_u8; 64 * 1024];
+            while !cancellation.is_cancelled() {
+                let read = file
+                    .read(&mut chunk)
+                    .map_err(|e| format!("Failed to read ZIP file content: {}", e))?;
+                if read == 0 {
+                    break;
+                }
+                buf.extend_from_slice(&chunk[..read]);
+            }
+            if cancellation.is_cancelled() {
+                drop(file);
+                drop(archive);
+                fs::remove_dir_all(&tmp_dir).ok();
+                return Err(INSTALL_CANCELLED_ERROR.to_string());
+            }
             fs::write(&out_path, &buf).map_err(|e| format!("Failed to write file: {}", e))?;
 
             // Set executable permissions on Unix
@@ -334,8 +369,21 @@ pub async fn download_and_install(
         }
     }
 
-    // Remove existing plugin dir if present
+    // Cancellation remains safe until this commit point: the existing plugin
+    // is still registered and its files have not been touched.
+    if cancellation.is_cancelled() {
+        fs::remove_dir_all(&tmp_dir).ok();
+        return Err(INSTALL_CANCELLED_ERROR.to_string());
+    }
+
+    // Updating an installed plugin must stop its process immediately before
+    // replacing files, otherwise the OS may keep them locked. Once this short
+    // commit phase starts, installation is completed atomically rather than
+    // leaving the existing plugin disabled.
     if final_dir.exists() {
+        crate::drivers::registry::unregister_driver(plugin_id).await;
+        crate::drivers::registry::unregister_manifest(plugin_id).await;
+        sleep(Duration::from_millis(500)).await;
         fs::remove_dir_all(&final_dir)
             .map_err(|e| format!("Failed to remove existing plugin: {}", e))?;
     }

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -2,6 +2,7 @@ pub mod commands;
 pub mod compat; // COMPAT(registry-ga): remove with the BC layer
 pub mod deep_link;
 pub mod driver;
+pub mod install_cancellation;
 pub mod installer;
 pub mod integrity;
 pub mod manager;

--- a/src-tauri/src/plugins/tests.rs
+++ b/src-tauri/src/plugins/tests.rs
@@ -2,8 +2,36 @@ use std::fs;
 
 use tempfile::tempdir;
 
+use super::install_cancellation::{begin, cancel, INSTALL_CANCELLED_ERROR};
 use super::installer::{has_manifest, migrate_plugins_between, read_plugin_info_from_dir};
 use super::manager::ConfigManifest;
+
+#[test]
+fn cancellation_marks_an_active_install() {
+    let guard = begin("cancellation-test-plugin").expect("begin install");
+
+    assert!(!guard.cancellation().is_cancelled());
+    assert!(cancel("cancellation-test-plugin"));
+    assert_eq!(
+        guard.cancellation().check().expect_err("cancelled install"),
+        INSTALL_CANCELLED_ERROR
+    );
+
+    drop(guard);
+    assert!(!cancel("cancellation-test-plugin"));
+}
+
+#[test]
+fn duplicate_install_is_rejected_until_guard_is_dropped() {
+    let guard = begin("duplicate-install-test-plugin").expect("begin install");
+    let error = begin("duplicate-install-test-plugin")
+        .err()
+        .expect("duplicate install must fail");
+    assert!(error.contains("already running"));
+
+    drop(guard);
+    assert!(begin("duplicate-install-test-plugin").is_ok());
+}
 
 #[test]
 fn reads_canonical_tabularium_manifest() {

--- a/src/components/settings/PluginsTab.tsx
+++ b/src/components/settings/PluginsTab.tsx
@@ -31,6 +31,7 @@ import {
   Home,
   FolderOpen,
   BookOpen,
+  CircleStop,
 } from "lucide-react";
 import clsx from "clsx";
 import { useSettings } from "../../hooks/useSettings";
@@ -52,6 +53,8 @@ import { SlotAnchor } from "../ui/SlotAnchor";
 
 type CardAccent = "green" | "amber" | "blue" | null;
 type AvailableFilter = "all" | "installed" | "updates";
+
+const INSTALL_CANCELLED_ERROR = "PLUGIN_INSTALL_CANCELLED";
 
 /* ── Band palette (deterministic per plugin name) ── */
 
@@ -134,11 +137,11 @@ function PluginCard({
   return (
     <div
       className={clsx(
-        "group relative flex h-full flex-col rounded-xl bg-elevated overflow-hidden",
+        "group relative flex h-full flex-col overflow-hidden rounded-2xl bg-elevated",
         "transition-all duration-200 ease-out",
         "hover:-translate-y-0.5",
         !accent &&
-          "border border-default hover:border-strong hover:shadow-lg hover:shadow-black/20",
+          "border border-default hover:border-strong hover:shadow-xl hover:shadow-black/20",
         accent === "green" && [
           "border border-default border-l-[3px] border-l-green-500/80",
           "hover:border-strong hover:shadow-lg hover:shadow-green-900/30",
@@ -158,35 +161,37 @@ function PluginCard({
       {showBand && (
         <div
           className={clsx(
-            "relative flex h-14 shrink-0 items-center justify-center overflow-hidden",
+            "relative flex h-[72px] shrink-0 items-center justify-center overflow-hidden",
             band.bg,
           )}
         >
-          {/* Subtle radial highlight so the band reads as a "platform" surface, not a flat stripe. */}
-          <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-white/[0.04] via-transparent to-black/20" />
-          {iconUrl ? (
-            <img
-              src={iconUrl}
-              alt=""
-              loading="lazy"
-              className="relative h-10 w-10 object-contain drop-shadow-md"
-              onError={(e) => {
-                (e.currentTarget as HTMLImageElement).style.display = "none";
-              }}
-            />
-          ) : (
-            <span
-              className={clsx(
-                "relative select-none text-4xl font-bold leading-none",
-                band.text,
-              )}
-            >
-              {name.trim().charAt(0).toUpperCase()}
-            </span>
-          )}
+          <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-white/[0.08] via-transparent to-black/25" />
+          <div className="pointer-events-none absolute -top-12 left-1/2 h-24 w-40 -translate-x-1/2 rounded-full bg-white/[0.06] blur-2xl" />
+          <div className="relative flex h-12 w-12 items-center justify-center rounded-xl border border-white/10 bg-base/35 shadow-lg shadow-black/15 backdrop-blur-sm transition-transform duration-200 group-hover:scale-105">
+            {iconUrl ? (
+              <img
+                src={iconUrl}
+                alt=""
+                loading="lazy"
+                className="h-9 w-9 object-contain drop-shadow-md"
+                onError={(e) => {
+                  (e.currentTarget as HTMLImageElement).style.display = "none";
+                }}
+              />
+            ) : (
+              <span
+                className={clsx(
+                  "select-none text-2xl font-bold leading-none",
+                  band.text,
+                )}
+              >
+                {name.trim().charAt(0).toUpperCase()}
+              </span>
+            )}
+          </div>
           {!!downloads && downloads > 0 && (
-            <span className="absolute bottom-1.5 right-1.5 flex items-center gap-1 rounded-full bg-black/40 px-1.5 py-px text-[10px] font-medium text-white/80 backdrop-blur-sm">
-              <Download size={9} />
+            <span className="absolute right-3 top-3 flex items-center gap-1.5 rounded-full border border-white/10 bg-black/30 px-2 py-1 text-[10px] font-semibold text-white/75 shadow-sm backdrop-blur-md">
+              <Download size={10} />
               {formatCount(downloads)}
             </span>
           )}
@@ -206,23 +211,23 @@ function PluginCard({
         </div>
       )}
 
-      <div className="flex flex-1 flex-col p-4 gap-2.5">
+      <div className="flex flex-1 flex-col gap-3 p-5">
         {/* Header */}
-        <div className="flex items-start justify-between gap-2">
+        <div className="flex items-start justify-between gap-3">
           <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2 flex-wrap">
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
               {primaryHref ? (
                 <button
                   type="button"
                   onClick={() => openUrl(primaryHref)}
                   title={primaryHref}
-                  className="inline-flex min-w-0 items-center gap-1 text-left text-sm font-semibold text-primary cursor-pointer hover:underline underline-offset-2"
+                  className="inline-flex min-w-0 items-center gap-1.5 text-left text-[15px] font-semibold tracking-tight text-primary transition-colors hover:text-blue-300"
                 >
                   <span className="truncate">{name}</span>
-                  <ExternalLink size={11} className="shrink-0 text-muted" />
+                  <ExternalLink size={12} className="shrink-0 text-muted" />
                 </button>
               ) : (
-                <span className="block truncate text-sm font-semibold text-primary">
+                <span className="block truncate text-[15px] font-semibold tracking-tight text-primary">
                   {name}
                 </span>
               )}
@@ -234,9 +239,9 @@ function PluginCard({
                   aria-label={t("settings.plugins.openHomepage", {
                     defaultValue: "Open homepage",
                   })}
-                  className="text-muted hover:text-primary cursor-pointer transition-colors"
+                  className="rounded-md p-0.5 text-muted transition-colors hover:bg-surface-secondary hover:text-primary"
                 >
-                  <Home size={11} />
+                  <Home size={12} />
                 </button>
               )}
               {onShowReadme && (
@@ -249,9 +254,9 @@ function PluginCard({
                   aria-label={t("connectionCatalogue.viewDetails", {
                     defaultValue: "More details",
                   })}
-                  className="text-muted hover:text-primary cursor-pointer transition-colors"
+                  className="rounded-md p-0.5 text-muted transition-colors hover:bg-surface-secondary hover:text-primary"
                 >
-                  <BookOpen size={11} />
+                  <BookOpen size={12} />
                 </button>
               )}
               {version && (
@@ -261,7 +266,7 @@ function PluginCard({
               )}
             </div>
             {parsedAuthor && (
-              <p className="mt-0.5 text-[10px] text-muted">
+              <p className="mt-1 text-[11px] text-muted">
                 {t("settings.plugins.by")}{" "}
                 {parsedAuthor.url ?? homepage ? (
                   <button
@@ -280,7 +285,7 @@ function PluginCard({
           {status && <div className="shrink-0 mt-0.5">{status}</div>}
         </div>
 
-        <p className="text-xs leading-relaxed text-secondary line-clamp-2 flex-1">
+        <p className="line-clamp-2 flex-1 text-[13px] leading-5 text-secondary">
           {description}
         </p>
 
@@ -291,7 +296,7 @@ function PluginCard({
         )}
       </div>
 
-      <div className="flex min-h-11 items-center justify-end gap-2 border-t border-default bg-base/50 px-4 py-2.5">
+      <div className="flex min-h-14 w-full items-center gap-2 border-t border-default bg-base/40 px-4 py-3">
         {actions}
       </div>
     </div>
@@ -574,6 +579,9 @@ export function PluginsTab({
   const [installingPluginId, setInstallingPluginId] = useState<string | null>(
     null,
   );
+  const [cancellingPluginId, setCancellingPluginId] = useState<string | null>(
+    null,
+  );
   const [pluginInstallError, setPluginInstallError] = useState<{
     pluginId: string;
     error: string;
@@ -742,17 +750,34 @@ export function PluginsTab({
           pluginId;
         onPluginsChanged?.({ type: "install", pluginId, pluginName });
       } catch (err) {
-        setPluginInstallError({
-          pluginId,
-          error: String(err),
-          operation: "install",
-        });
+        if (String(err) !== INSTALL_CANCELLED_ERROR) {
+          setPluginInstallError({
+            pluginId,
+            error: String(err),
+            operation: "install",
+          });
+        }
       } finally {
         setInstallingPluginId(null);
+        setCancellingPluginId(null);
       }
     },
     [refreshRegistry, refreshDrivers, onPluginsChanged, registryPlugins],
   );
+
+  const doCancelInstall = useCallback(async (pluginId: string) => {
+    setCancellingPluginId(pluginId);
+    try {
+      await invoke<boolean>("cancel_plugin_install", { pluginId });
+    } catch (err) {
+      setCancellingPluginId(null);
+      setPluginInstallError({
+        pluginId,
+        error: String(err),
+        operation: "install",
+      });
+    }
+  }, []);
 
   const doRemove = useCallback(
     (pluginId: string, pluginName: string) => {
@@ -1341,14 +1366,14 @@ export function PluginsTab({
                     plugin.kind || remainingTags.length > 0 ? (
                       <>
                         {plugin.kind && (
-                          <span className="rounded-md border border-blue-700/30 bg-blue-900/20 px-1.5 py-px text-blue-300">
+                          <span className="rounded-full border border-blue-700/30 bg-blue-900/20 px-2 py-0.5 font-medium text-blue-300">
                             {plugin.kind}
                           </span>
                         )}
                         {remainingTags.slice(0, 4).map((tag) => (
                           <span
                             key={tag}
-                            className="rounded-md border border-default bg-base px-1.5 py-px"
+                            className="rounded-full border border-default bg-base px-2 py-0.5"
                           >
                             {tag}
                           </span>
@@ -1409,24 +1434,33 @@ export function PluginsTab({
                               (isCompatible ? (
                                 <button
                                   onClick={() =>
-                                    doInstall(plugin.id, selectedVer)
+                                    installingPluginId === plugin.id
+                                      ? doCancelInstall(plugin.id)
+                                      : doInstall(plugin.id, selectedVer)
                                   }
                                   disabled={
-                                    installingPluginId === plugin.id
+                                    (installingPluginId !== null &&
+                                      installingPluginId !== plugin.id) ||
+                                    cancellingPluginId === plugin.id
                                   }
-                                  className={`w-full flex items-center justify-center gap-1.5 px-4 py-1.5 rounded-lg text-xs font-medium text-white transition-colors disabled:opacity-50 ${
-                                    isDowngrade
-                                      ? "bg-amber-600 hover:bg-amber-500"
-                                      : isUpdate
-                                        ? "bg-green-600 hover:bg-green-500"
-                                        : "bg-blue-600 hover:bg-blue-500"
-                                  }`}
+                                  className={clsx(
+                                    "flex min-h-8 min-w-0 flex-1 items-center justify-center gap-1.5 rounded-lg px-4 py-1.5 text-xs font-semibold text-white shadow-sm transition-colors disabled:opacity-50",
+                                    installingPluginId === plugin.id
+                                      ? "bg-red-600 hover:bg-red-500"
+                                      : isDowngrade
+                                        ? "bg-amber-600 hover:bg-amber-500"
+                                        : isUpdate
+                                          ? "bg-green-600 hover:bg-green-500"
+                                          : "bg-blue-600 hover:bg-blue-500",
+                                  )}
                                 >
-                                  {installingPluginId === plugin.id ? (
+                                  {cancellingPluginId === plugin.id ? (
                                     <Loader2
                                       size={12}
                                       className="animate-spin"
                                     />
+                                  ) : installingPluginId === plugin.id ? (
+                                    <CircleStop size={12} />
                                   ) : isDowngrade ? (
                                     <RotateCcw size={12} />
                                   ) : isUpdate ? (
@@ -1434,27 +1468,29 @@ export function PluginsTab({
                                   ) : (
                                     <Download size={12} />
                                   )}
-                                  {isDowngrade
-                                    ? `${t("settings.plugins.downgrade")} v${selectedVer}`
-                                    : isUpdate
-                                      ? `${t("settings.plugins.update")} v${selectedVer}`
-                                      : `${t("settings.plugins.install")} v${selectedVer}`}
+                                  {installingPluginId === plugin.id
+                                    ? t("common.cancel")
+                                    : isDowngrade
+                                      ? `${t("settings.plugins.downgrade")} v${selectedVer}`
+                                      : isUpdate
+                                        ? `${t("settings.plugins.update")} v${selectedVer}`
+                                        : `${t("settings.plugins.install")} v${selectedVer}`}
                                 </button>
                               ) : (
-                                <div className="w-full flex flex-col items-end gap-1">
+                                <div className="flex min-w-0 flex-1 flex-col gap-1.5">
                                   <button
                                     disabled
                                     title={t(
                                       "settings.plugins.requiresVersion",
                                       { version: minVersion },
                                     )}
-                                    className="w-full flex items-center justify-center gap-1.5 px-4 py-1.5 rounded-lg text-xs font-medium text-muted bg-surface-tertiary cursor-not-allowed opacity-50"
+                                    className="flex min-h-8 w-full cursor-not-allowed items-center justify-center gap-1.5 rounded-lg border border-default bg-surface-tertiary px-4 py-1.5 text-xs font-medium text-muted opacity-60"
                                   >
                                     <Download size={12} />
                                     {t("settings.plugins.install")} v
                                     {selectedVer}
                                   </button>
-                                  <span className="text-[10px] text-amber-400/80 text-right">
+                                  <span className="truncate text-center text-[10px] font-medium text-amber-400/90">
                                     {t("settings.plugins.requiresVersion", {
                                       version: minVersion,
                                     })}


### PR DESCRIPTION
## Summary

- turn the install action into a cancel button while a plugin is downloading
- stop the active request and extraction, then remove staged files
- keep an existing plugin active until its replacement is verified and ready
- improve the registry card layout and installation states

## Testing

- `pnpm exec eslint src/components/settings/PluginsTab.tsx`
- `pnpm typecheck`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml plugins::tests::`