### PR TITLE
fix(snap): ship a desktop entry so the app appears in the launcher

### DIFF
--- a/snap/gui/tabularis.desktop
+++ b/snap/gui/tabularis.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=Tabularis
+Comment=Open-source database client with AI, notebooks, and plugins
+Exec=tabularis %u
+Icon=${SNAP}/usr/share/icons/hicolor/512x512/apps/tabularis.png
+Terminal=false
+Categories=Development;Database;
+StartupWMClass=tabularis
+MimeType=x-scheme-handler/tabularis;


### PR DESCRIPTION
Fixes the snap having no launcher entry, reported in #669.

## Problem

After `snap install tabularis` the app does not appear in the app grid / app menu. It can only be launched from a terminal.

snapd exports launchers from `meta/gui/` inside the snap. In the published revision that directory is empty, so nothing is exported:

```
$ ls -la /snap/tabularis/current/meta/gui/
total 0
drwxr-xr-x 2 root root  3 Aug 18 06:26 .
drwxr-xr-x 4 root root 56 Aug 18 06:26 ..

$ ls /var/lib/snapd/desktop/applications/ | grep tabularis
(nothing)
```

The desktop file from the bundled `.deb` is present, but in `usr/share/applications/`, which snapd does not export.

## Change

Adds `snap/gui/tabularis.desktop`. Files under `snap/gui/` are copied verbatim into `meta/gui/` at pack time, which is exactly the directory snapd reads.

The entry is written by hand rather than pointing `snapcraft.yaml` at the `.deb`'s copy via the `desktop:` key, because that file is not good enough as shipped:

```ini
Categories=
Comment=tabularis - A database manager for developers
Exec=tabularis
Icon=tabularis
Name=tabularis
```

- `Name=tabularis` is lowercase (it follows `productName` in `tauri.conf.json`).
- `Categories=` is empty, so the entry files under no menu category.
- `Icon=tabularis` is a bare theme name; under confinement the host icon theme has no such icon, so it resolves to nothing.
- It declares `MimeType=x-scheme-handler/tabularis` but `Exec=` has no `%u` field code, so the registered deep-link handler is invoked with no URL.

The new entry fixes all four and keeps `Categories=` to registered values (`Development` main category, `Database` additional).

## Verification

Verified on snapd 2.76.2 / core24 / Ubuntu 24.04 by installing a snap that contains this change and inspecting what snapd exported.

Method, stated precisely: I did **not** run `snapcraft pack` (no snapcraft or LXD on this machine). Instead I took the published revision 43 straight from `/snap/tabularis/current`, dropped this one file into `meta/gui/`, repacked with `snap pack`, and sideloaded it with `--dangerous`. The test snap is therefore byte-identical to the published snap plus exactly this file, which isolates the change. What this exercises is snapd's export behaviour; the `snap/gui/` → `meta/gui/` copy at pack time is standard snapcraft behaviour and is not covered by this test.

`meta/gui/` in the packed test snap now contains the entry, where the published revision has an empty directory:

```
$ unsquashfs -l tabularis-desktoptest.snap | grep meta/gui
squashfs-root/meta/gui
squashfs-root/meta/gui/tabularis.desktop
```

After `snap install --dangerous`, snapd exported the launcher — the file that does not exist at all for the published revision:

```
$ cat /var/lib/snapd/desktop/applications/tabularis_tabularis.desktop
[Desktop Entry]
X-SnapInstanceName=tabularis
Type=Application
Name=Tabularis
Comment=Open-source database client with AI, notebooks, and plugins
X-SnapAppName=tabularis
Exec=/snap/bin/tabularis %u
Icon=/snap/tabularis/current/usr/share/icons/hicolor/512x512/apps/tabularis.png
Terminal=false
Categories=Development;Database;
StartupWMClass=tabularis
MimeType=x-scheme-handler/tabularis;
```

The two rewrites this change depends on both happened, and the only differences from the source file are the two `X-Snap*` keys snapd injects:

- `Icon=${SNAP}/...` was expanded to `/snap/tabularis/current/...`, and the target resolves (`PNG image data, 512 x 512, 8-bit/color RGBA`).
- `Exec=tabularis %u` became `Exec=/snap/bin/tabularis %u` — the bare app name resolves because it equals the snap name, and the `%u` field code survived, so the deep-link handler now receives its URL.

`desktop-file-validate` reports the exported file clean, no errors or warnings. The scheme handler registers: `gio mime x-scheme-handler/tabularis` lists `tabularis_tabularis.desktop`.

End to end, the entry also shows up where it is supposed to: with the test snap installed, Tabularis appears in the desktop environment with its icon and an "Open" button in App Center, and launching it from there starts the app.

One caveat on the literal in-repo file: `desktop-file-validate` flags `Icon=${SNAP}/...` as "looks like a relative path". That is a known false positive — the validator does not know about snapd's expansion, and the shipping DBeaver, Spotify and Discord snaps all use the same `Icon=${SNAP}/...` pattern and produce the identical error. Once expanded, as shown above, it validates clean.

## Notes

- Deliberately **not** also adding `desktop: usr/share/applications/tabularis.desktop` to `snapcraft.yaml`. Both routes write `meta/gui/tabularis.desktop`; the `snap/gui/` file alone is the whole change.
- No CI signal on this PR: `ci.yml` is path-filtered to `src/**`, `src-tauri/**` and friends, and `snap.yml` runs only on `release: published` or manual dispatch. Hence the manual evidence above. Happy to re-run any of it, or to verify through a real `snapcraft pack` if a maintainer wants that closed too.
- Out of scope, but worth separate follow-ups: `bundle.category` is unset in `src-tauri/tauri.conf.json` (the actual reason `Categories=` is empty in the `.deb`), and `productName` is lowercase. Both also affect the `.deb`, AppImage and macOS builds.
