### PR TITLE
fix: unify safety confirmation guards

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -3,9 +3,9 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
+use std::sync::RwLock;
 use tauri::AppHandle;
 use tauri::Manager;
-use std::sync::RwLock;
 
 use std::collections::HashMap;
 
@@ -79,6 +79,8 @@ pub struct AppConfig {
     /// Default: `true` — matches the behaviour users expect from most editors.
     pub editor_accept_suggestion_on_enter: Option<bool>,
     pub run_statement_under_cursor: Option<bool>,
+    /// Delay destructive-query and production-write confirmations for five seconds. Default: false.
+    pub safety_confirmation_delay_enabled: Option<bool>,
     // ----- SQL Formatter -----
     pub formatter_keyword_case: Option<String>,
     pub formatter_indent_style: Option<String>,
@@ -371,6 +373,10 @@ pub fn save_config(app: AppHandle, config: AppConfig) -> Result<(), String> {
         }
         if config.run_statement_under_cursor.is_some() {
             existing_config.run_statement_under_cursor = config.run_statement_under_cursor;
+        }
+        if config.safety_confirmation_delay_enabled.is_some() {
+            existing_config.safety_confirmation_delay_enabled =
+                config.safety_confirmation_delay_enabled;
         }
         if config.ping_interval.is_some() {
             let old_interval = existing_config.ping_interval;
@@ -923,6 +929,7 @@ mod tests {
     #[test]
     fn editor_fields_default_to_none() {
         let config = AppConfig::default();
+        assert!(config.safety_confirmation_delay_enabled.is_none());
         assert!(config.editor_theme.is_none());
         assert!(config.editor_font_family.is_none());
         assert!(config.editor_font_size.is_none());
@@ -944,6 +951,7 @@ mod tests {
         config.editor_show_line_numbers = Some(true);
         config.editor_theme = Some("tabularis-light".to_string());
         config.editor_accept_suggestion_on_enter = Some(true);
+        config.safety_confirmation_delay_enabled = Some(true);
 
         let json = serde_json::to_string(&config).unwrap();
         assert!(json.contains("editorFontFamily"));
@@ -954,9 +962,11 @@ mod tests {
         assert!(json.contains("editorShowLineNumbers"));
         assert!(json.contains("editorTheme"));
         assert!(json.contains("editorAcceptSuggestionOnEnter"));
+        assert!(json.contains("safetyConfirmationDelayEnabled"));
         // snake_case must not appear
         assert!(!json.contains("editor_font_family"));
         assert!(!json.contains("editor_accept_suggestion_on_enter"));
+        assert!(!json.contains("safety_confirmation_delay_enabled"));
     }
 
     #[test]
@@ -969,7 +979,8 @@ mod tests {
             "editorWordWrap": true,
             "editorShowLineNumbers": true,
             "editorTheme": "tabularis-dark",
-            "editorAcceptSuggestionOnEnter": true
+            "editorAcceptSuggestionOnEnter": true,
+            "safetyConfirmationDelayEnabled": true
         }"#;
 
         let config: AppConfig = serde_json::from_str(json).unwrap();
@@ -980,6 +991,7 @@ mod tests {
         assert_eq!(config.editor_show_line_numbers, Some(true));
         assert_eq!(config.editor_theme.as_deref(), Some("tabularis-dark"));
         assert_eq!(config.editor_accept_suggestion_on_enter, Some(true));
+        assert_eq!(config.safety_confirmation_delay_enabled, Some(true));
     }
 
     #[test]

--- a/src/components/notebook/NotebookView.tsx
+++ b/src/components/notebook/NotebookView.tsx
@@ -60,6 +60,8 @@ import {
 import { useDatabase } from "../../hooks/useDatabase";
 import { useSqlAutocompleteRegistration } from "../../hooks/useSqlAutocompleteRegistration";
 import { usesMultiDatabaseLayout } from "../../utils/database";
+import { isProductionConnection } from "../../utils/environment";
+import { passQueryGuards } from "../../utils/queryGuard";
 import { useSettings } from "../../hooks/useSettings";
 import { useAlert } from "../../hooks/useAlert";
 import { useKeybindings } from "../../hooks/useKeybindings";
@@ -92,8 +94,13 @@ export function NotebookView({
   isActive,
 }: NotebookViewProps) {
   const { t } = useTranslation();
-  const { activeSchema, activeCapabilities, selectedDatabases, activeDriver } =
-    useDatabase();
+  const {
+    activeSchema,
+    activeCapabilities,
+    selectedDatabases,
+    activeDriver,
+    connections,
+  } = useDatabase();
   const isMultiDb = usesMultiDatabaseLayout(activeCapabilities, selectedDatabases);
   const effectiveSchema =
     tab.schema || activeSchema || (isMultiDb ? selectedDatabases[0] : null);
@@ -102,13 +109,17 @@ export function NotebookView({
     enabled: isActive,
   });
   const { settings } = useSettings();
+  const hasProductionConnection = isProductionConnection(
+    connections,
+    connectionId,
+  );
   const { showAlert } = useAlert();
   const { matchesShortcut } = useKeybindings();
   const {
     pending: dangerousQuery,
     guardQuery: guardDangerousQuery,
     resolve: resolveDangerousQuery,
-  } = useDangerousQueryGuard();
+  } = useDangerousQueryGuard(!hasProductionConnection);
   const guardProductionWrite = useProductionGuard();
 
   // Local notebook state — loaded from store/disk, NOT from tab
@@ -369,12 +380,11 @@ export function NotebookView({
         return;
       }
 
-      if (!(await guardDangerousQuery(resolvedSql))) {
-        updateCell(cellId, { isLoading: false });
-        return;
-      }
-
-      if (!(await guardProductionWrite(connectionId, resolvedSql))) {
+      const mayRun = await passQueryGuards({
+        guardProduction: () => guardProductionWrite(connectionId, resolvedSql),
+        guardDangerousQuery: () => guardDangerousQuery(resolvedSql),
+      });
+      if (!mayRun) {
         updateCell(cellId, { isLoading: false });
         return;
       }
@@ -863,7 +873,9 @@ export function NotebookView({
         sql={dangerousQuery?.sql}
         confirmLabel={t("editor.dangerousQueryConfirm")}
         variant="danger"
-        confirmDelaySeconds={5}
+        confirmDelaySeconds={
+          settings.safetyConfirmationDelayEnabled ? 5 : undefined
+        }
       />
       <NotebookToolbar {...toolbarProps} />
       {showHistory && (

--- a/src/components/notebook/NotebookView.tsx
+++ b/src/components/notebook/NotebookView.tsx
@@ -60,16 +60,11 @@ import {
 import { useDatabase } from "../../hooks/useDatabase";
 import { useSqlAutocompleteRegistration } from "../../hooks/useSqlAutocompleteRegistration";
 import { usesMultiDatabaseLayout } from "../../utils/database";
-import { isProductionConnection } from "../../utils/environment";
-import { passQueryGuards } from "../../utils/queryGuard";
 import { useSettings } from "../../hooks/useSettings";
 import { useAlert } from "../../hooks/useAlert";
 import { useKeybindings } from "../../hooks/useKeybindings";
-import {
-  useDangerousQueryGuard,
-  DANGEROUS_QUERY_I18N,
-} from "../../hooks/useDangerousQueryGuard";
-import { useProductionGuard } from "../../hooks/useProductionGuard";
+import { DANGEROUS_QUERY_I18N } from "../../hooks/useDangerousQueryGuard";
+import { useQueryGuards } from "../../hooks/useQueryGuards";
 import { ConfirmModal } from "../modals/ConfirmModal";
 import { NotebookToolbar } from "./NotebookToolbar";
 import { NotebookHistoryPanel } from "./NotebookHistoryPanel";
@@ -94,13 +89,8 @@ export function NotebookView({
   isActive,
 }: NotebookViewProps) {
   const { t } = useTranslation();
-  const {
-    activeSchema,
-    activeCapabilities,
-    selectedDatabases,
-    activeDriver,
-    connections,
-  } = useDatabase();
+  const { activeSchema, activeCapabilities, selectedDatabases, activeDriver } =
+    useDatabase();
   const isMultiDb = usesMultiDatabaseLayout(activeCapabilities, selectedDatabases);
   const effectiveSchema =
     tab.schema || activeSchema || (isMultiDb ? selectedDatabases[0] : null);
@@ -109,18 +99,13 @@ export function NotebookView({
     enabled: isActive,
   });
   const { settings } = useSettings();
-  const hasProductionConnection = isProductionConnection(
-    connections,
-    connectionId,
-  );
   const { showAlert } = useAlert();
   const { matchesShortcut } = useKeybindings();
   const {
     pending: dangerousQuery,
-    guardQuery: guardDangerousQuery,
+    guardQuery: guardQueryExecution,
     resolve: resolveDangerousQuery,
-  } = useDangerousQueryGuard(!hasProductionConnection);
-  const guardProductionWrite = useProductionGuard();
+  } = useQueryGuards(connectionId);
 
   // Local notebook state — loaded from store/disk, NOT from tab
   const [notebook, setNotebook] = useState<NotebookState | null>(() =>
@@ -380,10 +365,7 @@ export function NotebookView({
         return;
       }
 
-      const mayRun = await passQueryGuards({
-        guardProduction: () => guardProductionWrite(connectionId, resolvedSql),
-        guardDangerousQuery: () => guardDangerousQuery(resolvedSql),
-      });
+      const mayRun = await guardQueryExecution(resolvedSql);
       if (!mayRun) {
         updateCell(cellId, { isLoading: false });
         return;
@@ -443,8 +425,7 @@ export function NotebookView({
       updateCell,
       params,
       activeDriver,
-      guardDangerousQuery,
-      guardProductionWrite,
+      guardQueryExecution,
     ],
   );
 

--- a/src/components/settings/GeneralTab.tsx
+++ b/src/components/settings/GeneralTab.tsx
@@ -146,6 +146,18 @@ export function GeneralTab() {
             onChange={(v) => updateSetting("runStatementUnderCursor", v)}
           />
         </SettingRow>
+
+        <SettingRow
+          label={t("settings.safetyConfirmationDelay")}
+          description={t("settings.safetyConfirmationDelayDesc")}
+        >
+          <SettingToggle
+            checked={settings.safetyConfirmationDelayEnabled === true}
+            onChange={(v) =>
+              updateSetting("safetyConfirmationDelayEnabled", v)
+            }
+          />
+        </SettingRow>
       </SettingSection>
 
       <SettingSection title={t("settings.connectionHealthCheck")}>

--- a/src/contexts/ProductionGuardContext.tsx
+++ b/src/contexts/ProductionGuardContext.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { TriangleAlert, X } from "lucide-react";
 import { Modal } from "../components/ui/Modal";
 import { SqlPreview } from "../components/ui/SqlPreview";
+import { useSettings } from "../hooks/useSettings";
 import {
   ProductionGuardContext,
   snoozedConnectionIds,
@@ -23,18 +24,29 @@ interface PendingPrompt {
 
 export function ProductionGuardProvider({ children }: { children: ReactNode }) {
   const { t } = useTranslation();
+  const { settings } = useSettings();
   const [pending, setPending] = useState<PendingPrompt | null>(null);
   const [snooze, setSnooze] = useState(false);
+  const [remaining, setRemaining] = useState(0);
 
   const request = useCallback<GuardRequest>(
     (connectionId, connectionName, sql) => {
       return new Promise<boolean>((resolve) => {
         setSnooze(false);
+        setRemaining(settings.safetyConfirmationDelayEnabled ? 5 : 0);
         setPending({ connectionId, connectionName, sql, resolve });
       });
     },
-    [],
+    [settings.safetyConfirmationDelayEnabled],
   );
+
+  useEffect(() => {
+    if (!pending || remaining <= 0) return;
+    const timeout = setTimeout(() => {
+      setRemaining((previous) => Math.max(0, previous - 1));
+    }, 1000);
+    return () => clearTimeout(timeout);
+  }, [pending, remaining]);
 
   const finish = (ok: boolean) => {
     if (!pending) return;
@@ -42,6 +54,7 @@ export function ProductionGuardProvider({ children }: { children: ReactNode }) {
       snoozedConnectionIds.add(pending.connectionId);
     }
     pending.resolve(ok);
+    setRemaining(0);
     setPending(null);
   };
 
@@ -97,9 +110,12 @@ export function ProductionGuardProvider({ children }: { children: ReactNode }) {
             </button>
             <button
               onClick={() => finish(true)}
-              className="px-4 py-2 bg-red-600 hover:bg-red-500 text-white rounded-lg text-sm font-medium transition-colors"
+              disabled={remaining > 0}
+              className="px-4 py-2 bg-red-600 hover:bg-red-500 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {t("environment.warnConfirm")}
+              {remaining > 0
+                ? `${t("environment.warnConfirm")} (${remaining})`
+                : t("environment.warnConfirm")}
             </button>
           </div>
         </div>

--- a/src/contexts/SettingsContext.ts
+++ b/src/contexts/SettingsContext.ts
@@ -64,6 +64,8 @@ export interface Settings {
   editorShowLineNumbers?: boolean;
   editorAcceptSuggestionOnEnter?: boolean;
   runStatementUnderCursor?: boolean;
+  /** Delay destructive-query and production-write confirmations for five seconds. Default: false. */
+  safetyConfirmationDelayEnabled?: boolean;
   // SQL Formatter
   formatterKeywordCase?: "upper" | "lower" | "preserve";
   formatterIndentStyle?: "standard" | "tabularLeft" | "tabularRight";
@@ -162,6 +164,7 @@ export const DEFAULT_SETTINGS: Settings = {
   editorShowLineNumbers: true,
   editorAcceptSuggestionOnEnter: true,
   runStatementUnderCursor: true,
+  safetyConfirmationDelayEnabled: false,
   formatterKeywordCase: "upper",
   formatterIndentStyle: "standard",
   formatterTabWidth: 2,

--- a/src/hooks/useDangerousQueryGuard.ts
+++ b/src/hooks/useDangerousQueryGuard.ts
@@ -39,9 +39,10 @@ export const DANGEROUS_QUERY_I18N: Record<
  * dialog) for safe statements; for dangerous ones it opens the dialog and
  * resolves once the user answers. A second dangerous statement submitted while
  * a dialog is already open is declined immediately instead of replacing the
- * pending one, so the first caller's promise always settles.
+ * pending one, so the first caller's promise always settles. Pass `false` to
+ * disable this guard when a higher-priority safety prompt handles the action.
  */
-export function useDangerousQueryGuard() {
+export function useDangerousQueryGuard(enabled = true) {
   const [pending, setPending] = useState<DangerousQueryInfo | null>(null);
   const resolverRef = useRef<((confirmed: boolean) => void) | null>(null);
 
@@ -64,6 +65,8 @@ export function useDangerousQueryGuard() {
 
   const guardQuery = useCallback(
     (sqlOrQueries: string | string[]): Promise<boolean> => {
+      if (!enabled) return Promise.resolve(true);
+
       const statements = Array.isArray(sqlOrQueries)
         ? sqlOrQueries
         : [sqlOrQueries];
@@ -80,7 +83,7 @@ export function useDangerousQueryGuard() {
       if (!first) return Promise.resolve(true);
       return requestConfirmation({ ...first, count });
     },
-    [requestConfirmation],
+    [enabled, requestConfirmation],
   );
 
   return { pending, isPending: pending !== null, guardQuery, resolve };

--- a/src/hooks/useQueryGuards.ts
+++ b/src/hooks/useQueryGuards.ts
@@ -1,0 +1,52 @@
+import { useCallback } from "react";
+import { useDatabase } from "./useDatabase";
+import {
+  useDangerousQueryGuard,
+  type DangerousQueryInfo,
+} from "./useDangerousQueryGuard";
+import { useProductionGuard } from "./useProductionGuard";
+import { isProductionConnection } from "../utils/environment";
+import { passQueryGuards } from "../utils/queryGuard";
+
+interface QueryGuards {
+  pending: DangerousQueryInfo | null;
+  isPending: boolean;
+  guardQuery: (sqlOrQueries: string | string[]) => Promise<boolean>;
+  resolve: (confirmed: boolean) => void;
+}
+
+/**
+ * Composes production and dangerous-query confirmations into one ordered gate.
+ * On production connections, the production prompt replaces the standard
+ * dangerous-query prompt so a write never displays two confirmations.
+ */
+export function useQueryGuards(
+  connectionId: string | null | undefined,
+): QueryGuards {
+  const { connections } = useDatabase();
+  const isProduction = isProductionConnection(connections, connectionId);
+  const {
+    pending,
+    isPending,
+    guardQuery: guardDangerousQuery,
+    resolve,
+  } = useDangerousQueryGuard(!isProduction);
+  const guardProductionWrite = useProductionGuard();
+
+  const guardQuery = useCallback(
+    (sqlOrQueries: string | string[]) => {
+      const productionSql = Array.isArray(sqlOrQueries)
+        ? sqlOrQueries.join(";\n")
+        : sqlOrQueries;
+
+      return passQueryGuards({
+        guardProduction: () =>
+          guardProductionWrite(connectionId, productionSql),
+        guardDangerousQuery: () => guardDangerousQuery(sqlOrQueries),
+      });
+    },
+    [connectionId, guardDangerousQuery, guardProductionWrite],
+  );
+
+  return { pending, isPending, guardQuery, resolve };
+}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -471,6 +471,8 @@
     "queryExecution": "Abfrageausführung",
     "runStatementUnderCursor": "Anweisung unter dem Cursor ausführen",
     "runStatementUnderCursorDesc": "Wenn ein Skript mehrere Anweisungen enthält, wird die Anweisung unter dem Cursor ausgeführt, statt die Abfrageauswahl anzuzeigen. Markiere Text, um einen bestimmten Bereich auszuführen.",
+    "safetyConfirmationDelay": "Sicherheitsbestätigungen verzögern",
+    "safetyConfirmationDelayDesc": "Deaktiviert Bestätigungsschaltflächen für destruktive Abfragen und Produktionsschreibvorgänge fünf Sekunden lang.",
     "formatter_title": "SQL-Formatierung",
     "formatter_keywordCase": "Schlüsselwort-Schreibweise",
     "formatter_keywordCaseDesc": "Groß-/Kleinschreibung von SQL-Schlüsselwörtern (SELECT, FROM, WHERE) nach der Formatierung.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -506,6 +506,8 @@
     "queryExecution": "Query Execution",
     "runStatementUnderCursor": "Run statement under cursor",
     "runStatementUnderCursorDesc": "When a script has multiple statements, run the one under the cursor instead of showing the query picker. Select text to run a specific range.",
+    "safetyConfirmationDelay": "Delay safety confirmations",
+    "safetyConfirmationDelayDesc": "Disable confirmation buttons for five seconds for destructive queries and production writes.",
     "formatter_title": "SQL Formatter",
     "formatter_keywordCase": "Keyword Case",
     "formatter_keywordCaseDesc": "How SQL keywords (SELECT, FROM, WHERE) are capitalized after formatting.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -496,6 +496,8 @@
     "queryExecution": "Ejecución de consultas",
     "runStatementUnderCursor": "Ejecutar la instrucción bajo el cursor",
     "runStatementUnderCursorDesc": "Cuando un script tiene varias instrucciones, ejecuta la que está bajo el cursor en lugar de mostrar el selector de consultas. Selecciona texto para ejecutar un rango específico.",
+    "safetyConfirmationDelay": "Retrasar las confirmaciones de seguridad",
+    "safetyConfirmationDelayDesc": "Desactiva los botones de confirmación durante cinco segundos para consultas destructivas y escrituras en producción.",
     "formatter_title": "Formateador SQL",
     "formatter_keywordCase": "Mayúsculas en palabras clave",
     "formatter_keywordCaseDesc": "Cómo se capitalizan las palabras clave SQL (SELECT, FROM, WHERE) después del formateo.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -501,6 +501,8 @@
     "queryExecution": "Exécution des requêtes",
     "runStatementUnderCursor": "Exécuter l'instruction sous le curseur",
     "runStatementUnderCursorDesc": "Lorsqu'un script contient plusieurs instructions, exécute celle sous le curseur au lieu d'afficher le sélecteur de requêtes. Sélectionnez du texte pour exécuter une plage spécifique.",
+    "safetyConfirmationDelay": "Retarder les confirmations de sécurité",
+    "safetyConfirmationDelayDesc": "Désactive les boutons de confirmation pendant cinq secondes pour les requêtes destructives et les écritures en production.",
     "formatter_title": "Formateur SQL",
     "formatter_keywordCase": "Casse des mots-clés",
     "formatter_keywordCaseDesc": "Comment les mots-clés SQL (SELECT, FROM, WHERE) sont capitalisés après le formatage.",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -496,6 +496,8 @@
     "queryExecution": "Esecuzione query",
     "runStatementUnderCursor": "Esegui l'istruzione sotto il cursore",
     "runStatementUnderCursorDesc": "Quando uno script contiene più istruzioni, esegue quella sotto il cursore invece di mostrare il selettore di query. Seleziona il testo per eseguire un intervallo specifico.",
+    "safetyConfirmationDelay": "Ritarda le conferme di sicurezza",
+    "safetyConfirmationDelayDesc": "Disabilita i pulsanti di conferma per cinque secondi per le query distruttive e le scritture in produzione.",
     "formatter_title": "Formattatore SQL",
     "formatter_keywordCase": "Maiuscole parole chiave",
     "formatter_keywordCaseDesc": "Come vengono capitalizzate le parole chiave SQL (SELECT, FROM, WHERE) dopo la formattazione.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -482,6 +482,8 @@
     "queryExecution": "クエリの実行",
     "runStatementUnderCursor": "カーソル位置のステートメントを実行",
     "runStatementUnderCursorDesc": "スクリプトに複数のステートメントがある場合、クエリ選択画面を表示せずにカーソル位置のステートメントを実行します。特定の範囲を実行するにはテキストを選択してください。",
+    "safetyConfirmationDelay": "安全確認を遅延",
+    "safetyConfirmationDelayDesc": "破壊的なクエリと本番環境への書き込みでは、確認ボタンを5秒間無効にします。",
     "formatter_title": "SQLフォーマッター",
     "formatter_keywordCase": "キーワードの大文字/小文字",
     "formatter_keywordCaseDesc": "フォーマット後のSQLキーワード（SELECT、FROM、WHERE）の大文字/小文字。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -446,6 +446,8 @@
     "queryExecution": "쿼리 실행",
     "runStatementUnderCursor": "커서 위치의 구문 실행",
     "runStatementUnderCursorDesc": "스크립트에 여러 구문이 있을 때 쿼리 선택 창을 표시하지 않고 커서 위치의 구문을 실행합니다. 특정 범위를 실행하려면 텍스트를 선택하세요.",
+    "safetyConfirmationDelay": "안전 확인 지연",
+    "safetyConfirmationDelayDesc": "파괴적인 쿼리와 프로덕션 쓰기의 확인 버튼을 5초 동안 비활성화합니다.",
     "formatter_title": "SQL 포맷터",
     "formatter_keywordCase": "키워드 대소문자",
     "formatter_keywordCaseDesc": "포맷 후 SQL 키워드(SELECT, FROM, WHERE)의 대소문자 처리.",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -477,6 +477,8 @@
     "queryExecution": "Execução de Consultas",
     "runStatementUnderCursor": "Executar instrução sob o cursor",
     "runStatementUnderCursorDesc": "Quando um script tem várias instruções, executa a que está sob o cursor em vez de mostrar o seletor de consultas. Selecione um texto para executar um intervalo específico.",
+    "safetyConfirmationDelay": "Atrasar confirmações de segurança",
+    "safetyConfirmationDelayDesc": "Desativa os botões de confirmação por cinco segundos para consultas destrutivas e gravações em produção.",
     "formatter_title": "Formatador SQL",
     "formatter_keywordCase": "Caixa das Palavras-Chave",
     "formatter_keywordCaseDesc": "Como as palavras-chave SQL (SELECT, FROM, WHERE) são capitalizadas após a formatação.",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -466,6 +466,8 @@
     "queryExecution": "Выполнение запросов",
     "runStatementUnderCursor": "Выполнять запрос под курсором",
     "runStatementUnderCursorDesc": "Если скрипт содержит несколько запросов, выполняется тот, что под курсором, вместо показа списка запросов. Выделите текст, чтобы выполнить определённый фрагмент.",
+    "safetyConfirmationDelay": "Задержка подтверждений безопасности",
+    "safetyConfirmationDelayDesc": "Отключает кнопки подтверждения на пять секунд для разрушительных запросов и записи в production.",
     "formatter_title": "Форматирование SQL",
     "formatter_keywordCase": "Регистр ключевых слов",
     "formatter_keywordCaseDesc": "Регистр ключевых слов SQL (SELECT, FROM, WHERE) после форматирования.",

--- a/src/i18n/locales/tl.json
+++ b/src/i18n/locales/tl.json
@@ -501,6 +501,8 @@
     "queryExecution": "Pagpapatakbo ng Query",
     "runStatementUnderCursor": "Patakbuhin ang statement sa ilalim ng cursor",
     "runStatementUnderCursorDesc": "Kapag maraming statement ang isang script, patakbuhin ang nasa ilalim ng cursor sa halip na ipakita ang query picker. Pumili ng teksto para patakbuhin ang isang partikular na saklaw.",
+    "safetyConfirmationDelay": "Iantala ang mga kumpirmasyon sa kaligtasan",
+    "safetyConfirmationDelayDesc": "I-disable ang mga confirmation button nang limang segundo para sa mapanirang query at production writes.",
     "formatter_title": "SQL Formatter",
     "formatter_keywordCase": "Case ng Keyword",
     "formatter_keywordCaseDesc": "Paano icapitalize ang SQL keywords (SELECT, FROM, WHERE) pagkatapos i-format.",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -778,7 +778,9 @@
     },
     "queryExecution": "查询执行",
     "runStatementUnderCursor": "执行光标所在的语句",
-    "runStatementUnderCursorDesc": "当脚本包含多条语句时，执行光标所在的语句，而不显示查询选择器。选中文本可执行指定范围。"
+    "runStatementUnderCursorDesc": "当脚本包含多条语句时，执行光标所在的语句，而不显示查询选择器。选中文本可执行指定范围。",
+    "safetyConfirmationDelay": "延迟安全确认",
+    "safetyConfirmationDelayDesc": "对于破坏性查询和生产环境写入，将确认按钮禁用五秒。"
   },
   "update": {
     "newVersionAvailable": "有新版本可用",

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -15,6 +15,8 @@ import {
   usesMultiDatabaseLayout,
 } from "../utils/database";
 import { isReadonly, supportsExplain } from "../utils/driverCapabilities";
+import { isProductionConnection } from "../utils/environment";
+import { passQueryGuards } from "../utils/queryGuard";
 import { useClickOutside } from "../hooks/useClickOutside";
 import {
   useDangerousQueryGuard,
@@ -236,6 +238,10 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
   const driverReadonly = isReadonly(activeCapabilities);
   const driverSupportsExplain = supportsExplain(activeCapabilities);
   const activeDialect = activeCapabilities?.sql_dialect;
+  const hasProductionConnection = isProductionConnection(
+    connections,
+    activeConnectionId,
+  );
 
   // Editor panes stay mounted (hidden with display:none) so Monaco never
   // remounts. Render them sorted by id, decoupled from the tab-strip order:
@@ -413,7 +419,7 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
     pending: dangerousQuery,
     guardQuery: guardDangerousQuery,
     resolve: resolveDangerousQuery,
-  } = useDangerousQueryGuard();
+  } = useDangerousQueryGuard(!hasProductionConnection);
   const guardProductionWrite = useProductionGuard();
   const [isTabSwitcherOpen, setIsTabSwitcherOpen] = useState(false);
   const [isRunDropdownOpen, setIsRunDropdownOpen] = useState(false);
@@ -929,8 +935,12 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
 
       if (!textToRun || !textToRun.trim()) return;
 
-      if (!(await guardDangerousQuery(textToRun))) return;
-      if (!(await guardProductionWrite(activeConnectionId, textToRun))) return;
+      const mayRun = await passQueryGuards({
+        guardProduction: () =>
+          guardProductionWrite(activeConnectionId, textToRun),
+        guardDangerousQuery: () => guardDangerousQuery(textToRun),
+      });
+      if (!mayRun) return;
 
       // Check for parameters
       const params = extractQueryParams(textToRun, activeDialect);
@@ -1171,10 +1181,12 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
       const targetTab = tabsRef.current.find((t) => t.id === targetTabId);
       if (!targetTab) return;
 
-      if (!(await guardDangerousQuery(queries))) return;
-      if (!(await guardProductionWrite(activeConnectionId, queries.join(";\n")))) {
-        return;
-      }
+      const mayRun = await passQueryGuards({
+        guardProduction: () =>
+          guardProductionWrite(activeConnectionId, queries.join(";\n")),
+        guardDangerousQuery: () => guardDangerousQuery(queries),
+      });
+      if (!mayRun) return;
 
       // Collect all unique parameters across all queries
       const allParams = [
@@ -4687,7 +4699,9 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
         sql={dangerousQuery?.sql}
         confirmLabel={t("editor.dangerousQueryConfirm")}
         variant="danger"
-        confirmDelaySeconds={5}
+        confirmDelaySeconds={
+          settings.safetyConfirmationDelayEnabled ? 5 : undefined
+        }
       />
       <TabSwitcherModal
         isOpen={isTabSwitcherOpen}
@@ -4720,7 +4734,8 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
         schema={activeTab?.schema ?? activeSchema ?? undefined}
         onInsert={(q) => {
           updateActiveTab({ query: q });
-          runQuery(q, 1);
+          // AI-generated SQL uses the same production-first safety pipeline.
+          void runQuery(q, 1);
         }}
       />
       <AiExplainModal

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -15,14 +15,10 @@ import {
   usesMultiDatabaseLayout,
 } from "../utils/database";
 import { isReadonly, supportsExplain } from "../utils/driverCapabilities";
-import { isProductionConnection } from "../utils/environment";
-import { passQueryGuards } from "../utils/queryGuard";
 import { useClickOutside } from "../hooks/useClickOutside";
-import {
-  useDangerousQueryGuard,
-  DANGEROUS_QUERY_I18N,
-} from "../hooks/useDangerousQueryGuard";
+import { DANGEROUS_QUERY_I18N } from "../hooks/useDangerousQueryGuard";
 import { useProductionGuard } from "../hooks/useProductionGuard";
+import { useQueryGuards } from "../hooks/useQueryGuards";
 import {
   generateTempId,
   initializeNewRow,
@@ -238,10 +234,6 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
   const driverReadonly = isReadonly(activeCapabilities);
   const driverSupportsExplain = supportsExplain(activeCapabilities);
   const activeDialect = activeCapabilities?.sql_dialect;
-  const hasProductionConnection = isProductionConnection(
-    connections,
-    activeConnectionId,
-  );
 
   // Editor panes stay mounted (hidden with display:none) so Monaco never
   // remounts. Render them sorted by id, decoupled from the tab-strip order:
@@ -417,9 +409,9 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
     useState(false);
   const {
     pending: dangerousQuery,
-    guardQuery: guardDangerousQuery,
+    guardQuery: guardQueryExecution,
     resolve: resolveDangerousQuery,
-  } = useDangerousQueryGuard(!hasProductionConnection);
+  } = useQueryGuards(activeConnectionId);
   const guardProductionWrite = useProductionGuard();
   const [isTabSwitcherOpen, setIsTabSwitcherOpen] = useState(false);
   const [isRunDropdownOpen, setIsRunDropdownOpen] = useState(false);
@@ -935,11 +927,7 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
 
       if (!textToRun || !textToRun.trim()) return;
 
-      const mayRun = await passQueryGuards({
-        guardProduction: () =>
-          guardProductionWrite(activeConnectionId, textToRun),
-        guardDangerousQuery: () => guardDangerousQuery(textToRun),
-      });
+      const mayRun = await guardQueryExecution(textToRun);
       if (!mayRun) return;
 
       // Check for parameters
@@ -1167,8 +1155,7 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
       isMultiDb,
       activeDatabaseName,
       addHistoryEntry,
-      guardDangerousQuery,
-      guardProductionWrite,
+      guardQueryExecution,
       activeDialect,
     ],
   );
@@ -1181,11 +1168,7 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
       const targetTab = tabsRef.current.find((t) => t.id === targetTabId);
       if (!targetTab) return;
 
-      const mayRun = await passQueryGuards({
-        guardProduction: () =>
-          guardProductionWrite(activeConnectionId, queries.join(";\n")),
-        guardDangerousQuery: () => guardDangerousQuery(queries),
-      });
+      const mayRun = await guardQueryExecution(queries);
       if (!mayRun) return;
 
       // Collect all unique parameters across all queries
@@ -1370,8 +1353,7 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
       isMultiDb,
       activeDatabaseName,
       addHistoryEntry,
-      guardDangerousQuery,
-      guardProductionWrite,
+      guardQueryExecution,
       activeDialect,
     ],
   );

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -2,6 +2,21 @@
 
 export type ConnectionEnvironment = "development" | "staging" | "production";
 
+interface EnvironmentConnection {
+  id: string;
+  environment?: ConnectionEnvironment;
+}
+
+export function isProductionConnection(
+  connections: readonly EnvironmentConnection[],
+  connectionId: string | null | undefined,
+): boolean {
+  return connections.some(
+    (connection) =>
+      connection.id === connectionId && connection.environment === "production",
+  );
+}
+
 /** Tailwind classes for the environment badge chip, per tier. */
 export const ENVIRONMENT_BADGE_CLASSES: Record<ConnectionEnvironment, string> = {
   development:

--- a/src/utils/queryGuard.ts
+++ b/src/utils/queryGuard.ts
@@ -1,0 +1,16 @@
+export interface QueryGuardPipeline {
+  guardProduction: () => Promise<boolean>;
+  guardDangerousQuery: () => Promise<boolean>;
+}
+
+/**
+ * Runs query safety checks in priority order. Production gets the first chance
+ * to block the operation; the standard dangerous-query guard runs afterwards.
+ */
+export async function passQueryGuards({
+  guardProduction,
+  guardDangerousQuery,
+}: QueryGuardPipeline): Promise<boolean> {
+  if (!(await guardProduction())) return false;
+  return guardDangerousQuery();
+}

--- a/tests/contexts/ProductionGuardContext.test.tsx
+++ b/tests/contexts/ProductionGuardContext.test.tsx
@@ -1,0 +1,98 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useContext, type ReactNode } from "react";
+import { ProductionGuardProvider } from "../../src/contexts/ProductionGuardContext";
+import { ProductionGuardContext } from "../../src/hooks/useProductionGuard";
+
+const settingsState = vi.hoisted(() => ({ delayEnabled: false }));
+
+vi.mock("../../src/hooks/useSettings", () => ({
+  useSettings: () => ({
+    settings: {
+      safetyConfirmationDelayEnabled: settingsState.delayEnabled,
+    },
+  }),
+}));
+
+vi.mock("lucide-react", () => ({
+  TriangleAlert: () => <span data-testid="warning-icon" />,
+  X: () => <span data-testid="close-icon" />,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      key === "environment.warnConfirm" ? "Run anyway" : key,
+  }),
+}));
+
+vi.mock("../../src/components/ui/SqlPreview", () => ({
+  SqlPreview: () => <div data-testid="sql-preview" />,
+}));
+
+vi.mock("../../src/components/ui/Modal", () => ({
+  Modal: ({
+    isOpen,
+    children,
+  }: {
+    isOpen: boolean;
+    children: ReactNode;
+  }) => (isOpen ? <div>{children}</div> : null),
+}));
+
+function GuardRequester() {
+  const request = useContext(ProductionGuardContext);
+
+  return (
+    <button
+      onClick={() => {
+        void request?.("prod-id", "Production", "DROP TABLE users");
+      }}
+    >
+      Request confirmation
+    </button>
+  );
+}
+
+describe("ProductionGuardProvider", () => {
+  beforeEach(() => {
+    settingsState.delayEnabled = false;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("allows immediate confirmation when the safety delay is disabled", () => {
+    render(
+      <ProductionGuardProvider>
+        <GuardRequester />
+      </ProductionGuardProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Request confirmation" }));
+
+    expect(screen.getByRole("button", { name: "Run anyway" })).not.toBeDisabled();
+  });
+
+  it("counts down production confirmation when the safety delay is enabled", () => {
+    settingsState.delayEnabled = true;
+    render(
+      <ProductionGuardProvider>
+        <GuardRequester />
+      </ProductionGuardProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Request confirmation" }));
+    expect(screen.getByRole("button", { name: "Run anyway (5)" })).toBeDisabled();
+
+    for (let second = 0; second < 5; second += 1) {
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+    }
+
+    expect(screen.getByRole("button", { name: "Run anyway" })).not.toBeDisabled();
+  });
+});

--- a/tests/contexts/SettingsProvider.test.tsx
+++ b/tests/contexts/SettingsProvider.test.tsx
@@ -68,6 +68,7 @@ describe("SettingsProvider", () => {
     expect(result.current.settings.aiEnabled).toBe(false);
     expect(result.current.settings.aiProvider).toBeNull();
     expect(result.current.settings.aiModel).toBeNull();
+    expect(result.current.settings.safetyConfirmationDelayEnabled).toBe(false);
   });
 
   it("should load settings from backend config", async () => {
@@ -79,6 +80,7 @@ describe("SettingsProvider", () => {
       aiEnabled: true,
       aiProvider: "openai",
       aiModel: "gpt-4",
+      safetyConfirmationDelayEnabled: true,
     };
 
     vi.mocked(invoke).mockImplementation((cmd: string) => {
@@ -113,6 +115,7 @@ describe("SettingsProvider", () => {
     expect(result.current.settings.aiEnabled).toBe(true);
     expect(result.current.settings.aiProvider).toBe("openai");
     expect(result.current.settings.aiModel).toBe("gpt-4");
+    expect(result.current.settings.safetyConfirmationDelayEnabled).toBe(true);
   });
 
   it("hydrates persisted settings even while language application is still pending", async () => {

--- a/tests/hooks/useDangerousQueryGuard.test.ts
+++ b/tests/hooks/useDangerousQueryGuard.test.ts
@@ -15,6 +15,18 @@ describe('useDangerousQueryGuard', () => {
     expect(result.current.isPending).toBe(false);
   });
 
+  it('skips confirmation when the guard is disabled', async () => {
+    const { result } = renderHook(() => useDangerousQueryGuard(false));
+
+    let resolved: boolean | undefined;
+    await act(async () => {
+      resolved = await result.current.guardQuery('DROP TABLE users');
+    });
+
+    expect(resolved).toBe(true);
+    expect(result.current.pending).toBeNull();
+  });
+
   it('opens a pending confirmation for a destructive query with no WHERE', async () => {
     const { result } = renderHook(() => useDangerousQueryGuard());
 

--- a/tests/hooks/useQueryGuards.test.ts
+++ b/tests/hooks/useQueryGuards.test.ts
@@ -1,0 +1,122 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useQueryGuards } from "../../src/hooks/useQueryGuards";
+
+const guardState = vi.hoisted(() => ({
+  connections: [] as Array<{
+    id: string;
+    environment?: "development" | "staging" | "production";
+  }>,
+  guardProduction: vi.fn(
+    async (
+      _connectionId: string | null | undefined,
+      _sql?: string,
+    ): Promise<boolean> => true,
+  ),
+}));
+
+vi.mock("../../src/hooks/useDatabase", () => ({
+  useDatabase: () => ({ connections: guardState.connections }),
+}));
+
+vi.mock("../../src/hooks/useProductionGuard", () => ({
+  useProductionGuard: () => guardState.guardProduction,
+}));
+
+describe("useQueryGuards", () => {
+  beforeEach(() => {
+    guardState.connections = [];
+    guardState.guardProduction.mockReset();
+    guardState.guardProduction.mockResolvedValue(true);
+  });
+
+  it("runs the production guard before opening a dangerous-query prompt", async () => {
+    guardState.connections = [
+      { id: "dev-id", environment: "development" },
+    ];
+    const { result } = renderHook(() => useQueryGuards("dev-id"));
+
+    let confirmation!: Promise<boolean>;
+    await act(async () => {
+      confirmation = result.current.guardQuery("DROP TABLE users");
+      await Promise.resolve();
+    });
+
+    expect(guardState.guardProduction).toHaveBeenCalledWith(
+      "dev-id",
+      "DROP TABLE users",
+    );
+    expect(result.current.pending?.kind).toBe("drop");
+
+    let allowed: boolean | undefined;
+    await act(async () => {
+      result.current.resolve(false);
+      allowed = await confirmation;
+    });
+    expect(allowed).toBe(false);
+  });
+
+  it("stops before the dangerous-query guard when production blocks", async () => {
+    guardState.connections = [
+      { id: "prod-id", environment: "production" },
+    ];
+    guardState.guardProduction.mockResolvedValue(false);
+    const { result } = renderHook(() => useQueryGuards("prod-id"));
+
+    let allowed: boolean | undefined;
+    await act(async () => {
+      allowed = await result.current.guardQuery("DROP TABLE users");
+    });
+
+    expect(allowed).toBe(false);
+    expect(result.current.pending).toBeNull();
+  });
+
+  it("uses only the production guard for dangerous production queries", async () => {
+    guardState.connections = [
+      { id: "prod-id", environment: "production" },
+    ];
+    const { result } = renderHook(() => useQueryGuards("prod-id"));
+
+    let allowed: boolean | undefined;
+    await act(async () => {
+      allowed = await result.current.guardQuery("DELETE FROM users");
+    });
+
+    expect(allowed).toBe(true);
+    expect(guardState.guardProduction).toHaveBeenCalledWith(
+      "prod-id",
+      "DELETE FROM users",
+    );
+    expect(result.current.pending).toBeNull();
+  });
+
+  it("serializes batch SQL for production while preserving statements for danger checks", async () => {
+    guardState.connections = [
+      { id: "dev-id", environment: "development" },
+    ];
+    const { result } = renderHook(() => useQueryGuards("dev-id"));
+    const queries = ["SELECT 1", "DROP TABLE users"];
+
+    let confirmation!: Promise<boolean>;
+    await act(async () => {
+      confirmation = result.current.guardQuery(queries);
+      await Promise.resolve();
+    });
+
+    expect(guardState.guardProduction).toHaveBeenCalledWith(
+      "dev-id",
+      "SELECT 1;\nDROP TABLE users",
+    );
+    expect(result.current.pending).toMatchObject({
+      kind: "drop",
+      sql: "DROP TABLE users",
+      count: 1,
+    });
+
+    await act(async () => {
+      result.current.resolve(true);
+      await confirmation;
+    });
+  });
+});

--- a/tests/utils/environment.test.ts
+++ b/tests/utils/environment.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { isProductionConnection } from "../../src/utils/environment";
+
+describe("environment", () => {
+  describe("isProductionConnection", () => {
+    const connections = [
+      { id: "dev", environment: "development" as const },
+      { id: "prod", environment: "production" as const },
+      { id: "plain" },
+    ];
+
+    it("returns true for the matching production connection", () => {
+      expect(isProductionConnection(connections, "prod")).toBe(true);
+    });
+
+    it("returns false for non-production, missing, and empty connection ids", () => {
+      expect(isProductionConnection(connections, "dev")).toBe(false);
+      expect(isProductionConnection(connections, "missing")).toBe(false);
+      expect(isProductionConnection(connections, null)).toBe(false);
+      expect(isProductionConnection(connections, undefined)).toBe(false);
+    });
+  });
+});

--- a/tests/utils/queryGuard.test.ts
+++ b/tests/utils/queryGuard.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import { passQueryGuards } from "../../src/utils/queryGuard";
+
+describe("passQueryGuards", () => {
+  it("runs the production guard before the standard dangerous-query guard", async () => {
+    const order: string[] = [];
+
+    const result = await passQueryGuards({
+      guardProduction: vi.fn(async () => {
+        order.push("production");
+        return true;
+      }),
+      guardDangerousQuery: vi.fn(async () => {
+        order.push("dangerous-query");
+        return true;
+      }),
+    });
+
+    expect(result).toBe(true);
+    expect(order).toEqual(["production", "dangerous-query"]);
+  });
+
+  it("does not run the standard guard when production blocks the query", async () => {
+    const guardDangerousQuery = vi.fn(async () => true);
+
+    const result = await passQueryGuards({
+      guardProduction: vi.fn(async () => false),
+      guardDangerousQuery,
+    });
+
+    expect(result).toBe(false);
+    expect(guardDangerousQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns false when the standard guard blocks a non-production query", async () => {
+    const result = await passQueryGuards({
+      guardProduction: vi.fn(async () => true),
+      guardDangerousQuery: vi.fn(async () => false),
+    });
+
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- disable the five-second destructive-query countdown by default and expose it as a persisted safety-confirmation setting
- reuse the optional delay for production-write confirmations
- suppress the standard dangerous-query modal on production connections so only the production warning is shown
- run production guards before standard dangerous-query guards across editor, batch, notebook, and AI-generated query execution paths
- add localized setting copy and regression coverage for guard ordering, production countdowns, environment detection, and persistence

## Validation
- `pnpm test --run` — 228 files, 3822 tests passed
- `pnpm exec tsc --noEmit`
- ESLint on changed TypeScript sources
- `cargo test --manifest-path src-tauri/Cargo.toml config::tests --lib` — 17 tests passed
- `rustfmt --check --edition 2021 src-tauri/src/config.rs`
- `git diff --check`

## Risk
GitNexus reports CRITICAL impact because the centralized `runQuery` path has 11 direct callers. The behavior change is limited to safety-guard ordering and is covered by a dedicated query-guard pipeline test.
