### PR TITLE
feat: per-tab page size selector in the results pagination bar

### DIFF
--- a/src/components/ui/PageSizeSelector.tsx
+++ b/src/components/ui/PageSizeSelector.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+import { ChevronDown } from "lucide-react";
+import clsx from "clsx";
+import {
+  computeDropdownPosition,
+  dropdownPositionStyle,
+  VIEWPORT_MARGIN,
+  type DropdownPosition,
+} from "../../utils/dropdownPosition";
+
+const PAGE_SIZE_PRESETS = [50, 100, 200, 500, 1000, 5000];
+const MENU_WIDTH = 200;
+
+interface PageSizeSelectorProps {
+  /** Current page size; 0 means pagination is off (all rows fetched). */
+  value: number;
+  /** Page size from the global settings, marked as default in the menu. */
+  defaultSize: number;
+  disabled?: boolean;
+  onChange: (size: number) => void;
+}
+
+/**
+ * Compact rows-per-page picker for a result grid's pagination bar. Offers
+ * preset sizes, a custom value, and "All" (pagination off); selecting a value
+ * overrides the global Result Page Size for the current tab only.
+ */
+export function PageSizeSelector({
+  value,
+  defaultSize,
+  disabled = false,
+  onChange,
+}: PageSizeSelectorProps) {
+  const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
+  const [customValue, setCustomValue] = useState("");
+  const [position, setPosition] = useState<DropdownPosition | null>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        buttonRef.current &&
+        !buttonRef.current.contains(event.target as Node) &&
+        menuRef.current &&
+        !menuRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen]);
+
+  const handleToggle = () => {
+    if (disabled) return;
+    if (!isOpen && buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      // Right-align the menu to the trigger: the bar sits at the pane's right
+      // edge, so a left-anchored panel would overflow the viewport.
+      setPosition(
+        computeDropdownPosition({
+          top: rect.top,
+          bottom: rect.bottom,
+          left: Math.max(VIEWPORT_MARGIN, rect.right - MENU_WIDTH),
+          width: MENU_WIDTH,
+        }),
+      );
+    }
+    setIsOpen(!isOpen);
+  };
+
+  const handleSelect = (size: number) => {
+    setIsOpen(false);
+    setCustomValue("");
+    if (size !== value) onChange(size);
+  };
+
+  const handleCustomCommit = () => {
+    const parsed = parseInt(customValue, 10);
+    if (!isNaN(parsed) && parsed > 0) handleSelect(parsed);
+  };
+
+  const presets = PAGE_SIZE_PRESETS.includes(defaultSize)
+    ? PAGE_SIZE_PRESETS
+    : [...PAGE_SIZE_PRESETS, defaultSize].sort((a, b) => a - b);
+
+  const optionClass = (isActive: boolean) =>
+    clsx(
+      "w-full text-left px-3 py-1.5 text-xs rounded transition-colors flex items-center justify-between gap-2",
+      isActive
+        ? "bg-blue-600/10 text-blue-400 font-medium"
+        : "text-primary hover:bg-surface-secondary",
+    );
+
+  const menu = isOpen && !disabled && position && (
+    <div
+      ref={menuRef}
+      className="fixed z-[200] bg-elevated border border-strong rounded-lg shadow-xl flex flex-col overflow-hidden animate-in fade-in zoom-in-95 duration-100"
+      style={dropdownPositionStyle(position)}
+    >
+      <div className="overflow-y-auto flex-1 p-1 scrollbar-thin scrollbar-thumb-surface-tertiary scrollbar-track-transparent">
+        {presets.map((size) => (
+          <button
+            key={size}
+            onClick={() => handleSelect(size)}
+            className={optionClass(value === size)}
+          >
+            <span>{size.toLocaleString()}</span>
+            {size === defaultSize && (
+              <span className="text-muted text-[10px]">
+                {t("pagination.defaultPageSize")}
+              </span>
+            )}
+          </button>
+        ))}
+        <button
+          onClick={() => handleSelect(0)}
+          className={optionClass(value === 0)}
+          title={t("pagination.allRowsHint")}
+        >
+          <span>{t("pagination.allRows")}</span>
+          <span className="text-accent-warning text-[10px] truncate">
+            {t("pagination.allRowsHint")}
+          </span>
+        </button>
+      </div>
+      <div className="p-1 border-t border-default">
+        <input autoCorrect="off" autoCapitalize="off" autoComplete="off" spellCheck={false}
+          type="text"
+          inputMode="numeric"
+          placeholder={t("pagination.customPageSize")}
+          value={customValue}
+          onChange={(e) => setCustomValue(e.target.value.replace(/\D/g, ""))}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleCustomCommit();
+            if (e.key === "Escape") setIsOpen(false);
+            e.stopPropagation();
+          }}
+          className="w-full bg-base border border-strong rounded px-2 py-1 text-xs text-primary focus:outline-none focus:border-blue-500 placeholder:text-muted"
+        />
+      </div>
+    </div>
+  );
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        disabled={disabled}
+        onClick={handleToggle}
+        className="flex items-center gap-0.5 px-1.5 py-1 hover:bg-surface-tertiary text-secondary hover:text-white disabled:opacity-30 disabled:cursor-not-allowed text-xs font-medium whitespace-nowrap"
+        title={t("pagination.pageSize")}
+        aria-label={t("pagination.pageSize")}
+      >
+        {value === 0 ? t("pagination.allRows") : value.toLocaleString()}
+        <ChevronDown size={12} />
+      </button>
+      {menu && createPortal(menu, document.body)}
+    </>
+  );
+}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -2026,7 +2026,12 @@
     "firstPage": "Erste Seite",
     "previousPage": "Vorherige Seite",
     "nextPage": "Nächste Seite",
-    "lastPage": "Letzte Seite"
+    "lastPage": "Letzte Seite",
+    "pageSize": "Zeilen pro Seite",
+    "allRows": "Alle",
+    "allRowsHint": "ruft alle Zeilen ab",
+    "customPageSize": "Benutzerdefiniert…",
+    "defaultPageSize": "Standard"
   },
   "miniGrid": {
     "runningQuery": "Abfrage wird ausgeführt...",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2115,7 +2115,12 @@
     "firstPage": "First page",
     "previousPage": "Previous page",
     "nextPage": "Next page",
-    "lastPage": "Last page"
+    "lastPage": "Last page",
+    "pageSize": "Rows per page",
+    "allRows": "All",
+    "allRowsHint": "fetches every row",
+    "customPageSize": "Custom…",
+    "defaultPageSize": "default"
   },
   "miniGrid": {
     "runningQuery": "Running query...",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1948,7 +1948,12 @@
     "firstPage": "Primera página",
     "previousPage": "Página anterior",
     "nextPage": "Página siguiente",
-    "lastPage": "Última página"
+    "lastPage": "Última página",
+    "pageSize": "Filas por página",
+    "allRows": "Todas",
+    "allRowsHint": "recupera todas las filas",
+    "customPageSize": "Personalizado…",
+    "defaultPageSize": "predeterminado"
   },
   "miniGrid": {
     "runningQuery": "Ejecutando consulta...",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -2104,7 +2104,12 @@
     "firstPage": "Première page",
     "previousPage": "Page précédente",
     "nextPage": "Page suivante",
-    "lastPage": "Dernière page"
+    "lastPage": "Dernière page",
+    "pageSize": "Lignes par page",
+    "allRows": "Toutes",
+    "allRowsHint": "récupère toutes les lignes",
+    "customPageSize": "Personnalisé…",
+    "defaultPageSize": "par défaut"
   },
   "miniGrid": {
     "runningQuery": "Exécution de la requête...",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -2028,7 +2028,12 @@
     "firstPage": "Prima pagina",
     "previousPage": "Pagina precedente",
     "nextPage": "Pagina successiva",
-    "lastPage": "Ultima pagina"
+    "lastPage": "Ultima pagina",
+    "pageSize": "Righe per pagina",
+    "allRows": "Tutte",
+    "allRowsHint": "recupera tutte le righe",
+    "customPageSize": "Personalizzato…",
+    "defaultPageSize": "predefinito"
   },
   "miniGrid": {
     "runningQuery": "Esecuzione query...",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2044,7 +2044,12 @@
     "firstPage": "最初のページ",
     "previousPage": "前のページ",
     "nextPage": "次のページ",
-    "lastPage": "最後のページ"
+    "lastPage": "最後のページ",
+    "pageSize": "1ページあたりの行数",
+    "allRows": "すべて",
+    "allRowsHint": "すべての行を取得",
+    "customPageSize": "カスタム…",
+    "defaultPageSize": "デフォルト"
   },
   "miniGrid": {
     "runningQuery": "クエリを実行中...",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -2030,7 +2030,12 @@
     "firstPage": "첫 페이지",
     "previousPage": "이전 페이지",
     "nextPage": "다음 페이지",
-    "lastPage": "마지막 페이지"
+    "lastPage": "마지막 페이지",
+    "pageSize": "페이지당 행 수",
+    "allRows": "전체",
+    "allRowsHint": "모든 행을 가져옴",
+    "customPageSize": "사용자 지정…",
+    "defaultPageSize": "기본값"
   },
   "miniGrid": {
     "runningQuery": "쿼리를 실행하는 중...",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -2077,7 +2077,12 @@
     "firstPage": "Primeira página",
     "previousPage": "Página anterior",
     "nextPage": "Próxima página",
-    "lastPage": "Última página"
+    "lastPage": "Última página",
+    "pageSize": "Linhas por página",
+    "allRows": "Todas",
+    "allRowsHint": "busca todas as linhas",
+    "customPageSize": "Personalizado…",
+    "defaultPageSize": "padrão"
   },
   "miniGrid": {
     "runningQuery": "Executando consulta...",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -2097,7 +2097,12 @@
     "firstPage": "Первая страница",
     "previousPage": "Предыдущая страница",
     "nextPage": "Следующая страница",
-    "lastPage": "Последняя страница"
+    "lastPage": "Последняя страница",
+    "pageSize": "Строк на странице",
+    "allRows": "Все",
+    "allRowsHint": "загружает все строки",
+    "customPageSize": "Свой размер…",
+    "defaultPageSize": "по умолчанию"
   },
   "miniGrid": {
     "runningQuery": "Выполнение запроса...",

--- a/src/i18n/locales/tl.json
+++ b/src/i18n/locales/tl.json
@@ -2096,7 +2096,12 @@
     "firstPage": "Unang pahina",
     "previousPage": "Nakaraang pahina",
     "nextPage": "Susunod na pahina",
-    "lastPage": "Huling pahina"
+    "lastPage": "Huling pahina",
+    "pageSize": "Mga row bawat pahina",
+    "allRows": "Lahat",
+    "allRowsHint": "kinukuha ang lahat ng row",
+    "customPageSize": "Custom…",
+    "defaultPageSize": "default"
   },
   "miniGrid": {
     "runningQuery": "Tumatakbo ang query...",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1966,7 +1966,12 @@
     "firstPage": "第一页",
     "previousPage": "上一页",
     "nextPage": "下一页",
-    "lastPage": "最后一页"
+    "lastPage": "最后一页",
+    "pageSize": "每页行数",
+    "allRows": "全部",
+    "allRowsHint": "获取所有行",
+    "customPageSize": "自定义…",
+    "defaultPageSize": "默认"
   },
   "miniGrid": {
     "runningQuery": "正在执行查询...",

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { reconstructTableQuery } from "../utils/editor";
+import { reconstructTableQuery, resolveTabPageSize } from "../utils/editor";
 import { shouldShowStatementSuccess } from "../utils/resultPresentation";
 import { formatRowsForCopy, copyTextToClipboard } from "../utils/clipboard";
 import { serializePkKey, buildPkMap } from "../utils/dataGrid";
@@ -72,6 +72,7 @@ import { TableToolbar } from "../components/ui/TableToolbar";
 import { DataGrid } from "../components/ui/DataGrid";
 import { MultiResultPanel } from "../components/ui/MultiResultPanel";
 import { ErrorDisplay } from "../components/ui/ErrorDisplay";
+import { PageSizeSelector } from "../components/ui/PageSizeSelector";
 import { NewRowModal } from "../components/modals/NewRowModal";
 import { QuerySelectionModal } from "../components/modals/QuerySelectionModal";
 import { ConfirmModal } from "../components/modals/ConfirmModal";
@@ -887,6 +888,9 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
         pendingDeletions?: Record<string, unknown>;
         pendingInsertions?: Record<string, PendingInsertion>;
       },
+      // Skips tab state (which may not have re-rendered yet) when the page
+      // size is changed and re-run in the same handler; 0 = no pagination.
+      pageSizeOverride?: number,
     ) => {
       const targetTabId = tabId || activeTabIdRef.current;
       if (!activeConnectionId || !targetTabId) return;
@@ -1000,12 +1004,13 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
 
       try {
         const start = performance.now();
-        // Use settings.resultPageSize for Page Size (pagination), ignoring the "Total Limit" input which is handled in SQL
-        // Fallback to 100 if settings not loaded yet
-        const pageSize =
-          settings.resultPageSize && settings.resultPageSize > 0
-            ? settings.resultPageSize
-            : 100;
+        // Per-tab page size (falling back to the global Result Page Size)
+        // drives pagination; the "Total Limit" input is handled in the SQL.
+        // undefined disables pagination entirely (the user picked "All").
+        const pageSize = resolveTabPageSize(
+          pageSizeOverride ?? targetTab.pageSize,
+          settings.resultPageSize,
+        );
         const res = await invoke<QueryResult>("execute_query", {
           connectionId: activeConnectionId,
           query: textToRun,
@@ -1203,10 +1208,10 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
         );
       }
 
-      const pageSize =
-        settings.resultPageSize && settings.resultPageSize > 0
-          ? settings.resultPageSize
-          : 100;
+      const pageSize = resolveTabPageSize(
+        targetTab.pageSize,
+        settings.resultPageSize,
+      );
       const schema = targetTab?.schema ?? activeSchema;
       const historyDb = schema
         || (isMultiDb ? activeDatabaseName : undefined)
@@ -1426,10 +1431,10 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
       const entry = currentTab?.results?.find((r) => r.id === entryId);
       if (!entry) return;
 
-      const pageSize =
-        settings.resultPageSize && settings.resultPageSize > 0
-          ? settings.resultPageSize
-          : 100;
+      const pageSize = resolveTabPageSize(
+        currentTab?.pageSize,
+        settings.resultPageSize,
+      );
       const schema = currentTab?.schema ?? activeSchema;
 
       // Mark this entry as loading
@@ -1492,6 +1497,37 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
       }
     },
     [activeConnectionId, updateTab, settings.resultPageSize, activeSchema, t],
+  );
+
+  const handlePageSizeChange = useCallback(
+    (newSize: number) => {
+      const targetTabId = activeTabIdRef.current;
+      const tab = tabsRef.current.find((t) => t.id === targetTabId);
+      if (!targetTabId || !tab) return;
+      updateTab(targetTabId, { pageSize: newSize });
+      // Keep the first visible row in view when the page size changes
+      const pagination = tab.result?.pagination;
+      const newPage =
+        newSize > 0 && pagination
+          ? Math.floor(
+              ((pagination.page - 1) * pagination.page_size) / newSize,
+            ) + 1
+          : 1;
+      // The override carries the new size: tab state won't have re-rendered
+      // into tabsRef by the time runQuery reads it.
+      runQuery(
+        undefined,
+        newPage,
+        targetTabId,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        newSize,
+      );
+    },
+    [runQuery, updateTab],
   );
 
   const loadCount = useCallback(
@@ -4262,15 +4298,29 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
                     </div>
 
                     {/* Pagination Controls */}
-                    {activeTab.result.pagination && (
+                    {(activeTab.result.pagination ||
+                      activeTab.pageSize === 0) && (
                       <div className="flex items-center gap-1 bg-surface-secondary rounded border border-strong shrink-0">
+                        <PageSizeSelector
+                          value={activeTab.result.pagination?.page_size ?? 0}
+                          defaultSize={
+                            settings.resultPageSize &&
+                            settings.resultPageSize > 0
+                              ? settings.resultPageSize
+                              : 100
+                          }
+                          disabled={!!activeTab.isLoading}
+                          onChange={handlePageSizeChange}
+                        />
+                        {activeTab.result.pagination && (
+                          <>
                         <button
                           disabled={
                             activeTab.result.pagination.page === 1 ||
                             activeTab.isLoading
                           }
                           onClick={() => runQuery(undefined, 1)}
-                          className="hidden @[420px]:block p-1 hover:bg-surface-tertiary text-secondary hover:text-white disabled:opacity-30 disabled:cursor-not-allowed"
+                          className="hidden @[420px]:block p-1 hover:bg-surface-tertiary text-secondary hover:text-white disabled:opacity-30 disabled:cursor-not-allowed border-l border-strong"
                           title="First Page"
                         >
                           <ChevronsLeft size={14} />
@@ -4286,7 +4336,7 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
                               activeTab.result!.pagination!.page - 1,
                             )
                           }
-                          className="p-1 hover:bg-surface-tertiary text-secondary hover:text-white disabled:opacity-30 disabled:cursor-not-allowed @[420px]:border-l border-strong"
+                          className="p-1 hover:bg-surface-tertiary text-secondary hover:text-white disabled:opacity-30 disabled:cursor-not-allowed border-l border-strong"
                           title="Previous Page"
                         >
                           <ChevronLeft size={14} />
@@ -4410,6 +4460,8 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
                         >
                           <ChevronsRight size={14} />
                         </button>
+                          </>
+                        )}
                       </div>
                     )}
                   </div>

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -114,6 +114,7 @@ export interface Tab {
   filterClause?: string; // SQL WHERE clause (without "WHERE")
   sortClause?: string; // SQL ORDER BY clause (without "ORDER BY")
   limitClause?: number; // SQL LIMIT value
+  pageSize?: number; // Per-tab rows-per-page override; 0 = fetch all rows (no pagination); unset = follow the global setting
   queryParams?: Record<string, string>; // Saved values for query parameters
   schema?: string; // Schema name (PostgreSQL) for query reconstruction
   readOnly?: boolean; // Hides the Run button (e.g. for definition views)

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -419,3 +419,20 @@ export function calculateTotalPages(
   if (totalRows === null || totalRows === 0) return 1;
   return Math.ceil(totalRows / pageSize);
 }
+
+/**
+ * Resolve the page size to request from the backend for a tab.
+ * The per-tab override wins over the global setting; a value of 0 means
+ * "no pagination" and yields undefined so no limit is sent at all.
+ * @param tabPageSize - Per-tab override (Tab.pageSize), if any
+ * @param globalPageSize - The resultPageSize from the global settings
+ * @returns The page size to send, or undefined to disable pagination
+ */
+export function resolveTabPageSize(
+  tabPageSize: number | undefined,
+  globalPageSize: number | undefined,
+): number | undefined {
+  if (tabPageSize === 0) return undefined;
+  if (tabPageSize && tabPageSize > 0) return tabPageSize;
+  return globalPageSize && globalPageSize > 0 ? globalPageSize : 100;
+}

--- a/src/utils/tabCleaner.ts
+++ b/src/utils/tabCleaner.ts
@@ -17,6 +17,7 @@ export interface CleanedTab {
   filterClause?: string;
   sortClause?: string;
   limitClause?: number;
+  pageSize?: number;
   queryParams?: Record<string, string>;
   notebookId?: string;
   schema?: string;
@@ -46,6 +47,7 @@ export function cleanTabForStorage(tab: Tab): CleanedTab {
     filterClause: tab.filterClause,
     sortClause: tab.sortClause,
     limitClause: tab.limitClause,
+    pageSize: tab.pageSize,
     queryParams: tab.queryParams,
     notebookId: tab.notebookId,
     schema: tab.schema,

--- a/tests/utils/editor.test.ts
+++ b/tests/utils/editor.test.ts
@@ -19,6 +19,7 @@ import {
   formatExportFileName,
   validatePageNumber,
   calculateTotalPages,
+  resolveTabPageSize,
 } from "../../src/utils/editor";
 
 describe("editor", () => {
@@ -975,6 +976,28 @@ describe("editor", () => {
     it("should handle small page sizes", () => {
       expect(calculateTotalPages(100, 1)).toBe(100);
       expect(calculateTotalPages(10, 3)).toBe(4);
+    });
+  });
+
+  describe("resolveTabPageSize", () => {
+    it("should prefer the per-tab override over the global setting", () => {
+      expect(resolveTabPageSize(51, 50)).toBe(51);
+      expect(resolveTabPageSize(25, 500)).toBe(25);
+    });
+
+    it("should fall back to the global setting when no override is set", () => {
+      expect(resolveTabPageSize(undefined, 500)).toBe(500);
+    });
+
+    it("should return undefined for 0 (pagination disabled)", () => {
+      expect(resolveTabPageSize(0, 500)).toBeUndefined();
+    });
+
+    it("should fall back to 100 when neither value is usable", () => {
+      expect(resolveTabPageSize(undefined, undefined)).toBe(100);
+      expect(resolveTabPageSize(undefined, 0)).toBe(100);
+      expect(resolveTabPageSize(undefined, -5)).toBe(100);
+      expect(resolveTabPageSize(-1, undefined)).toBe(100);
     });
   });
 });

--- a/tests/utils/tabCleaner.test.ts
+++ b/tests/utils/tabCleaner.test.ts
@@ -18,6 +18,7 @@ describe('tabCleaner', () => {
         filterClause: 'age > 18',
         sortClause: 'name ASC',
         limitClause: 100,
+        pageSize: 51,
         queryParams: { param1: 'value1' },
         // Temporary fields that should be excluded
         result: { columns: ['id'], rows: [[1]], affected_rows: 0 },
@@ -44,6 +45,7 @@ describe('tabCleaner', () => {
       expect(cleaned.filterClause).toBe('age > 18');
       expect(cleaned.sortClause).toBe('name ASC');
       expect(cleaned.limitClause).toBe(100);
+      expect(cleaned.pageSize).toBe(51);
       expect(cleaned.queryParams).toEqual({ param1: 'value1' });
 
       // Should NOT include temporary fields


### PR DESCRIPTION
Closes #672

Adds a rows-per-page selector to the results pagination bar. The value picked there overrides the global "Result Page Size (Limit)" for that tab only, so other tabs and new tabs keep using the default. This is the same model DataGrip and other clients use: the setting acts as the default, the grid control wins for the current view.

![page size selector](https://raw.githubusercontent.com/TabularisDB/tabularis/assets/page-size-selector/page-size-selector.png)

## What changed

- New `PageSizeSelector` component in the pagination bar with presets (50 to 5000, the global value is marked as default), a custom value input and an "All" option that turns pagination off for the tab.
- `Tab.pageSize` holds the per-tab override and is persisted with the tab, so it survives restarts.
- `runQuery`, `runMultipleQueries` and `runResultEntryPage` resolve the effective page size through a new `resolveTabPageSize` helper: per-tab value first, then the global setting, then the existing 100 fallback.
- When the page size changes, the page number is recalculated so the first visible row stays in view.
- Translations added for all 11 locales.

No backend changes. `execute_query` already takes an optional limit, and when none is sent the query runs as-is with no pagination clause, which is what "All" relies on.

## Why

As reported in the issue comments, changing the limit for a query did not really override the page size: with a global value of 50 and a `LIMIT 51`, the result was split into 2 pages (50 + 1). The limit input still works as a total cap, but now you can also raise the page size for that tab (or pick "All") and get the whole result on a single page.

## Tests

- Unit tests for `resolveTabPageSize` and for `pageSize` persistence in `tabCleaner`.
- Full frontend suite passes (230 files, 3838 tests), typecheck and lint are clean.
